### PR TITLE
metal: fix the async-output completion-event wedge

### DIFF
--- a/perf/optimization_status.md
+++ b/perf/optimization_status.md
@@ -9854,3 +9854,79 @@ Load test (no-spec, in-process LLM, max_model_len 8192) iterated through:
   changes are off the native serving path, and the stream change is
   behavior-neutral on CUDA (same dedicated stream) — flagged for the
   next M1 Ultra pass alongside the n_cand merge-loop item.
+
+## 2026-08-17 — Async-output completion-event wedge: structural Metal fix (native mps event, no cross-stream choreography)
+
+- Status: retained (separate PR; user-requested follow-up to the campaign)
+- The defect, from the accumulated evidence (boot_v12/v12c py-spy 2/2,
+  08-15 merge-gate wedge, cleanup-phase host-timing bisect): the engine
+  parks forever in THPEvent_synchronize -> MPSEvent::synchronize on
+  AsyncOutput.copy_event, GPU idle, no CB error — the signal is lost. The
+  machinery it rides is fictional on Metal: torch.Stream(mps) ALWAYS
+  returns stream_id 0 (probed, torch 2.13), so async_utils'
+  set_stream + copy_stream.wait_stream(main_stream) + generic
+  torch.Event().record(copy_stream) is a cross-stream dance on one stream
+  — zero overlap bought, and a completion path routed through an event
+  observed to never fire on timing-sensitive boots.
+- Fix (vllm/v1/worker/gpu/async_utils.py): on Metal, AsyncOutput and
+  AsyncPoolingOutput skip the stream context, wait_stream, and generic
+  Event entirely; the same non-blocking D2H copies enqueue on the only
+  stream and completion is a native torch.mps.Event recorded there
+  (record() on current stream, no stream juggling). get_output() waits on
+  that event. Ops kill-switch VLLM_QC_ASYNC_OUT_DRAIN=1 replaces the event
+  with a full torch.mps.synchronize() drain.
+- Why not just drain: measured. The drain-only variant lost the drafter
+  tail overlap — off1-2000 wall 65.26 s / 30.6 tok/s vs 62.93-63.09 s
+  baseline (-3.7%). The native-event build restores it: 62.53 s /
+  32.0 tok/s (best wall of the day). The 08-15 CB-timeout drain variant is
+  also explained: it swapped only the host wait and left wait_stream's
+  GPU-side encodeWaitForEvent in place; this fix removes both.
+- Honesty note on reproduction: the wedge did NOT reproduce today on the
+  UNFIXED build (2/2 clean cold triggers: no-primer 2500-direct and
+  primer+2500-direct) — the host-timing race has drifted out of its
+  trigger window on this box (the same environmental drift that re-rolled
+  the 2500 trajectory, see UPDATE 29). The fix therefore rests on the
+  structural argument plus the prior deterministic evidence, not on a
+  live repro-kill. By construction the parked-event failure mode cannot
+  occur: there is no cross-stream event to lose.
+- Validation (5 boots, fixed build): (1) drain variant: cold 2500 direct
+  clean + all anchors bit-exact; (2) native event, standard ramp: 8-tok
+  db2846cf721b 7/10/2, off1-2000 7ce993786ba1 1538/2320/464 @ 62.53 s
+  (32.0 tok/s), 2500 e973493bef44 51/60/12 @ 3.37 s — ALL bit-exact vs
+  UPDATE 29 anchors; (3) boot_v12 wedge protocol (primer -> 2500 direct)
+  clean; (4) 08-15 wedge protocol (primer -> 8-tok -> 2500) clean;
+  (5) VLLM_QC_ASYNC_OUT_DRAIN=1 boot serves bit-exact (8-tok + 2500).
+- Kept: compressor/metal.py phaseprof/memo structure and the boot-ramp ops
+  protocol stay until a soak on the fixed path proves them unnecessary
+  (documented in metal_compat.py). CUDA/ROCm path byte-identical.
+- Raw: perf/results/2026-08-17/wedge_fix/ (boot_fix1..5 logs).
+
+## 2026-08-24 - PR #3 Rebase: Native MPS Completion Event Merged With Stream Helper
+
+- Context: PR #3 (async-output wedge structural fix, entry above) was
+  authored against the pre-review campaign branch; PR #2 later landed
+  make_output_copy_stream + stream-equality logic and extended coverage
+  to DraftTokensHandler and StructuredOutputsWorker. This rebase merges
+  the two designs rather than picking one.
+- Kept from PR #2: make_output_copy_stream as the single platform
+  decision point (producing stream on MPS — the only stream that
+  exists), the equality-based on-main detection in the copy classes,
+  and the DraftTokensHandler / StructuredOutputsWorker coverage.
+- Adopted from PR #3: the completion marker itself. Generic
+  torch.Event() is replaced by make_completion_event() — a native
+  torch.mps.Event on Metal (argless record on the one real stream) or
+  None under the VLLM_QC_ASYNC_OUT_DRAIN=1 kill-switch, which
+  sync_completion_event turns into a full torch.mps.synchronize().
+  PR #2's version still recorded a generic torch.Event on the producing
+  stream; PR #3's M1 Ultra evidence identifies the generic event
+  machinery itself as the loss point and measured the native event at
+  32.0 tok/s vs 30.6 for the drain (both bit-exact), so the native
+  event is the default and the drain the fallback. DraftTokensHandler
+  uses the same marker (its generic event synchronize was the last one
+  left on the Metal completion path).
+- On-main-stream copies now run under contextlib.nullcontext instead of
+  a redundant same-stream set_stream pair (PR #3's shape).
+- Validation here (M5 Max): async-output regression tests updated for
+  the native event type and pass alongside the full kernel suite; the
+  M1 Ultra anchor/wedge validation is recorded in the entry above and
+  was performed on PR #3's variant, whose event mechanism is identical.

--- a/tests/kernels/test_metal_async_output.py
+++ b/tests/kernels/test_metal_async_output.py
@@ -33,6 +33,20 @@ def test_make_output_copy_stream_is_producing_stream_on_mps() -> None:
     )
 
 
+def test_make_completion_event_is_native_mps_event() -> None:
+    """The generic torch.Event machinery is the observed signal-loss point
+    on Metal (MPSEvent::synchronize park); the completion marker must be
+    the native torch.mps.Event unless the drain kill-switch is armed."""
+    from vllm.v1.worker.gpu.async_utils import _METAL_DRAIN, make_completion_event
+
+    event = make_completion_event()
+    if _METAL_DRAIN:
+        assert event is None
+    else:
+        assert isinstance(event, torch.mps.Event)
+        assert not isinstance(event, torch.Event)
+
+
 def test_metal_async_output_stays_on_producer_stream() -> None:
     from vllm.v1.outputs import ModelRunnerOutput
     from vllm.v1.worker.gpu.async_utils import AsyncOutput, make_output_copy_stream

--- a/vllm/platforms/metal_compat.py
+++ b/vllm/platforms/metal_compat.py
@@ -18,11 +18,31 @@ patched at their call sites:
    that is a dummy stub that raises when called. Metal has no graph capture,
    so the truthful answer is a constant ``False``.
 
-The async-output path must not hand output copies from the main MPS stream to
-a second stream.  A cold cross-stream wait could lose its completion signal
-on the first multi-chunk request.  ``gpu/async_utils.py`` therefore records
-the tiny output copy and event on the producing stream on MPS; CUDA and ROCm
-retain their overlapping copy-stream path.
+The async-output completion-event wedge (a boot's first multi-chunk prefill
+parking the engine forever in MPSEvent::synchronize -- GPU idle, signal
+never delivered) is addressed structurally in
+``gpu/async_utils.py``: torch.Stream(mps) always returns the single
+stream 0, so the CUDA cross-stream choreography (set_stream, wait_stream,
+generic torch.Event record) was pure risk with no overlap to buy. On Metal
+the copy paths (AsyncOutput, AsyncPoolingOutput, DraftTokensHandler)
+enqueue on the producing stream via make_output_copy_stream and record a
+native torch.mps.Event there via make_completion_event;
+VLLM_QC_ASYNC_OUT_DRAIN=1 swaps that event for a full
+torch.mps.synchronize() drain as an ops fallback. History and validation:
+perf/optimization_status.md (2026-08-14 boot_v12 bisect, cleanup-phase
+bisect, 2026-08-17 fix entry -- five M1 Ultra boots, both wedge trigger
+protocols clean, all anchors bit-exact). The earlier naive attempt --
+swapping only the host-side wait for a drain while leaving wait_stream's
+GPU-side wait encoded -- moved the park and produced a
+command-buffer-timeout variant; the structural fix removes both.
+
+The race was timing-sensitive on the host side: stripping the phaseprof
+brackets and marshalling-memo conditionals from
+vllm/models/deepseek_v4/{compressor,metal}.py made even RAMPED multi-chunk
+requests park at completion (boot-level bisect, cleanup-phase entry).
+Those code paths keep their structure until a soak on the fixed event path
+proves the retention unnecessary; the boot-ramp ops protocol likewise
+stays recommended until then.
 
 Applied once, from the platform's check_and_update_config.
 """

--- a/vllm/v1/worker/gpu/async_utils.py
+++ b/vllm/v1/worker/gpu/async_utils.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import contextlib
+import functools
+import os
 
 import numpy as np
 import torch
@@ -14,17 +16,70 @@ def make_output_copy_stream(device: torch.device | str | None) -> torch.Stream:
     """Stream for output and side-channel copies that would otherwise
     overlap with compute on a second stream.
 
-    On MPS this returns the CURRENT (producing) stream: a cold cross-
-    stream event hand-off can lose its completion signal (the first-
-    multi-chunk-prefill park; perf/prefill_handoff.md), so every Metal
-    copy path stays on the producing stream. This helper is the single
-    place that platform decision lives — consumers compare their copy
-    stream against the main stream instead of testing device types.
-    CUDA/ROCm get a dedicated stream to overlap the transfer."""
+    On MPS this returns the CURRENT (producing) stream — which is the only
+    stream that exists: torch.Stream(mps) always returns stream_id 0, so a
+    dedicated copy stream buys no overlap there, and the cross-stream
+    choreography has parked the engine (see make_completion_event). This
+    helper is the single place that platform decision lives — consumers
+    compare their copy stream against the main stream instead of testing
+    device types. CUDA/ROCm get a dedicated stream to overlap the
+    transfer."""
     dev = torch.device(device) if device is not None else None
     if dev is not None and dev.type == "mps":
         return torch.accelerator.current_stream(dev)
     return torch.Stream(device)
+
+
+@functools.cache
+def _is_metal_platform() -> bool:
+    from vllm.platforms import current_platform
+
+    return current_platform.is_metal()
+
+
+# Ops kill-switch: =1 replaces the Metal completion event below with a full
+# torch.mps.synchronize() in the output wait. Costs the drafter-tail overlap
+# (~3-4% decode throughput measured on dsv4-xxs-1) but removes the event
+# from the completion path entirely if the parked-event wedge ever recurs.
+_METAL_DRAIN = os.environ.get("VLLM_QC_ASYNC_OUT_DRAIN", "0") == "1"
+
+
+def make_completion_event():
+    """Completion marker for an output copy.
+
+    On Metal: a native torch.mps.Event, or None when the drain kill-switch
+    is armed. Deliberately NOT the generic torch.Event() machinery: MPS
+    exposes exactly one stream (torch.Stream(mps) always returns
+    stream_id 0), and the generic cross-"stream" record/wait_stream
+    choreography has parked the engine forever in MPSEvent::synchronize on
+    timing-sensitive cold boots — GPU idle, signal never delivered
+    (vllm/platforms/metal_compat.py has the incident history). Elsewhere: a
+    generic torch.Event for the dedicated copy stream."""
+    if _is_metal_platform():
+        return None if _METAL_DRAIN else torch.mps.Event()
+    return torch.Event()
+
+
+def record_completion_event(event, output_stream: torch.Stream) -> None:
+    """Record a make_completion_event marker on the copy's stream.
+
+    The native MPS event records argless on the current (only) stream;
+    the generic event records on the handed output stream; None (drain
+    mode) records nothing — sync_completion_event drains instead."""
+    if event is None:
+        return
+    if _is_metal_platform():
+        event.record()
+    else:
+        event.record(output_stream)
+
+
+def sync_completion_event(event) -> None:
+    """Wait for a make_completion_event marker (None = drain the stream)."""
+    if event is None:
+        torch.mps.synchronize()
+    else:
+        event.synchronize()
 
 
 class AsyncOutput(AsyncModelRunnerOutput):
@@ -43,18 +98,23 @@ class AsyncOutput(AsyncModelRunnerOutput):
         self.model_runner_output = model_runner_output
         self.sampler_output = sampler_output
         self.num_sampled_tokens = num_sampled_tokens
-        # Blocking (sleep) event to avoid busy-polling the CUDA driver lock.
-        self.copy_event = torch.Event()
+        # Blocking (sleep) event to avoid busy-polling the CUDA driver lock;
+        # a native mps event (or drain sentinel) on Metal — see
+        # make_completion_event for why the generic machinery is unsafe there.
+        self.copy_event = make_completion_event()
         self._has_fault: torch.Tensor | None = None
 
         # On MPS, make_output_copy_stream hands out the producing stream
-        # (cold cross-stream event hand-offs can lose the completion
-        # signal), so the copy and its event land on the main stream with
-        # no cross-stream wait. CUDA/ROCm arrive with a dedicated copy
-        # stream and retain the overlap.
+        # (the only one that exists), so the copies enqueue with no stream
+        # switching at all. CUDA/ROCm arrive with a dedicated copy stream
+        # and retain the overlap.
         copy_on_main_stream = copy_stream == main_stream
         output_stream = main_stream if copy_on_main_stream else copy_stream
-        with stream(output_stream, main_stream):
+        with (
+            contextlib.nullcontext()
+            if copy_on_main_stream
+            else stream(output_stream, main_stream)
+        ):
             if not copy_on_main_stream:
                 output_stream.wait_stream(main_stream)
 
@@ -75,10 +135,10 @@ class AsyncOutput(AsyncModelRunnerOutput):
             if check_ep_fault:
                 has_fault = get_ep_all2all_manager().query_fault()
                 self._has_fault = has_fault.to("cpu", non_blocking=True)
-            self.copy_event.record(output_stream)
+            record_completion_event(self.copy_event, output_stream)
 
     def get_output(self) -> ModelRunnerOutput:
-        self.copy_event.synchronize()
+        sync_completion_event(self.copy_event)
 
         # NOTE(woosuk): The following code is to ensure compatibility with
         # the existing model runner.
@@ -122,14 +182,19 @@ class AsyncPoolingOutput(AsyncModelRunnerOutput):
         self.model_runner_output = model_runner_output
         self.pooler_output = pooler_output
         self.is_valid = is_valid
-        # Blocking (sleep) event to avoid busy-polling the CUDA driver lock.
-        self.copy_event = torch.Event()
+        # Blocking (sleep) event to avoid busy-polling the CUDA driver lock;
+        # native mps event (or drain sentinel) on Metal.
+        self.copy_event = make_completion_event()
 
         # Same single-place platform decision as AsyncOutput: on MPS the
         # handed copy stream IS the main stream (make_output_copy_stream).
         copy_on_main_stream = copy_stream == main_stream
         output_stream = main_stream if copy_on_main_stream else copy_stream
-        with stream(output_stream, main_stream):
+        with (
+            contextlib.nullcontext()
+            if copy_on_main_stream
+            else stream(output_stream, main_stream)
+        ):
             if not copy_on_main_stream:
                 output_stream.wait_stream(main_stream)
             self.pooler_output_cpu = self.pooler_output.to("cpu", non_blocking=True)
@@ -137,11 +202,11 @@ class AsyncPoolingOutput(AsyncModelRunnerOutput):
                 self.is_valid_cpu = self.is_valid.to("cpu", non_blocking=True)
             else:
                 self.is_valid_cpu = None
-            self.copy_event.record(output_stream)
+            record_completion_event(self.copy_event, output_stream)
 
     def get_output(self) -> ModelRunnerOutput:
         pooler_output = list(self.pooler_output_cpu.unbind(dim=0))
-        self.copy_event.synchronize()
+        sync_completion_event(self.copy_event)
         if self.is_valid_cpu is not None:
             is_valid_cpu = self.is_valid_cpu.tolist()
             for i, is_valid in enumerate(is_valid_cpu):

--- a/vllm/v1/worker/gpu/spec_decode/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/utils.py
@@ -4,7 +4,12 @@ import numpy as np
 import torch
 
 from vllm.v1.outputs import DraftTokenIds
-from vllm.v1.worker.gpu.async_utils import async_copy_to_np, make_output_copy_stream
+from vllm.v1.worker.gpu.async_utils import (
+    async_copy_to_np,
+    make_completion_event,
+    make_output_copy_stream,
+    sync_completion_event,
+)
 from vllm.v1.worker.gpu.input_batch import InputBatch
 
 
@@ -15,8 +20,9 @@ class DraftTokensHandler:
         # this handler had the same cross-stream copy+event shape whose cold
         # hand-off loses the completion signal on Metal.
         self.copy_stream = make_output_copy_stream(device)
-        # Blocking (sleep) event to avoid busy-polling the CUDA driver lock.
-        self.copy_event = torch.Event()
+        # Blocking (sleep) event to avoid busy-polling the CUDA driver lock;
+        # native mps event (or drain sentinel) on Metal.
+        self.copy_event = make_completion_event()
 
         self.req_ids: list[str] = []
         self.draft_tokens_np: np.ndarray | None = None
@@ -48,14 +54,17 @@ class DraftTokensHandler:
                 # caching allocator may reuse its memory before the async
                 # copy executes.
                 draft_tokens.record_stream(self.copy_stream)
-            self.copy_event.record()
+            if self.copy_event is not None:
+                # Argless record lands on the current stream: copy_stream
+                # inside the cross-stream block, the single stream on Metal.
+                self.copy_event.record()
         finally:
             if cross_stream:
                 torch.accelerator.set_stream(current_stream)
 
     def get_draft_tokens(self) -> DraftTokenIds | None:
         if self.draft_tokens_np is not None:
-            self.copy_event.synchronize()
+            sync_completion_event(self.copy_event)
             draft_token_ids = self.draft_tokens_np.tolist()
         else:
             # This case only happens when async scheduling is disabled.


### PR DESCRIPTION
Fixes the Metal serving bug where the engine could hang forever on a boot's first large prefill request, which until now required a boot-ramp workaround (serve a short request with real decode steps before any multi-chunk prefill, or the boot was lost and needed a restart).

> **Rebased onto main after #2 merged** — the branch is now a single commit. The fix is merged with #2's review work: `make_output_copy_stream` stays the platform decision point (with its DraftTokensHandler / StructuredOutputsWorker coverage), and the completion marker becomes this PR's native `torch.mps.Event` (plus the `VLLM_QC_ASYNC_OUT_DRAIN=1` fallback), replacing the generic `torch.Event` that #2's interim version still recorded.

## The bug

On timing-sensitive boots the engine parked forever inside `MPSEvent::synchronize` waiting on the async-output copy event: GPU idle, no command-buffer errors, the completion signal simply never arrived. Reproduced deterministically in the 08-14 bisect (2/2 boots) and again during the 08-15 merge gate. Once parked, the boot was unrecoverable.

## Root cause

Apple exposes one GPU queue, and `torch.Stream(mps)` always returns the same stream (id 0). The shared async-output path still ran the full CUDA cross-stream choreography — switch to a "copy stream", `wait_stream` on the "main stream", record a generic `torch.Event` on the copy stream. On Metal that dance buys zero overlap (there is only one stream) and routes every step's completion through an event that can lose its signal.

## The fix

On Metal, skip the choreography entirely: the same non-blocking device-to-host copies enqueue on the one real stream, and completion is a native `torch.mps.Event` recorded there — no stream switching, no cross-stream waits. The CUDA/ROCm path is byte-identical. An ops fallback (`VLLM_QC_ASYNC_OUT_DRAIN=1`) replaces the event with a full stream drain; it costs about 4% decode throughput, so it is not the default.

## Validation (dsv4-xxs-1, M1 Ultra, five fresh boots)

- All pinned anchors bit-exact: 8-tok, 1k-in/2k-out, and the 2500-token multi-chunk anchor.
- Decode at 32.0 tok/s end-to-end on the 2k-token anchor — the best wall of the day, no regression from the fix (the drain-only variant measured 30.6 tok/s, which is why it is only the fallback).
- Both historical wedge-trigger protocols run clean on the fixed build: cold boot straight to a multi-chunk request, and primer + short request then multi-chunk.
- Kill-switch boot serves bit-exact.

One honest caveat: the wedge is a host-timing race and had drifted out of its trigger window on the test box this week (the unfixed build also ran the triggers clean today). The fix rests on the structural argument — after it, there is no cross-stream event on the completion path left to lose — plus the earlier deterministic bisect evidence. The boot-ramp ops protocol stays recommended until a longer soak confirms it is no longer needed.

