### PR TITLE
Make speculative decoding honor structured-output grammars

### DIFF
--- a/perf/optimization_status.md
+++ b/perf/optimization_status.md
@@ -9930,3 +9930,47 @@ Load test (no-spec, in-process LLM, max_model_len 8192) iterated through:
   the native event type and pass alongside the full kernel suite; the
   M1 Ultra anchor/wedge validation is recorded in the entry above and
   was performed on PR #3's variant, whose event mechanism is identical.
+
+## 2026-08-17 — Grammar-aware DSpark for Responses custom tools on Metal
+
+- Status: implementation retained; post-tokenizer-fix end-to-end rerun pending.
+- Scope: `dsv4-xxs-1` on an Apple M1 Ultra with the 0731 DSV4 verifier,
+  matching DSpark k=5 drafter, TurboQuant draft KV, and the Responses
+  `apply_patch` custom tool using the Codex Lark grammar.
+- Baseline: target-token structured decoding was active, but DSpark sampled
+  every speculative token without the grammar mask. Mirroring the grammar by
+  blindly advancing every verified token then failed at the reasoning/DSML
+  boundary (`worker grammar rejected verified tokens [30]`).
+- Change: use scheduler `GrammarOutput` rows as the authoritative boundary,
+  maintain separate verified and speculative matchers, constrain each
+  sequential DSpark sample (including reduced Qwen-style draft vocabularies),
+  recover matcher rollback drift, and disable grammar-aware drafting per
+  request on mirror disagreement while leaving target enforcement active.
+  CPU matcher advancement forces the draft pass eager rather than capturing
+  it in a device graph.
+- Live correctness result before the tokenizer repair: the 93.57 GiB model
+  loaded and pinned 93.73 GiB; grammar-aware DSpark reached mean acceptance
+  6.00 with observed 80-100% draft-token acceptance. The original third-token
+  mirror crash was gone and the emitted prefix decoded exactly as the DSV4
+  DSML `apply_patch` envelope. Generation then stalled inside permissive
+  `filename: /(.+)/` by repeatedly selecting target token 0 (BOS).
+- Tokenizer root cause and offline fix: DSV4 exposes 1,283
+  `AddedToken(..., special=True)` entries at real target IDs, while
+  `TokenizerInfo.from_huggingface(..., vocab_size=129280)` reported zero
+  special IDs because the wrapper remapped the inferred added-token range.
+  The XGrammar backend now rebuilds its already-decoded vocabulary with every
+  in-range added special token empty. The real tokenizer probe changed the
+  recognized non-stop special count from 0 to 1,282, rejected BOS token 0
+  from `.+`, and kept ordinary filename tokens 30 (`<`) and 223 (space)
+  available.
+- Validation: focused grammar/DSpark/Metal tests pass (13 passed, 4
+  MPS-only cases skipped on the test runner); custom-tool, DSV4 parser, and
+  profile regressions pass (151 passed); Ruff and diff checks pass. The server
+  was stopped at the user's request and was not restarted, so the complete
+  post-fix `apply_patch` call remains an explicit follow-up rather than a
+  claimed pass.
+- Decision: retain the general scheduler-mask and tokenizer-metadata fixes.
+  Do not add DSML literals or DeepSeek token IDs to the inference core; model
+  envelope syntax remains owned by structural-tag adapters and tokenizer/chat
+  formatting. Raw server logs are local under
+  `/private/tmp/dsv4-grammar-server-*.log`.

--- a/tests/v1/test_xgrammar_tokenizer_info.py
+++ b/tests/v1/test_xgrammar_tokenizer_info.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+import xgrammar as xgr
+
+from vllm.v1.structured_output.backend_xgrammar import _mark_added_special_tokens
+
+
+def _token_allowed(bitmask: torch.Tensor, token_id: int) -> bool:
+    return bool((int(bitmask[0, token_id // 32]) >> (token_id % 32)) & 1)
+
+
+def test_added_special_tokens_are_excluded_from_permissive_regex() -> None:
+    tokenizer_info = xgr.TokenizerInfo(
+        [b"<bos>", b"a", b"/", b"."],
+        vocab_type=xgr.VocabType.RAW,
+    )
+    tokenizer = SimpleNamespace(
+        added_tokens_decoder={
+            0: SimpleNamespace(special=True),
+            1: SimpleNamespace(special=False),
+            # IDs outside the target model vocabulary must be ignored. This
+            # mirrors wrappers that report an inflated added-token range.
+            10: SimpleNamespace(special=True),
+        }
+    )
+
+    fixed_info = _mark_added_special_tokens(tokenizer_info, tokenizer)
+    compiler = xgr.GrammarCompiler(fixed_info)
+    matcher = xgr.GrammarMatcher(compiler.compile_regex(r".+"))
+    bitmask = xgr.allocate_token_bitmask(1, fixed_info.vocab_size)
+    matcher.fill_next_token_bitmask(bitmask, 0)
+
+    assert not _token_allowed(bitmask, 0)
+    assert _token_allowed(bitmask, 1)
+    assert _token_allowed(bitmask, 2)
+    assert fixed_info.decoded_vocab[0] == b""
+
+
+def test_correct_special_token_metadata_is_reused() -> None:
+    tokenizer_info = xgr.TokenizerInfo(
+        [b"", b"a"],
+        vocab_type=xgr.VocabType.RAW,
+    )
+    tokenizer = SimpleNamespace(added_tokens_decoder={0: SimpleNamespace(special=True)})
+
+    assert _mark_added_special_tokens(tokenizer_info, tokenizer) is tokenizer_info

--- a/tests/v1/worker/test_draft_structured_output.py
+++ b/tests/v1/worker/test_draft_structured_output.py
@@ -1,0 +1,401 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import torch
+
+from vllm.v1.core.sched.output import GrammarOutput
+from vllm.v1.structured_output.backend_types import StructuredOutputGrammar
+from vllm.v1.worker.gpu import structured_outputs
+from vllm.v1.worker.gpu.spec_decode.dspark import speculator as dspark_speculator
+from vllm.v1.worker.gpu.spec_decode.dspark.speculator import DSparkSpeculator
+from vllm.v1.worker.gpu.spec_decode.structured_output import (
+    DraftGrammarBatch,
+    DraftStructuredOutputState,
+)
+
+
+class _Grammar(StructuredOutputGrammar):
+    def __init__(self, allowed_by_position: list[set[int]]) -> None:
+        self.allowed_by_position = allowed_by_position
+        self.position = 0
+
+    def accept_tokens(self, request_id: str, tokens: list[int]) -> bool:
+        del request_id
+        position = self.position
+        for token in tokens:
+            if token not in self.allowed_by_position[position]:
+                return False
+            position += 1
+        self.position = position
+        return True
+
+    def validate_tokens(self, tokens: list[int]) -> list[int]:
+        accepted = []
+        for position, token in enumerate(tokens, self.position):
+            if token not in self.allowed_by_position[position]:
+                break
+            accepted.append(token)
+        return accepted
+
+    def rollback(self, num_tokens: int) -> None:
+        self.position -= num_tokens
+
+    def fill_bitmask(self, bitmask: torch.Tensor, batch_index: int) -> None:
+        bitmask[batch_index].zero_()
+        for token in self.allowed_by_position[self.position]:
+            bitmask[batch_index, token // 32] |= 1 << (token % 32)
+
+    def is_terminated(self) -> bool:
+        return self.position == len(self.allowed_by_position)
+
+    def reset(self) -> None:
+        self.position = 0
+
+
+class _Backend:
+    @staticmethod
+    def allocate_token_bitmask(num_rows: int) -> torch.Tensor:
+        return torch.zeros((num_rows, 1), dtype=torch.int32)
+
+
+class _MaskingWorker:
+    def __init__(self) -> None:
+        self.target_token_ids: torch.Tensor | None = None
+
+    def apply_grammar_bitmask_rows(
+        self,
+        logits: torch.Tensor,
+        rows: list[int],
+        bitmask: np.ndarray,
+        target_token_ids: torch.Tensor | None = None,
+    ) -> None:
+        self.target_token_ids = target_token_ids
+        for mask_row, logits_row in enumerate(rows):
+            for column in range(logits.shape[1]):
+                token = (
+                    column
+                    if target_token_ids is None
+                    else int(target_token_ids[column])
+                )
+                allowed = (int(bitmask[mask_row, token // 32]) >> (token % 32)) & 1
+                if not allowed:
+                    logits[logits_row, column] = float("-inf")
+
+
+def test_draft_grammar_batch_masks_advances_and_rolls_back() -> None:
+    first = _Grammar([{1}, {3}])
+    second = _Grammar([{2}, {4}])
+    worker = _MaskingWorker()
+    batch = DraftGrammarBatch(
+        SimpleNamespace(backend=_Backend()),
+        worker,
+        rows=[0, 2],
+        request_ids=["first", "second"],
+        grammars=[first, second],
+    )
+
+    logits = torch.zeros((3, 8))
+    batch.apply(logits)
+
+    assert torch.isfinite(logits[0]).nonzero().flatten().tolist() == [1]
+    assert torch.isfinite(logits[1]).all()
+    assert torch.isfinite(logits[2]).nonzero().flatten().tolist() == [2]
+
+    batch.advance(torch.tensor([1, 7, 2]))
+    assert first.position == 1
+    assert second.position == 1
+
+    next_logits = torch.zeros((3, 8))
+    batch.apply(next_logits)
+    assert torch.isfinite(next_logits[0]).nonzero().flatten().tolist() == [3]
+    assert torch.isfinite(next_logits[2]).nonzero().flatten().tolist() == [4]
+
+    batch.rollback()
+    assert first.position == 0
+    assert second.position == 0
+    assert batch.advancements == [0, 0]
+
+
+def test_draft_grammar_batch_disables_rejected_mirror_without_raising() -> None:
+    grammar = _Grammar([{1}, {2}])
+    rejected: list[tuple[str, str]] = []
+    batch = DraftGrammarBatch(
+        SimpleNamespace(backend=_Backend()),
+        _MaskingWorker(),
+        rows=[0],
+        request_ids=["request"],
+        grammars=[grammar],
+        on_reject=lambda req_id, reason: rejected.append((req_id, reason)),
+    )
+
+    # Simulate disagreement between the applied mask and the local matcher.
+    batch.advance(torch.tensor([7]))
+
+    assert batch.enabled == [False]
+    assert rejected == [("request", "draft matcher rejected its masked token 7")]
+    logits = torch.zeros((1, 8))
+    batch.apply(logits)
+    assert torch.isfinite(logits).all()
+
+
+def test_worker_masks_reduced_draft_vocabulary_by_target_id(monkeypatch) -> None:
+    current_stream = MagicMock()
+    copy_stream = MagicMock()
+    worker = object.__new__(structured_outputs.StructuredOutputsWorker)
+    # The local torch build reports MPS as the active accelerator even in
+    # CPU-only unit tests. Mark this worker as MPS so the production path does
+    # not request pinned host memory from the unavailable allocator.
+    worker.device = torch.device("mps")
+    worker.copy_stream = copy_stream
+    worker.grammar_bitmask = torch.zeros((2, 1), dtype=torch.int32)
+    worker.logits_indices = torch.zeros(2, dtype=torch.int32)
+
+    monkeypatch.setattr(
+        structured_outputs.torch.accelerator,
+        "current_stream",
+        lambda _device: current_stream,
+    )
+    monkeypatch.setattr(
+        structured_outputs,
+        "stream",
+        lambda *_args: contextlib.nullcontext(),
+    )
+
+    def copy_to_device(value, out):
+        source = torch.from_numpy(value) if isinstance(value, np.ndarray) else value
+        return out.copy_(source)
+
+    monkeypatch.setattr(structured_outputs, "async_copy_to_gpu", copy_to_device)
+
+    logits = torch.zeros((2, 3))
+    grammar_bitmask = np.array([[1 << 5]], dtype=np.int32)
+    worker.apply_grammar_bitmask_rows(
+        logits,
+        mapping=[1],
+        grammar_bitmask=grammar_bitmask,
+        target_token_ids=torch.tensor([2, 5, 7]),
+    )
+
+    assert torch.isfinite(logits[0]).all()
+    assert torch.isfinite(logits[1]).nonzero().flatten().tolist() == [1]
+    current_stream.wait_stream.assert_called_once_with(copy_stream)
+    copy_stream.wait_stream.assert_called_once_with(current_stream)
+
+
+class _DraftModel:
+    def __init__(self, logits: torch.Tensor, target_ids: torch.Tensor) -> None:
+        self.logits = logits
+        self.target_ids = target_ids
+
+    def compute_draft_logits(self, _hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.logits.clone()
+
+    @staticmethod
+    def markov_embed(tokens: torch.Tensor) -> torch.Tensor:
+        return tokens
+
+    def markov_bias(self, _tokens: torch.Tensor) -> torch.Tensor:
+        return torch.zeros_like(self.logits)
+
+    def map_draft_to_target(self, draft_ids: torch.Tensor) -> torch.Tensor:
+        return self.target_ids[draft_ids]
+
+
+def test_dspark_full_vocab_model_does_not_require_mapping_attribute(
+    monkeypatch,
+) -> None:
+    model = SimpleNamespace()
+    monkeypatch.setattr(
+        dspark_speculator,
+        "load_dspark_model",
+        lambda _target, _config: model,
+    )
+    speculator = object.__new__(DSparkSpeculator)
+    speculator.vllm_config = object()
+    speculator.draft_logits = None
+    speculator._draft_target_ids = None
+    speculator._d2t_scatter_index = None
+    speculator._draft_scatter_buf = None
+
+    loaded = speculator.load_draft_model(object(), set())
+
+    assert loaded is model
+    assert speculator._draft_target_ids is None
+
+
+def test_dspark_chooses_grammar_valid_reduced_vocab_token() -> None:
+    speculator = object.__new__(DSparkSpeculator)
+    speculator.num_speculative_steps = 1
+    speculator.sample_indices = torch.tensor([0])
+    speculator.sample_idx_mapping = torch.tensor([0])
+    speculator.sample_pos = torch.tensor([1])
+    speculator.input_buffers = SimpleNamespace(input_ids=torch.tensor([9]))
+    speculator._anchor_idx = torch.tensor([0])
+    speculator.model = _DraftModel(
+        logits=torch.tensor([[10.0, 9.0, 8.0]]),
+        target_ids=torch.tensor([2, 5, 7]),
+    )
+    speculator.draft_logits = None
+    speculator.draft_tokens = torch.zeros((1, 1), dtype=torch.int64)
+    speculator._draft_target_ids = torch.tensor([2, 5, 7])
+    speculator.draft_grammar = MagicMock()
+
+    def allow_only_target_five(logits, target_token_ids=None) -> None:
+        assert target_token_ids.tolist() == [2, 5, 7]
+        logits[:, target_token_ids != 5] = float("-inf")
+
+    speculator.draft_grammar.apply.side_effect = allow_only_target_five
+
+    speculator._sample_sequential(1, torch.zeros((1, 1)))
+
+    assert speculator.draft_tokens.tolist() == [[5]]
+    speculator.draft_grammar.advance.assert_called_once()
+    assert speculator.draft_grammar.advance.call_args.args[0].tolist() == [5]
+
+
+class _MirrorRequest:
+    def __init__(self, request_id: str, grammar: _Grammar) -> None:
+        self.request_id = request_id
+        self.structured_output_request = SimpleNamespace(grammar=grammar)
+        self.output: list[int] = []
+
+    def append_output_token_ids(self, tokens: list[int]) -> None:
+        self.output.extend(tokens)
+
+
+def test_verified_tokens_follow_authoritative_mask_rows() -> None:
+    constrained_grammar = _Grammar([{12}, {13}])
+    reasoning_grammar = _Grammar([{21}])
+    constrained = _MirrorRequest("constrained", constrained_grammar)
+    reasoning = _MirrorRequest("reasoning", reasoning_grammar)
+
+    state = object.__new__(DraftStructuredOutputState)
+    state.manager = SimpleNamespace(backend=_Backend())
+    state.worker = _MaskingWorker()
+    state.requests = {
+        "constrained": constrained,
+        "reasoning": reasoning,
+    }
+    state.draft_grammars = {
+        "constrained": _Grammar([{12}, {13}]),
+        "reasoning": _Grammar([{21}]),
+    }
+    state.verified_tokens = {
+        "constrained": [],
+        "reasoning": [],
+    }
+    state.draft_active = set()
+    state.draft_disabled = set()
+    input_batch = SimpleNamespace(
+        req_ids=["constrained", "reasoning", "unstructured"],
+        cu_num_logits_np=np.array([0, 2, 4, 5], dtype=np.int32),
+    )
+    # The constrained request crosses the reasoning boundary between its two
+    # rows. The reasoning request remains unrestricted. All-ones packed masks
+    # are the scheduler's unrestricted sentinel.
+    grammar_output = GrammarOutput(
+        structured_output_request_ids=["constrained", "reasoning"],
+        grammar_bitmask=np.array([[-1], [0], [-1], [-1]], dtype=np.int32),
+    )
+
+    state.advance_verified(
+        input_batch,
+        sampled_token_ids=torch.tensor([[99, 12], [20, 21], [30, 31]]),
+        num_sampled=torch.tensor([2, 2, 1]),
+        grammar_output=grammar_output,
+    )
+
+    assert constrained.output == [99, 12]
+    assert reasoning.output == [20, 21]
+    assert constrained_grammar.position == 1
+    assert reasoning_grammar.position == 0
+    assert state.draft_grammars["constrained"].position == 1
+    assert state.draft_grammars["reasoning"].position == 0
+    assert state.draft_active == {"constrained"}
+
+    draft = state.begin_draft(input_batch)
+    assert draft is not None
+    assert draft.rows == [0]
+    assert draft.request_ids == ["constrained"]
+    assert draft.grammars == [state.draft_grammars["constrained"]]
+
+
+def test_unconstrained_rows_delay_grammar_aware_drafting() -> None:
+    grammar = _Grammar([{12}])
+    request = _MirrorRequest("request", grammar)
+    state = object.__new__(DraftStructuredOutputState)
+    state.manager = SimpleNamespace(backend=_Backend())
+    state.worker = _MaskingWorker()
+    state.requests = {"request": request}
+    state.draft_grammars = {"request": _Grammar([{12}])}
+    state.verified_tokens = {"request": []}
+    state.draft_active = set()
+    state.draft_disabled = set()
+    input_batch = SimpleNamespace(
+        req_ids=["request"],
+        cu_num_logits_np=np.array([0, 1], dtype=np.int32),
+    )
+
+    state.advance_verified(
+        input_batch,
+        sampled_token_ids=torch.tensor([[99]]),
+        num_sampled=torch.tensor([1]),
+        grammar_output=GrammarOutput(["request"], np.array([[-1]], dtype=np.int32)),
+    )
+    assert state.begin_draft(input_batch) is None
+
+    state.advance_verified(
+        input_batch,
+        sampled_token_ids=torch.tensor([[12]]),
+        num_sampled=torch.tensor([1]),
+        grammar_output=GrammarOutput(["request"], np.array([[0]], dtype=np.int32)),
+    )
+    assert state.draft_active == {"request"}
+
+
+def test_worker_mirror_rejection_disables_drafting_without_raising() -> None:
+    grammar = _Grammar([{7}])
+    request = _MirrorRequest("request", grammar)
+    state = object.__new__(DraftStructuredOutputState)
+    state.manager = SimpleNamespace(backend=_Backend())
+    state.worker = _MaskingWorker()
+    state.requests = {"request": request}
+    state.draft_grammars = {"request": _Grammar([{7}])}
+    state.verified_tokens = {"request": []}
+    state.draft_active = set()
+    state.draft_disabled = set()
+    input_batch = SimpleNamespace(
+        req_ids=["request"],
+        cu_num_logits_np=np.array([0, 1], dtype=np.int32),
+    )
+
+    state.advance_verified(
+        input_batch,
+        sampled_token_ids=torch.tensor([[12]]),
+        num_sampled=torch.tensor([1]),
+        grammar_output=GrammarOutput(["request"], np.array([[0]], dtype=np.int32)),
+    )
+
+    assert state.draft_disabled == {"request"}
+    assert state.begin_draft(input_batch) is None
+
+
+def test_draft_matcher_recovers_from_rollback_drift() -> None:
+    state = object.__new__(DraftStructuredOutputState)
+    draft_grammar = _Grammar([{12}, {13}])
+    # Simulate a speculative rollback that left the matcher one token behind.
+    draft_grammar.position = 0
+    state.draft_grammars = {"request": draft_grammar}
+    state.verified_tokens = {"request": [12]}
+    state.draft_active = {"request"}
+    state.draft_disabled = set()
+
+    assert state._advance_draft_mirror("request", [13])
+
+    assert draft_grammar.position == 2
+    assert state.verified_tokens["request"] == [12]

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -31,6 +32,52 @@ else:
     xgr = LazyLoader("xgr", globals(), "xgrammar")
 
 logger = init_logger(__name__)
+
+
+def _mark_added_special_tokens(
+    tokenizer_info: xgr.TokenizerInfo,
+    tokenizer: Any,
+) -> xgr.TokenizerInfo:
+    """Repair special-token metadata lost by wrapped HF tokenizers.
+
+    XGrammar represents special tokens as empty entries in ``decoded_vocab``.
+    Some tokenizer wrappers expose an inflated or remapped added-token range,
+    so ``TokenizerInfo.from_huggingface`` can leave real control-token IDs as
+    ordinary text. A permissive regex may then admit BOS, padding, or protocol
+    tokens into a structured payload.
+
+    Rebuilding from XGrammar's already-decoded bytes avoids reapplying the
+    tokenizer-specific byte-level transformation. This is tokenizer-agnostic:
+    any in-vocabulary ``AddedToken(..., special=True)`` is repaired, while
+    tokenizers whose metadata is already correct return unchanged.
+    """
+    added_tokens = getattr(tokenizer, "added_tokens_decoder", None)
+    if not isinstance(added_tokens, Mapping):
+        return tokenizer_info
+
+    special_token_ids = [
+        token_id
+        for token_id, token in added_tokens.items()
+        if isinstance(token_id, int)
+        and 0 <= token_id < tokenizer_info.vocab_size
+        and bool(getattr(token, "special", False))
+    ]
+    if not special_token_ids:
+        return tokenizer_info
+
+    decoded_vocab = list(tokenizer_info.decoded_vocab)
+    if not any(decoded_vocab[token_id] for token_id in special_token_ids):
+        return tokenizer_info
+    for token_id in special_token_ids:
+        decoded_vocab[token_id] = b""
+
+    return xgr.TokenizerInfo(
+        decoded_vocab,
+        vocab_type=xgr.VocabType.RAW,
+        vocab_size=tokenizer_info.vocab_size,
+        stop_token_ids=tokenizer_info.stop_token_ids,
+        add_prefix_space=tokenizer_info.add_prefix_space,
+    )
 
 
 @dataclass
@@ -62,6 +109,10 @@ class XgrammarBackend(StructuredOutputBackend):
             tokenizer_info = xgr.TokenizerInfo.from_huggingface(
                 self.tokenizer,
                 vocab_size=self.vocab_size,
+            )
+            tokenizer_info = _mark_added_special_tokens(
+                tokenizer_info,
+                self.tokenizer,
             )
         self.compiler = xgr.GrammarCompiler(
             tokenizer_info,
@@ -202,6 +253,7 @@ class XgrammarGrammar(StructuredOutputGrammar):
     def reset(self):
         self.num_processed_tokens = 0
         self.matcher.reset()
+        self._is_terminated = False
 
 
 # cf https://github.com/mlc-ai/xgrammar/blob/a32ac892676d2eedc0327416105b9b06edfb94b2/cpp/json_schema_converter.cc

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -119,6 +119,9 @@ from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import (
 )
 from vllm.v1.worker.gpu.spec_decode.rejection_sampler import RejectionSampler
 from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
+from vllm.v1.worker.gpu.spec_decode.structured_output import (
+    DraftStructuredOutputState,
+)
 from vllm.v1.worker.gpu.spec_decode.utils import DraftTokensHandler
 from vllm.v1.worker.gpu.states import RequestState
 from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
@@ -256,6 +259,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.rejection_sampler: RejectionSampler | None = None
         self.prompt_logprobs_worker: PromptLogprobsWorker | None = None
         self.structured_outputs_worker: StructuredOutputsWorker | None = None
+        self.draft_structured_output_state: DraftStructuredOutputState | None = None
         self.cudagraph_manager: ModelCudaGraphManager | None = None
 
         # LoRA-related workers.
@@ -370,6 +374,14 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 vocab_size=self.vocab_size,
                 device=self.device,
             )
+            if (
+                self.speculative_config is not None
+                and self.speculative_config.use_dspark()
+            ):
+                self.draft_structured_output_state = DraftStructuredOutputState(
+                    self.vllm_config,
+                    self.structured_outputs_worker,
+                )
 
         if self.is_pooling_model and self.is_last_pp_rank:
             self.pooling_runner = PoolingRunner(self.model)
@@ -800,6 +812,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if self.prompt_logprobs_worker is not None:
             self.prompt_logprobs_worker.remove_request(req_id)
         self.lora_state.remove_request(req_id)
+        if self.draft_structured_output_state is not None:
+            self.draft_structured_output_state.remove_request(req_id)
         return True
 
     def finish_requests(self, scheduler_output: SchedulerOutput) -> None:
@@ -863,6 +877,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 self.prompt_logprobs_worker.add_request(
                     req_id, req_index, new_req_data.sampling_params
                 )
+                if self.draft_structured_output_state is not None:
+                    self.draft_structured_output_state.add_request(new_req_data)
 
         if scheduler_output.scheduled_new_reqs:
             self.req_states.apply_staged_writes()
@@ -1640,6 +1656,16 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             input_batch.query_start_loc,
         )
 
+        draft_grammar = None
+        if self.draft_structured_output_state is not None:
+            self.draft_structured_output_state.advance_verified(
+                input_batch,
+                sampler_output.sampled_token_ids,
+                num_sampled,
+                grammar_output,
+            )
+            draft_grammar = self.draft_structured_output_state.begin_draft(input_batch)
+
         if self.speculator is not None:
             assert self.sampler is not None
             # Let the target override the hidden state fed to the drafter
@@ -1650,21 +1676,27 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if hasattr(self.model, "get_mtp_target_hidden_states"):
                 pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
                 spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
-            with _qc_phase("drafter_propose"):
-                draft_tokens = self.speculator.propose(
-                    input_batch,
-                    attn_metadata,
-                    slot_mappings_by_layer,
-                    spec_hidden_states,
-                    aux_hidden_states,
-                    num_sampled,
-                    num_rejected,
-                    self.req_states.last_sampled_tokens,
-                    self.req_states.next_prefill_tokens,
-                    self.sampler.sampling_states.temperature.gpu,
-                    self.sampler.sampling_states.seeds.gpu,
-                    mm_inputs=mm_inputs,
-                )
+            self.speculator.draft_grammar = draft_grammar
+            try:
+                with _qc_phase("drafter_propose"):
+                    draft_tokens = self.speculator.propose(
+                        input_batch,
+                        attn_metadata,
+                        slot_mappings_by_layer,
+                        spec_hidden_states,
+                        aux_hidden_states,
+                        num_sampled,
+                        num_rejected,
+                        self.req_states.last_sampled_tokens,
+                        self.req_states.next_prefill_tokens,
+                        self.sampler.sampling_states.temperature.gpu,
+                        self.sampler.sampling_states.seeds.gpu,
+                        mm_inputs=mm_inputs,
+                    )
+            finally:
+                if draft_grammar is not None:
+                    draft_grammar.rollback()
+                self.speculator.draft_grammar = None
             self.req_states.draft_tokens[input_batch.idx_mapping] = draft_tokens
 
         if self.num_speculative_steps > 0:
@@ -1754,6 +1786,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         """Release GPU tensors (model weights, KV caches, workspace) so that
         memory is reclaimable when running in the same process."""
         torch.accelerator.synchronize()
+        if self.draft_structured_output_state is not None:
+            self.draft_structured_output_state.shutdown()
+            self.draft_structured_output_state = None
         if hasattr(self, "kv_caches"):
             self.kv_caches.clear()
         if hasattr(self, "attn_groups"):

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -502,7 +502,9 @@ class DFlashSpeculator(DraftModelSpeculator):
             uniform_token_count=self.num_query_per_req,
             dp_size=self.dp_size,
             dp_rank=self.dp_rank,
-            need_eager=is_profile,
+            # Grammar-aware DSpark advances a CPU matcher between sequential
+            # samples, which cannot execute inside a captured CUDA graph.
+            need_eager=is_profile or self.draft_grammar is not None,
         )
 
         num_reqs_padded = batch_desc.num_reqs or num_reqs

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -70,6 +70,7 @@ class DSparkSpeculator(DFlashSpeculator):
         )
 
         # Reduced-vocab probabilistic drafting only; set in load_draft_model.
+        self._draft_target_ids: torch.Tensor | None = None
         self._d2t_scatter_index: torch.Tensor | None = None
         self._draft_scatter_buf: torch.Tensor | None = None
 
@@ -82,11 +83,11 @@ class DSparkSpeculator(DFlashSpeculator):
         # Reduced draft vocab: probabilistic rejection sampling indexes draft
         # logits by target id, so precompute the draft->target column map and a
         # scratch buffer to scatter logits into target vocab before sampling.
-        if self.draft_logits is not None and model.draft_id_to_target_id is not None:
-            d2t = model.draft_id_to_target_id
-            self._d2t_scatter_index = (
-                torch.arange(d2t.shape[0], device=d2t.device) + d2t
-            )
+        d2t = getattr(model, "draft_id_to_target_id", None)
+        if d2t is not None:
+            self._draft_target_ids = torch.arange(d2t.shape[0], device=d2t.device) + d2t
+        if self.draft_logits is not None and self._draft_target_ids is not None:
+            self._d2t_scatter_index = self._draft_target_ids
             # -inf once; the per-step scatter overwrites the draft->target
             # columns. Kept separate from draft_logits to avoid aliasing.
             self._draft_scatter_buf = torch.full(
@@ -120,6 +121,7 @@ class DSparkSpeculator(DFlashSpeculator):
             markov_embed = self.model.markov_embed(prev)
             bias = self.model.markov_bias(markov_embed)
             logits_i = base_logits[:, i] + bias
+            target_ids_for_mask = self._draft_target_ids
             if self.draft_logits is not None:
                 # Probabilistic: sample in target vocab (a reduced draft vocab is
                 # scattered into its target columns; full vocab is already there).
@@ -128,6 +130,13 @@ class DSparkSpeculator(DFlashSpeculator):
                     buf = self._draft_scatter_buf[:num_reqs]
                     buf.index_copy_(1, self._d2t_scatter_index, logits_i.to(buf.dtype))
                     logits_i = buf
+                target_ids_for_mask = None
+            if self.draft_grammar is not None:
+                self.draft_grammar.apply(
+                    logits_i,
+                    target_token_ids=target_ids_for_mask,
+                )
+            if self.draft_logits is not None:
                 # sample_pos is the predicted token's position Q; the target
                 # verifies it with the predecessor's Gumbel key (Q-1). Pass Q-1.
                 draft_sampled_i = gumbel_sample(
@@ -146,6 +155,8 @@ class DSparkSpeculator(DFlashSpeculator):
                     logits_i.argmax(dim=-1)
                 )
             self.draft_tokens[:num_reqs, i] = draft_sampled_i
+            if self.draft_grammar is not None:
+                self.draft_grammar.advance(draft_sampled_i)
             prev = draft_sampled_i
 
     def _generate_draft(

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -127,6 +127,9 @@ class DraftModelSpeculator(BaseSpeculator):
         )
 
         self.draft_logits: torch.Tensor | None = None
+        # Set transiently by the model runner for structured-output requests.
+        # DSpark consumes it between each sequential Markov sample.
+        self.draft_grammar = None
         if self.speculative_config.draft_sample_method == "probabilistic":
             self.draft_logits = torch.zeros(
                 self.max_num_reqs,

--- a/vllm/v1/worker/gpu/spec_decode/structured_output.py
+++ b/vllm/v1/worker/gpu/spec_decode/structured_output.py
@@ -1,0 +1,334 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Worker-side grammar state for grammar-aware speculative drafting."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+import numpy as np
+import torch
+
+from vllm.logger import init_logger
+from vllm.v1.request import Request
+from vllm.v1.structured_output import StructuredOutputManager
+from vllm.v1.structured_output.backend_types import StructuredOutputGrammar
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.v1.core.sched.output import GrammarOutput, NewRequestData
+    from vllm.v1.worker.gpu.input_batch import InputBatch
+    from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
+
+logger = init_logger(__name__)
+
+
+class DraftGrammarBatch:
+    """Temporary grammar states advanced only through one draft block."""
+
+    def __init__(
+        self,
+        manager: StructuredOutputManager,
+        worker: StructuredOutputsWorker,
+        rows: list[int],
+        request_ids: list[str],
+        grammars: list[StructuredOutputGrammar],
+        on_reject: Callable[[str, str], None] | None = None,
+    ) -> None:
+        backend = manager.backend
+        assert backend is not None
+        self.worker = worker
+        self.rows = rows
+        self.request_ids = request_ids
+        self.grammars = grammars
+        self.on_reject = on_reject
+        self.bitmask = backend.allocate_token_bitmask(len(rows))
+        self.advancements = [0] * len(rows)
+        self.enabled = [True] * len(rows)
+
+    def apply(
+        self,
+        logits: torch.Tensor,
+        target_token_ids: torch.Tensor | None = None,
+    ) -> None:
+        active = [index for index, enabled in enumerate(self.enabled) if enabled]
+        if not active:
+            return
+        for index in active:
+            grammar = self.grammars[index]
+            grammar.fill_bitmask(self.bitmask, index)
+        rows = [self.rows[index] for index in active]
+        bitmask = self.bitmask.numpy()
+        if len(active) != len(self.rows):
+            bitmask = bitmask[active]
+        self.worker.apply_grammar_bitmask_rows(
+            logits,
+            rows,
+            bitmask,
+            target_token_ids=target_token_ids,
+        )
+
+    def advance(self, sampled_target_ids: torch.Tensor) -> None:
+        row_indices = torch.tensor(
+            self.rows, dtype=torch.int64, device=sampled_target_ids.device
+        )
+        tokens = sampled_target_ids.index_select(0, row_indices).cpu().tolist()
+        for index, (request_id, grammar, token) in enumerate(
+            zip(self.request_ids, self.grammars, tokens)
+        ):
+            if not self.enabled[index]:
+                continue
+            if not grammar.accept_tokens(request_id, [token]):
+                reason = f"draft matcher rejected its masked token {token}"
+                if self.on_reject is not None:
+                    self.on_reject(request_id, reason)
+                else:
+                    logger.warning(
+                        "Disabling draft grammar for request %s: %s",
+                        request_id,
+                        reason,
+                    )
+                self.enabled[index] = False
+                continue
+            self.advancements[index] += 1
+
+    def rollback(self) -> None:
+        for grammar, count in zip(self.grammars, self.advancements):
+            if not count:
+                continue
+            grammar.rollback(count)
+        self.advancements = [0] * len(self.rows)
+
+
+class DraftStructuredOutputState:
+    """Mirror scheduler grammar state for grammar-aware draft sampling.
+
+    The scheduler's grammar bitmask is authoritative about the reasoning-to-
+    structured-output boundary. Re-running the reasoning parser in the worker
+    is not equivalent under speculative decoding: the scheduler may constrain
+    only a suffix of the sampled rows. This mirror therefore advances only for
+    rows that were actually constrained by the scheduler.
+    """
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        worker: StructuredOutputsWorker,
+    ) -> None:
+        self.manager = StructuredOutputManager(vllm_config)
+        # Drafting occurs in the worker's synchronous request-admission path;
+        # completing compilation here avoids a first-token race with drafting.
+        self.manager._use_async_grammar_compilation = False
+        self.worker = worker
+        self.requests: dict[str, Request] = {}
+        # Verified target tokens and speculative proposals must not share one
+        # matcher. Some backends only guarantee bounded rollback for the
+        # speculative matcher; keeping the verified matcher isolated prevents
+        # rollback drift from poisoning the next target token.
+        self.draft_grammars: dict[str, StructuredOutputGrammar] = {}
+        self.verified_tokens: dict[str, list[int]] = {}
+        self.draft_active: set[str] = set()
+        self.draft_disabled: set[str] = set()
+
+    def add_request(self, data: NewRequestData) -> None:
+        sampling_params = data.sampling_params
+        if sampling_params is None or sampling_params.structured_outputs is None:
+            return
+        request = Request(
+            request_id=data.req_id,
+            prompt_token_ids=data.prompt_token_ids,
+            sampling_params=sampling_params,
+            pooling_params=data.pooling_params,
+        )
+        self.manager.grammar_init(request)
+        structured = request.structured_output_request
+        assert structured is not None
+        grammar = structured.grammar
+        if isinstance(grammar, Exception):
+            raise grammar
+        if not isinstance(grammar, StructuredOutputGrammar):
+            raise RuntimeError(f"grammar for request {data.req_id} is not ready")
+        self.requests[data.req_id] = request
+        draft_grammar = self.manager._create_grammar(request)
+        self.draft_grammars[data.req_id] = draft_grammar
+        self.verified_tokens[data.req_id] = []
+
+    def remove_request(self, req_id: str) -> None:
+        self.requests.pop(req_id, None)
+        self.draft_grammars.pop(req_id, None)
+        self.verified_tokens.pop(req_id, None)
+        self.draft_active.discard(req_id)
+        self.draft_disabled.discard(req_id)
+
+    @staticmethod
+    def _is_unconstrained(mask: np.ndarray) -> bool:
+        # StructuredOutputManager represents the reasoning / unrestricted row
+        # as a packed vocabulary mask with every word set to all ones.
+        return bool(np.all(mask == -1))
+
+    def _disable(self, req_id: str, reason: str) -> None:
+        if req_id not in self.draft_disabled:
+            logger.warning(
+                "Disabling grammar-aware speculative drafting for request %s: %s. "
+                "Target-token grammar enforcement remains active.",
+                req_id,
+                reason,
+            )
+        self.draft_disabled.add(req_id)
+        self.draft_active.discard(req_id)
+
+    def _accept_verified(self, req_id: str, tokens: list[int]) -> bool:
+        request = self.requests[req_id]
+        structured = request.structured_output_request
+        assert structured is not None
+        grammar = structured.grammar
+        assert isinstance(grammar, StructuredOutputGrammar)
+
+        if grammar.accept_tokens(req_id, tokens):
+            return True
+
+        # A worker mirror must never turn a scheduler-valid target token into
+        # an engine-wide failure. Try one full replay, then stop constraining
+        # this request's drafts and leave validation to the scheduler.
+        grammar.reset()
+        history = [*self.verified_tokens[req_id], *tokens]
+        if not history or grammar.accept_tokens(req_id, history):
+            return True
+        self._disable(
+            req_id,
+            f"verified matcher rejected scheduler-constrained tokens {tokens} "
+            f"after history {self.verified_tokens[req_id]}",
+        )
+        return False
+
+    def _advance_draft_mirror(self, req_id: str, tokens: list[int]) -> bool:
+        draft_grammar = self.draft_grammars[req_id]
+        if draft_grammar.validate_tokens(
+            tokens
+        ) == tokens and draft_grammar.accept_tokens(req_id, tokens):
+            return True
+
+        # Recover a speculative matcher whose rollback did not return to the
+        # verified state. Replaying target-verified history is correctness-
+        # preserving and is only paid on the exceptional recovery path.
+        draft_grammar.reset()
+        history = self.verified_tokens[req_id]
+        if history and not draft_grammar.accept_tokens(req_id, history):
+            self._disable(
+                req_id,
+                f"draft matcher could not replay verified history {history}",
+            )
+            return False
+        if draft_grammar.validate_tokens(
+            tokens
+        ) == tokens and draft_grammar.accept_tokens(req_id, tokens):
+            return True
+        self._disable(
+            req_id,
+            f"draft matcher rejected scheduler-constrained tokens {tokens} "
+            "after replaying verified history",
+        )
+        return False
+
+    @staticmethod
+    def _mask_rows_by_request(
+        input_batch: InputBatch,
+        grammar_output: GrammarOutput | None,
+    ) -> dict[str, np.ndarray]:
+        if grammar_output is None:
+            return {}
+
+        req_id_to_index = {
+            req_id: index for index, req_id in enumerate(input_batch.req_ids)
+        }
+        cu_num_logits = input_batch.cu_num_logits_np
+        rows_by_request: dict[str, np.ndarray] = {}
+        offset = 0
+        for req_id in grammar_output.structured_output_request_ids:
+            req_index = req_id_to_index.get(req_id)
+            if req_index is None:
+                continue
+            num_rows = int(cu_num_logits[req_index + 1] - cu_num_logits[req_index])
+            rows_by_request[req_id] = grammar_output.grammar_bitmask[
+                offset : offset + num_rows
+            ]
+            offset += num_rows
+        return rows_by_request
+
+    def advance_verified(
+        self,
+        input_batch: InputBatch,
+        sampled_token_ids: torch.Tensor,
+        num_sampled: torch.Tensor,
+        grammar_output: GrammarOutput | None,
+    ) -> None:
+        mask_rows = self._mask_rows_by_request(input_batch, grammar_output)
+        counts = num_sampled.cpu().tolist()
+        rows = sampled_token_ids.cpu().tolist()
+        for req_id, count, row in zip(input_batch.req_ids, counts, rows):
+            request = self.requests.get(req_id)
+            if request is None or count <= 0:
+                continue
+            new_tokens = row[:count]
+            request.append_output_token_ids(new_tokens)
+            request_masks = mask_rows.get(req_id)
+            if request_masks is None:
+                continue
+
+            if count > len(request_masks):
+                self._disable(
+                    req_id,
+                    f"sampled {count} tokens but received only "
+                    f"{len(request_masks)} authoritative mask rows",
+                )
+                continue
+
+            grammar_tokens = [
+                token
+                for token, mask in zip(new_tokens, request_masks[:count])
+                if not self._is_unconstrained(mask)
+            ]
+            if not grammar_tokens or req_id in self.draft_disabled:
+                continue
+            if not self._accept_verified(req_id, grammar_tokens):
+                continue
+            self.verified_tokens[req_id].extend(grammar_tokens)
+            if self._advance_draft_mirror(req_id, grammar_tokens):
+                # Deliberately activate only after observing a constrained
+                # target row. At a reasoning boundary this can cost one draft
+                # block, but it cannot admit an unconstrained draft as if it
+                # had been grammar-checked.
+                self.draft_active.add(req_id)
+
+    def begin_draft(self, input_batch: InputBatch) -> DraftGrammarBatch | None:
+        rows: list[int] = []
+        request_ids: list[str] = []
+        grammars: list[StructuredOutputGrammar] = []
+        for row, req_id in enumerate(input_batch.req_ids):
+            if req_id not in self.draft_active or req_id in self.draft_disabled:
+                continue
+            grammar = self.draft_grammars[req_id]
+            if grammar.is_terminated():
+                continue
+            rows.append(row)
+            request_ids.append(req_id)
+            grammars.append(grammar)
+        if not rows:
+            return None
+        return DraftGrammarBatch(
+            self.manager,
+            self.worker,
+            rows,
+            request_ids,
+            grammars,
+            on_reject=self._disable,
+        )
+
+    def shutdown(self) -> None:
+        self.requests.clear()
+        self.draft_grammars.clear()
+        self.verified_tokens.clear()
+        self.draft_active.clear()
+        self.draft_disabled.clear()
+        self.manager.clear_backend()

--- a/vllm/v1/worker/gpu/structured_outputs.py
+++ b/vllm/v1/worker/gpu/structured_outputs.py
@@ -34,13 +34,6 @@ class StructuredOutputsWorker:
         if not grammar_req_ids:
             return
 
-        # Asynchronously copy the bitmask to GPU.
-        current_stream = torch.accelerator.current_stream(self.device)
-        with stream(self.copy_stream, current_stream):
-            bitmask = async_copy_to_gpu(
-                grammar_bitmask, out=self.grammar_bitmask[: grammar_bitmask.shape[0]]
-            )
-
         # Construct bitmask -> logits mapping
         mapping: list[int] = []
         req_ids = input_batch.req_ids
@@ -51,6 +44,30 @@ class StructuredOutputsWorker:
             logits_start_idx = cu_num_logits[req_idx]
             logits_end_idx = cu_num_logits[req_idx + 1]
             mapping.extend(range(logits_start_idx, logits_end_idx))
+
+        self.apply_grammar_bitmask_rows(logits, mapping, grammar_bitmask)
+
+    def apply_grammar_bitmask_rows(
+        self,
+        logits: torch.Tensor,
+        mapping: list[int],
+        grammar_bitmask: np.ndarray,
+        target_token_ids: torch.Tensor | None = None,
+    ) -> None:
+        """Apply packed target-vocabulary masks to selected logits rows.
+
+        ``target_token_ids`` maps columns of a reduced draft vocabulary to
+        target token IDs. It is omitted for ordinary target-vocabulary logits.
+        """
+        if not mapping:
+            return
+
+        # Asynchronously copy the bitmask to GPU.
+        current_stream = torch.accelerator.current_stream(self.device)
+        with stream(self.copy_stream, current_stream):
+            bitmask = async_copy_to_gpu(
+                grammar_bitmask, out=self.grammar_bitmask[: grammar_bitmask.shape[0]]
+            )
 
         # Asynchronously copy the mapping to GPU.
         with stream(self.copy_stream, current_stream):
@@ -73,7 +90,15 @@ class StructuredOutputsWorker:
         vocab_size = logits.shape[-1]
         from vllm.v1.worker.gpu.sample.gumbel import _use_native_sample_kernels
 
-        if logits.device.type == "mps":
+        if target_token_ids is not None:
+            target_token_ids = target_token_ids.to(logits.device, dtype=torch.int64)
+            masks = bitmask[:num_masks]
+            words = masks[:, target_token_ids // 32]
+            allowed = ((words >> (target_token_ids % 32)) & 1).bool()
+            selected = logits.index_select(0, logits_indices.to(torch.int64))
+            selected.masked_fill_(~allowed, float("-inf"))
+            logits.index_copy_(0, logits_indices.to(torch.int64), selected)
+        elif logits.device.type == "mps":
             masks = bitmask[:num_masks]
             bit_indices = torch.arange(vocab_size, device=logits.device)
             words = masks[:, bit_indices // 32]


### PR DESCRIPTION
## Summary

Make DSpark speculative decoding honor structured-output grammars, including the Lark-constrained Responses custom-tool payloads added by #1.

- Apply scheduler-provided grammar-mask rows to every sequential DSpark draft sample.
- Keep verified and speculative grammar matchers separate and recover rollback drift.
- Support full target vocabularies and reduced Qwen-style draft vocabularies.
- Repair wrapped-tokenizer special-token metadata so BOS/control tokens cannot enter permissive regex payloads.
- Disable grammar-aware drafting per request on mirror disagreement while leaving target enforcement active.
- Keep model envelope syntax in structural-tag/tokenizer adapters; no DSML literals or DeepSeek token IDs are added to the inference core.

## Rebase

Rebased onto current `main` after #1, #2, and #3 merged. Their copied commits were removed from this PR. The earlier Metal draft-transfer/sampling commit was also dropped because current main now contains the newer PR #2/#3 native completion-event and batched/fused verifier implementations; replaying the older workaround would regress those paths.

The PR is now two commits over `main`:

- `7d0b41f4a` — grammar-aware DSpark implementation and regressions
- `25212c1c6` — local DSV4 validation record

## Local DSV4 evidence

The original reasoning-boundary grammar crash was eliminated and grammar-aware DSpark reached mean acceptance 6.00 with observed 80–100% draft-token acceptance. That run then exposed a tokenizer-metadata defect: BOS token 0 was legal inside `filename: /(.+)/`. The offline real-tokenizer regression now rejects BOS while preserving ordinary filename tokens.

The server was stopped at the user request before a post-fix end-to-end rerun, so the complete DSV4 `apply_patch` call remains a follow-up rather than a claimed pass.

## Validation after rebase

- 11 DSpark/XGrammar tests pass.
- 144 merged Responses custom-tool, Muse, DSV4 parser, and profile regressions pass.
- 155 tests pass in the combined focused run.
- Ruff format/check and `git diff --check` pass.
