### PR TITLE
qwen3_5: load the HF safetensors checkpoint

### DIFF
--- a/vllm/model_executor/models/qwen3_5_vision.py
+++ b/vllm/model_executor/models/qwen3_5_vision.py
@@ -725,8 +725,24 @@ class Qwen3_5ForConditionalGeneration(
         params_dict = dict(self.named_parameters())
         loaded: set[str] = set()
         for name, weight in weights:
+            # The HF safetensors checkpoint nests both towers under `model.`
+            # (`model.visual.*`, `model.language_model.*`) and ships the MTP
+            # head beside them. The GGUF path feeds the vision tower in
+            # already stripped, from a separate mmproj file; normalize to that
+            # stripped form so one loader serves both sources.
+            if name.startswith("model.visual."):
+                name = name[len("model.") :]
+            elif name.startswith("mtp."):
+                # Multi-token-prediction head: a speculator loaded separately,
+                # not part of the target graph.
+                continue
             if name.startswith("visual."):
                 param = params_dict[name]
+                # patch_embed.proj is a Conv3d in the HF checkpoint
+                # ([hidden, C, T, P, P]) and a Linear here; the GGUF ships it
+                # already flattened. Same values, same [C, T, P, P] row order.
+                if weight.shape != param.shape:
+                    weight = weight.reshape(param.shape)
                 param.data.copy_(weight.to(param.dtype))
                 loaded.add(name)
             elif name.startswith("language_model."):


### PR DESCRIPTION
Lets `Qwen3_5ForConditionalGeneration` load the HF safetensors checkpoint in
addition to the existing GGUF path. Three mismatches were in the way:

- **Nesting.** The HF checkpoint puts both towers under `model.`
  (`model.visual.*`, `model.language_model.*`). The GGUF path feeds the vision
  tower in already stripped, from a separate mmproj file. The loader now
  normalizes to the stripped form so one loader serves both sources.
- **`patch_embed.proj`.** A `Conv3d` in the HF checkpoint
  (`[hidden, C, T, P, P]`) and a `Linear` here; the GGUF ships it already
  flattened. Same values and same `[C, T, P, P]` row order, so a reshape to the
  parameter shape is sufficient.
- **MTP head.** Shipped beside the towers, but it is a speculator loaded
  separately and not part of the target graph, so it is skipped.

Scope: `vllm/model_executor/models/qwen3_5_vision.py`, +16. No change to the
GGUF path.