### PR TITLE
Fix grammar-aware DSpark review findings

### DIFF
--- a/perf/optimization_status.md
+++ b/perf/optimization_status.md
@@ -9974,3 +9974,68 @@ Load test (no-spec, in-process LLM, max_model_len 8192) iterated through:
   envelope syntax remains owned by structural-tag adapters and tokenizer/chat
   formatting. Raw server logs are local under
   `/private/tmp/dsv4-grammar-server-*.log`.
+  CORRECTION (2026-08-24): that artifact location is volatile and violates
+  the notebook rules (perf/results/ + never /private/tmp for evidence);
+  the logs are presumed lost to reboot. This entry also records no
+  measured throughput despite the change adding a per-step sync and
+  forced-eager drafting; both costs are addressed in the 2026-08-24
+  review-fix entry below and a tok/s gate on the serving box remains
+  open.
+
+## 2026-08-24 - Grammar-Aware DSpark Review Fixes (PR #4 Follow-Up)
+
+- Context: independent multi-angle review of the merged PR #4 (10 finder
+  angles, ~50 candidates, 20 deduped mechanisms; 7 confirmed / 1
+  plausible / 4 refuted, plus 1 sweep finding). All confirmed findings
+  fixed or explicitly deferred below.
+- Fixed (crash): DraftGrammarBatch no longer fills a matcher that
+  terminated mid-draft-block (xgrammar raises a native RuntimeError from
+  fill_next_token_bitmask on a terminated matcher — reproduced on
+  xgrammar 0.2.3 by the reviewer); apply() skips terminated rows and
+  advance() stops pushing tokens into them while keeping the terminating
+  advancement counted for rollback.
+- Fixed (silent corruption): a grammar state admitting no token inside
+  the draft vocabulary previously masked the row to all -inf; the argmax
+  then picked target token 0 (BOS) and the -inf draft logits made the
+  rejection sampler's NaN guard force-accept it into the constrained
+  payload. apply() now checks per-row support against the draft
+  vocabulary (CPU-side, sync-free via a load-time id copy) and leaves
+  unsupported rows unmasked + disabled; the probabilistic branch passes
+  the draft-vocab restriction too, since its scatter buffer is -inf
+  outside draft columns even under a full-target-space mask.
+- Fixed (hot path): advance_verified early-returns when no structured
+  requests exist — its two .cpu() syncs sat between the async-output
+  copy and propose() on every step of every DSpark deployment.
+- Fixed (robustness): worker-side grammar admission failures are
+  contained to the one request (unconstrained drafting, warning) instead
+  of raising out of add_requests; the empty-history replay dead-guard in
+  _accept_verified no longer converts a failed replay into silent
+  success; the StructuredOutputManager mirror is built lazily on the
+  first structured request (was: per-rank tokenizer load + executors at
+  model load for every DSpark deployment) and shutdown() closes its
+  executors; draft_grammar is threaded through propose() as a parameter
+  instead of transient attribute smuggling.
+- Fixed (sentinel ambiguity): the scheduler now ships authoritative
+  per-row constrained flags (GrammarOutput.apply_rows, recorded in
+  _fill_bitmasks) — a permissive grammar state fills an all-ones mask
+  bit-identical to the unrestricted sentinel, so the worker mirror's
+  sniff misclassified those rows and self-disabled; the sniff remains
+  only as a fallback for producers without the field.
+- Fixed (guidance backend): reset() clears terminated/rollback_lag (the
+  same latent bug PR #4 fixed for xgrammar), and a REJECTED speculative
+  EOS no longer marks the grammar terminated.
+- Deferred (design follow-ups, recorded): preemption/re-add rebuilds the
+  mirror at position 0 (needs scheduler-side state or the apply_rows
+  channel extended to carry resume history; today it degrades to
+  disabled drafting, outputs stay correct); need_eager granularity (one
+  structured request forces the whole draft batch — and via the DP
+  min-mode all-reduce, every replica — out of graph replay); off-thread
+  mirror grammar compilation; special-token repair at the tokenizer
+  wrapper (guidance backend still unrepaired).
+- Validation: 16 draft-grammar/xgrammar tests pass (5 new: terminated
+  mid-block, empty-support full and reduced vocab, early-out no-sync
+  sentinel, contained admission failure, apply_rows-over-sniff);
+  tests/v1 suite passes; ruff clean. Throughput not re-measured here
+  (M5 Max); the dsv4 profiles' tok/s gate on the serving box remains
+  the open validation item, now without the unconditional per-step
+  sync.

--- a/tests/v1/worker/test_draft_structured_output.py
+++ b/tests/v1/worker/test_draft_structured_output.py
@@ -243,10 +243,14 @@ def test_dspark_chooses_grammar_valid_reduced_vocab_token() -> None:
     speculator.draft_logits = None
     speculator.draft_tokens = torch.zeros((1, 1), dtype=torch.int64)
     speculator._draft_target_ids = torch.tensor([2, 5, 7])
+    speculator._draft_target_ids_cpu = np.array([2, 5, 7], dtype=np.int64)
     speculator.draft_grammar = MagicMock()
 
-    def allow_only_target_five(logits, target_token_ids=None) -> None:
+    def allow_only_target_five(
+        logits, target_token_ids=None, target_token_ids_cpu=None
+    ) -> None:
         assert target_token_ids.tolist() == [2, 5, 7]
+        assert target_token_ids_cpu.tolist() == [2, 5, 7]
         logits[:, target_token_ids != 5] = float("-inf")
 
     speculator.draft_grammar.apply.side_effect = allow_only_target_five
@@ -310,8 +314,10 @@ def test_verified_tokens_follow_authoritative_mask_rows() -> None:
         grammar_output=grammar_output,
     )
 
-    assert constrained.output == [99, 12]
-    assert reasoning.output == [20, 21]
+    # The mirror keeps no request token history of its own (grammar state is
+    # the only per-request state): nothing is appended to the Request.
+    assert constrained.output == []
+    assert reasoning.output == []
     assert constrained_grammar.position == 1
     assert reasoning_grammar.position == 0
     assert state.draft_grammars["constrained"].position == 1
@@ -399,3 +405,200 @@ def test_draft_matcher_recovers_from_rollback_drift() -> None:
 
     assert draft_grammar.position == 2
     assert state.verified_tokens["request"] == [12]
+
+
+def test_draft_grammar_batch_skips_terminated_matcher_mid_block() -> None:
+    """A payload that completes on an earlier draft step must not be filled
+    again: the real xgrammar matcher raises a native RuntimeError from
+    fill_next_token_bitmask once terminated (the _Grammar fixture mirrors
+    that by indexing past its allowed positions)."""
+    grammar = _Grammar([{1}])
+    batch = DraftGrammarBatch(
+        SimpleNamespace(backend=_Backend()),
+        _MaskingWorker(),
+        rows=[0],
+        request_ids=["request"],
+        grammars=[grammar],
+    )
+
+    logits = torch.zeros((1, 8))
+    batch.apply(logits)
+    batch.advance(torch.tensor([1]))
+    assert grammar.is_terminated()
+    assert batch.advancements == [0 + 1]
+
+    # Next draft step: must not fill the terminated matcher, must leave the
+    # row unconstrained, and must not push tokens into the matcher.
+    next_logits = torch.zeros((1, 8))
+    batch.apply(next_logits)
+    assert torch.isfinite(next_logits).all()
+    batch.advance(torch.tensor([5]))
+    assert batch.advancements == [1]
+
+    batch.rollback()
+    assert grammar.position == 0
+
+
+def test_draft_grammar_batch_disables_empty_support_rows() -> None:
+    """A grammar state admitting no token (or none inside a reduced draft
+    vocabulary) must leave the row unmasked and stop constraining it — an
+    all -inf row would argmax to BOS and the -inf draft logits force-accept
+    it through the rejection sampler's NaN guard."""
+    empty = _Grammar([set(), {1}])
+    rejected: list[tuple[str, str]] = []
+    batch = DraftGrammarBatch(
+        SimpleNamespace(backend=_Backend()),
+        _MaskingWorker(),
+        rows=[0],
+        request_ids=["request"],
+        grammars=[empty],
+        on_reject=lambda req_id, reason: rejected.append((req_id, reason)),
+    )
+    logits = torch.zeros((1, 8))
+    batch.apply(logits)
+    assert torch.isfinite(logits).all()
+    assert batch.enabled == [False]
+    assert rejected and "no token in the draft vocabulary" in rejected[0][1]
+
+    # Reduced vocabulary: the grammar allows target token 5, but the draft
+    # vocabulary only reaches target ids 0..3 — same dead-row hazard.
+    disjoint = _Grammar([{5}])
+    rejected.clear()
+    batch2 = DraftGrammarBatch(
+        SimpleNamespace(backend=_Backend()),
+        _MaskingWorker(),
+        rows=[0],
+        request_ids=["request"],
+        grammars=[disjoint],
+        on_reject=lambda req_id, reason: rejected.append((req_id, reason)),
+    )
+    logits2 = torch.zeros((1, 4))
+    batch2.apply(
+        logits2,
+        target_token_ids_cpu=np.array([0, 1, 2, 3], dtype=np.int64),
+    )
+    assert torch.isfinite(logits2).all()
+    assert batch2.enabled == [False]
+
+    # Same grammar with the token inside the draft vocabulary masks normally.
+    in_vocab = _Grammar([{2}])
+    batch3 = DraftGrammarBatch(
+        SimpleNamespace(backend=_Backend()),
+        _MaskingWorker(),
+        rows=[0],
+        request_ids=["request"],
+        grammars=[in_vocab],
+    )
+    logits3 = torch.zeros((1, 4))
+    batch3.apply(
+        logits3,
+        target_token_ids=torch.tensor([0, 1, 2, 3]),
+        target_token_ids_cpu=np.array([0, 1, 2, 3], dtype=np.int64),
+    )
+    assert torch.isfinite(logits3[0]).nonzero().flatten().tolist() == [2]
+
+
+class _NoSync:
+    """Sentinel standing in for a GPU tensor: any device sync is a failure."""
+
+    def cpu(self):
+        raise AssertionError(
+            "advance_verified must not sync without structured requests"
+        )
+
+
+def test_advance_verified_early_out_without_structured_requests() -> None:
+    state = object.__new__(DraftStructuredOutputState)
+    state.requests = {}
+    input_batch = SimpleNamespace(req_ids=["plain"], cu_num_logits_np=None)
+    state.advance_verified(
+        input_batch,
+        sampled_token_ids=_NoSync(),
+        num_sampled=_NoSync(),
+        grammar_output=None,
+    )
+
+
+def test_add_request_failure_is_contained() -> None:
+    """A worker-side grammar failure must degrade that one request to
+    unconstrained drafting, never raise out of the admission path."""
+    state = object.__new__(DraftStructuredOutputState)
+    state.requests = {}
+    state.draft_grammars = {}
+    state.verified_tokens = {}
+    state.draft_active = set()
+    state.draft_disabled = set()
+
+    def boom() -> None:
+        raise RuntimeError("grammar compile failed")
+
+    state._ensure_manager = boom
+    data = SimpleNamespace(
+        req_id="request",
+        prompt_token_ids=[1, 2],
+        sampling_params=SimpleNamespace(structured_outputs=object()),
+        pooling_params=None,
+    )
+    state.add_request(data)
+    assert state.requests == {}
+    assert "request" not in state.draft_grammars
+
+
+def test_apply_rows_flags_override_sentinel_sniff() -> None:
+    """A permissive grammar state can fill an all-ones mask bit-identical to
+    the unrestricted sentinel; the scheduler's authoritative apply_rows
+    flags must decide, not the mask bits."""
+    permissive_grammar = _Grammar([set(range(8))])
+    request = _MirrorRequest("request", permissive_grammar)
+    state = object.__new__(DraftStructuredOutputState)
+    state.manager = SimpleNamespace(backend=_Backend())
+    state.worker = _MaskingWorker()
+    state.requests = {"request": request}
+    state.draft_grammars = {"request": _Grammar([set(range(8))])}
+    state.verified_tokens = {"request": []}
+    state.draft_active = set()
+    state.draft_disabled = set()
+    input_batch = SimpleNamespace(
+        req_ids=["request"],
+        cu_num_logits_np=np.array([0, 1], dtype=np.int32),
+    )
+
+    # The mask row is all ones (permissive fill == sentinel bytes), but the
+    # scheduler says the row WAS constrained: the mirror must advance.
+    state.advance_verified(
+        input_batch,
+        sampled_token_ids=torch.tensor([[3]]),
+        num_sampled=torch.tensor([1]),
+        grammar_output=GrammarOutput(
+            ["request"],
+            np.array([[-1]], dtype=np.int32),
+            apply_rows=np.array([True]),
+        ),
+    )
+    assert permissive_grammar.position == 1
+    assert state.draft_active == {"request"}
+
+    # And an explicit False flag keeps a sentinel row unconstrained even
+    # for producers that fill real bytes there.
+    state2 = object.__new__(DraftStructuredOutputState)
+    grammar2 = _Grammar([{3}])
+    request2 = _MirrorRequest("request", grammar2)
+    state2.manager = SimpleNamespace(backend=_Backend())
+    state2.worker = _MaskingWorker()
+    state2.requests = {"request": request2}
+    state2.draft_grammars = {"request": _Grammar([{3}])}
+    state2.verified_tokens = {"request": []}
+    state2.draft_active = set()
+    state2.draft_disabled = set()
+    state2.advance_verified(
+        input_batch,
+        sampled_token_ids=torch.tensor([[99]]),
+        num_sampled=torch.tensor([1]),
+        grammar_output=GrammarOutput(
+            ["request"],
+            np.array([[0]], dtype=np.int32),
+            apply_rows=np.array([False]),
+        ),
+    )
+    assert grammar2.position == 0
+    assert state2.draft_active == set()

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -283,3 +283,10 @@ class GrammarOutput:
     structured_output_request_ids: list[str]
     # Bitmask ordered as structured_output_request_ids.
     grammar_bitmask: "npt.NDArray[np.int32]"
+    # Per-row flags, same order as grammar_bitmask rows: True where the row
+    # holds a real grammar mask, False where the scheduler wrote the
+    # unrestricted sentinel (reasoning rows, terminated grammars). A
+    # permissive grammar state can fill a mask bit-identical to the
+    # sentinel, so consumers must use these flags rather than sniff the
+    # mask bits. None only for producers that predate the field.
+    apply_rows: "npt.NDArray[np.bool_] | None" = None

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1578,12 +1578,15 @@ class Scheduler(SchedulerInterface):
         if not structured_output_request_ids:
             return None
 
-        bitmask = self.structured_output_manager.grammar_bitmask(
+        result = self.structured_output_manager.grammar_bitmask(
             self.requests,
             structured_output_request_ids,
             scheduler_output.scheduled_spec_decode_tokens,
         )
-        return GrammarOutput(structured_output_request_ids, bitmask)
+        if result is None:
+            return None
+        bitmask, apply_rows = result
+        return GrammarOutput(structured_output_request_ids, bitmask, apply_rows)
 
     def update_from_output(
         self,

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -55,6 +55,9 @@ class StructuredOutputManager:
         )
 
         self._grammar_bitmask: torch.Tensor | None = None
+        # Per-row record of whether _fill_bitmasks wrote a real grammar mask
+        # (vs. the unrestricted sentinel); same row indexing as the bitmask.
+        self._apply_rows: npt.NDArray[np.bool_] | None = None
         self._full_mask = torch.tensor(-1, dtype=torch.int32)
 
         max_batch_size = self.vllm_config.scheduler_config.max_num_seqs
@@ -195,8 +198,17 @@ class StructuredOutputManager:
         self, batch: Iterable[tuple[StructuredOutputGrammar, int, bool]]
     ) -> None:
         assert self._grammar_bitmask is not None
+        assert self._apply_rows is not None
         for grammar, index, apply_bitmask in batch:
-            if apply_bitmask and not grammar.is_terminated():
+            filled = apply_bitmask and not grammar.is_terminated()
+            # Authoritative per-row record of whether a real grammar mask
+            # was written: a permissive grammar state can legitimately fill
+            # an all-ones mask that is bit-identical to the unrestricted
+            # sentinel below, so consumers must not sniff the mask bits.
+            # Distinct indices per row make this thread-safe under the
+            # fill-mask executor.
+            self._apply_rows[index] = filled
+            if filled:
                 grammar.fill_bitmask(self._grammar_bitmask, index)
             else:
                 # Note that for thinking support, we will need to
@@ -214,7 +226,7 @@ class StructuredOutputManager:
         requests: dict[str, "Request"],
         structured_output_request_ids: list[str],
         scheduled_spec_decode_tokens: dict[str, list[int]],
-    ) -> "npt.NDArray[np.int32] | None":
+    ) -> "tuple[npt.NDArray[np.int32], npt.NDArray[np.bool_]] | None":
         # Prepare the structured output bitmask for this batch.
         if not structured_output_request_ids:
             return None
@@ -232,6 +244,9 @@ class StructuredOutputManager:
             self._grammar_bitmask = self.backend.allocate_token_bitmask(
                 max_batch_size * (1 + max_num_spec_tokens)
             )
+            self._apply_rows = torch.zeros(
+                self._grammar_bitmask.shape[0], dtype=torch.bool
+            ).numpy()
 
         # Generate a batched bitmask for all structured output requests.
         # When speculative decoding is enabled, we need to include multiple
@@ -356,7 +371,10 @@ class StructuredOutputManager:
         # After finishing with the xgrammar operations, we convert to
         # np.ndarray, because that is much more efficient for serialization
         # and deserialization when sending this to the GPU workers.
-        return bitmask_tensor.numpy()
+        assert self._apply_rows is not None
+        # Copied because the backing buffer is reused on the next step.
+        apply_rows = self._apply_rows[:cumulative_index].copy()
+        return bitmask_tensor.numpy(), apply_rows
 
     def should_fill_bitmask(self, request: "Request") -> bool:
         # NOTE (Hanchen) if enable_in_reasoning is True, it means that

--- a/vllm/v1/structured_output/backend_guidance.py
+++ b/vllm/v1/structured_output/backend_guidance.py
@@ -162,12 +162,12 @@ class GuidanceGrammar(StructuredOutputGrammar):
         Returns False if the parser failed to advance.
         """
 
-        if self.ll_tokenizer.eos_token in tokens:
-            if self.ll_matcher.is_stopped() and not self.terminated:
-                self.rollback_lag = 1
-            self.terminated = True
-
+        eos_in_tokens = self.ll_tokenizer.eos_token in tokens
         if self.ll_matcher.is_stopped():
+            if eos_in_tokens:
+                if not self.terminated:
+                    self.rollback_lag = 1
+                self.terminated = True
             return True
 
         # TODO - Add jump decoding support in the future:
@@ -181,6 +181,12 @@ class GuidanceGrammar(StructuredOutputGrammar):
 
         self.check_error()
 
+        # Terminated only when the tokens were actually consumed: a REJECTED
+        # speculative EOS must not leave the grammar marked terminated, or
+        # the request is permanently excluded from further drafting with no
+        # advancement to roll the state back.
+        if r and eos_in_tokens:
+            self.terminated = True
         return r
 
     def validate_tokens(self, tokens: list[int]) -> list[int]:
@@ -217,8 +223,14 @@ class GuidanceGrammar(StructuredOutputGrammar):
         return self.terminated
 
     def reset(self):
-        # This method may be not needed anymore? TODO
+        # Full reset: the worker-side draft mirror uses reset() for rollback
+        # -drift recovery and then replays verified history, so the Python-
+        # side termination bookkeeping must reset along with ll_matcher —
+        # stale terminated/rollback_lag would make the next rollback
+        # under-roll by one and desync every subsequent draft mask.
         self.ll_matcher.reset()
+        self.terminated = False
+        self.rollback_lag = 0
 
 
 def serialize_guidance_grammar(

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1676,7 +1676,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if hasattr(self.model, "get_mtp_target_hidden_states"):
                 pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
                 spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
-            self.speculator.draft_grammar = draft_grammar
             try:
                 with _qc_phase("drafter_propose"):
                     draft_tokens = self.speculator.propose(
@@ -1692,11 +1691,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                         self.sampler.sampling_states.temperature.gpu,
                         self.sampler.sampling_states.seeds.gpu,
                         mm_inputs=mm_inputs,
+                        draft_grammar=draft_grammar,
                     )
             finally:
                 if draft_grammar is not None:
                     draft_grammar.rollback()
-                self.speculator.draft_grammar = None
             self.req_states.draft_tokens[input_batch.idx_mapping] = draft_tokens
 
         if self.num_speculative_steps > 0:

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -152,6 +152,9 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         skip_attn_for_dummy_run: bool = False,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
+        # Accepted for interface parity; grammar-aware drafting is only
+        # implemented by the DSpark sequential sampler.
+        draft_grammar=None,
     ) -> torch.Tensor:
         num_tokens = input_batch.num_tokens_after_padding
         num_reqs = input_batch.num_reqs

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -397,7 +397,12 @@ class DFlashSpeculator(DraftModelSpeculator):
         skip_attn_for_dummy_run: bool = False,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
+        draft_grammar=None,
     ) -> torch.Tensor:
+        # Bound for this call only; refreshed (including back to None) on
+        # every propose, so no stale batch can leak into the next step.
+        # Consumed by _generate_draft (eager gating) and _sample_sequential.
+        self.draft_grammar = draft_grammar
         num_reqs = input_batch.num_reqs
         num_target_tokens = input_batch.num_tokens
         num_query_tokens = num_reqs * self.num_query_per_req

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -25,6 +25,7 @@ backbone forward AND the sequential Markov sampling.
 
 from typing import Any
 
+import numpy as np
 import torch
 
 from vllm.config import VllmConfig
@@ -71,6 +72,7 @@ class DSparkSpeculator(DFlashSpeculator):
 
         # Reduced-vocab probabilistic drafting only; set in load_draft_model.
         self._draft_target_ids: torch.Tensor | None = None
+        self._draft_target_ids_cpu: np.ndarray | None = None
         self._d2t_scatter_index: torch.Tensor | None = None
         self._draft_scatter_buf: torch.Tensor | None = None
 
@@ -86,6 +88,12 @@ class DSparkSpeculator(DFlashSpeculator):
         d2t = getattr(model, "draft_id_to_target_id", None)
         if d2t is not None:
             self._draft_target_ids = torch.arange(d2t.shape[0], device=d2t.device) + d2t
+            # CPU copy for the grammar batch's draft-vocab support check
+            # (does the mask admit any draft-vocab token at all); computed
+            # once at load so the per-step check stays sync-free.
+            self._draft_target_ids_cpu = (
+                self._draft_target_ids.cpu().numpy().astype(np.int64)
+            )
         if self.draft_logits is not None and self._draft_target_ids is not None:
             self._d2t_scatter_index = self._draft_target_ids
             # -inf once; the per-step scatter overwrites the draft->target
@@ -132,9 +140,16 @@ class DSparkSpeculator(DFlashSpeculator):
                     logits_i = buf
                 target_ids_for_mask = None
             if self.draft_grammar is not None:
+                # target_token_ids_cpu restricts the empty-support check to
+                # the draft vocabulary in BOTH branches: the probabilistic
+                # scatter buffer is -inf outside the draft-vocab columns, so
+                # a grammar admitting only non-draft tokens would still
+                # produce a dead row even though the full-target-space mask
+                # itself is non-empty.
                 self.draft_grammar.apply(
                     logits_i,
                     target_token_ids=target_ids_for_mask,
+                    target_token_ids_cpu=self._draft_target_ids_cpu,
                 )
             if self.draft_logits is not None:
                 # sample_pos is the predicted token's position Q; the target

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -62,6 +62,7 @@ class BaseSpeculator(ABC):
         skip_attn_for_dummy_run: bool = False,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
+        draft_grammar=None,
     ) -> torch.Tensor:
         pass
 
@@ -127,8 +128,9 @@ class DraftModelSpeculator(BaseSpeculator):
         )
 
         self.draft_logits: torch.Tensor | None = None
-        # Set transiently by the model runner for structured-output requests.
-        # DSpark consumes it between each sequential Markov sample.
+        # Bound per propose() call from its draft_grammar parameter; internal
+        # plumbing between propose, _generate_draft (eager gating), and the
+        # DSpark sequential sampler. Never mutated from outside.
         self.draft_grammar = None
         if self.speculative_config.draft_sample_method == "probabilistic":
             self.draft_logits = torch.zeros(

--- a/vllm/v1/worker/gpu/spec_decode/structured_output.py
+++ b/vllm/v1/worker/gpu/spec_decode/structured_output.py
@@ -47,21 +47,61 @@ class DraftGrammarBatch:
         self.advancements = [0] * len(rows)
         self.enabled = [True] * len(rows)
 
+    def _reject(self, index: int, reason: str) -> None:
+        request_id = self.request_ids[index]
+        if self.on_reject is not None:
+            self.on_reject(request_id, reason)
+        else:
+            logger.warning(
+                "Disabling draft grammar for request %s: %s", request_id, reason
+            )
+        self.enabled[index] = False
+
     def apply(
         self,
         logits: torch.Tensor,
         target_token_ids: torch.Tensor | None = None,
+        target_token_ids_cpu: np.ndarray | None = None,
     ) -> None:
-        active = [index for index, enabled in enumerate(self.enabled) if enabled]
+        # A matcher that terminated mid-block (the payload completed on an
+        # earlier draft step) must not be filled again: xgrammar raises a
+        # native RuntimeError from fill_next_token_bitmask on a terminated
+        # matcher. The remaining draft slots for that row go unconstrained;
+        # the target's own enforcement still verifies them.
+        active = [
+            index
+            for index, enabled in enumerate(self.enabled)
+            if enabled and not self.grammars[index].is_terminated()
+        ]
         if not active:
             return
         for index in active:
             grammar = self.grammars[index]
             grammar.fill_bitmask(self.bitmask, index)
-        rows = [self.rows[index] for index in active]
         bitmask = self.bitmask.numpy()
-        if len(active) != len(self.rows):
-            bitmask = bitmask[active]
+        # A grammar state whose allowed set is disjoint from the draft
+        # vocabulary would mask the row to all -inf; downstream that argmaxes
+        # to token 0 (BOS) and the -inf draft logits make the rejection
+        # sampler's NaN guard force-accept it into the constrained payload.
+        # Leave such rows unmasked and stop constraining them instead — the
+        # unconstrained draft is then verified (and rejected) by the target.
+        supported: list[int] = []
+        for index in active:
+            row = bitmask[index]
+            if target_token_ids_cpu is not None:
+                words = row[target_token_ids_cpu >> 5]
+                any_allowed = bool(np.any((words >> (target_token_ids_cpu & 31)) & 1))
+            else:
+                any_allowed = bool(np.any(row != 0))
+            if any_allowed:
+                supported.append(index)
+            else:
+                self._reject(index, "grammar admits no token in the draft vocabulary")
+        if not supported:
+            return
+        rows = [self.rows[index] for index in supported]
+        if len(supported) != len(self.rows):
+            bitmask = bitmask[supported]
         self.worker.apply_grammar_bitmask_rows(
             logits,
             rows,
@@ -79,17 +119,14 @@ class DraftGrammarBatch:
         ):
             if not self.enabled[index]:
                 continue
+            if grammar.is_terminated():
+                # The payload completed on an earlier draft step; later
+                # draft slots are unconstrained and must not be pushed into
+                # the terminated matcher. rollback() still unwinds the
+                # counted advancements, including the terminating token.
+                continue
             if not grammar.accept_tokens(request_id, [token]):
-                reason = f"draft matcher rejected its masked token {token}"
-                if self.on_reject is not None:
-                    self.on_reject(request_id, reason)
-                else:
-                    logger.warning(
-                        "Disabling draft grammar for request %s: %s",
-                        request_id,
-                        reason,
-                    )
-                self.enabled[index] = False
+                self._reject(index, f"draft matcher rejected its masked token {token}")
                 continue
             self.advancements[index] += 1
 
@@ -116,10 +153,12 @@ class DraftStructuredOutputState:
         vllm_config: VllmConfig,
         worker: StructuredOutputsWorker,
     ) -> None:
-        self.manager = StructuredOutputManager(vllm_config)
-        # Drafting occurs in the worker's synchronous request-admission path;
-        # completing compilation here avoids a first-token race with drafting.
-        self.manager._use_async_grammar_compilation = False
+        self.vllm_config = vllm_config
+        # Built lazily on the first structured request: every DSpark rank
+        # constructs this state at load, and an eager manager would pay a
+        # per-rank tokenizer load plus backend construction even on
+        # deployments that never see a structured request.
+        self.manager: StructuredOutputManager | None = None
         self.worker = worker
         self.requests: dict[str, Request] = {}
         # Verified target tokens and speculative proposals must not share one
@@ -131,28 +170,53 @@ class DraftStructuredOutputState:
         self.draft_active: set[str] = set()
         self.draft_disabled: set[str] = set()
 
+    def _ensure_manager(self) -> StructuredOutputManager:
+        if self.manager is None:
+            manager = StructuredOutputManager(self.vllm_config)
+            # Drafting occurs in the worker's synchronous request-admission
+            # path; completing compilation there avoids a first-token race
+            # with drafting.
+            manager._use_async_grammar_compilation = False
+            self.manager = manager
+        return self.manager
+
     def add_request(self, data: NewRequestData) -> None:
         sampling_params = data.sampling_params
         if sampling_params is None or sampling_params.structured_outputs is None:
             return
-        request = Request(
-            request_id=data.req_id,
-            prompt_token_ids=data.prompt_token_ids,
-            sampling_params=sampling_params,
-            pooling_params=data.pooling_params,
-        )
-        self.manager.grammar_init(request)
-        structured = request.structured_output_request
-        assert structured is not None
-        grammar = structured.grammar
-        if isinstance(grammar, Exception):
-            raise grammar
-        if not isinstance(grammar, StructuredOutputGrammar):
-            raise RuntimeError(f"grammar for request {data.req_id} is not ready")
-        self.requests[data.req_id] = request
-        draft_grammar = self.manager._create_grammar(request)
-        self.draft_grammars[data.req_id] = draft_grammar
-        self.verified_tokens[data.req_id] = []
+        # A worker mirror must never turn a per-request grammar problem into
+        # an engine-wide failure: the scheduler's own enforcement stands
+        # regardless, so on any admission error this request simply drafts
+        # unconstrained.
+        try:
+            manager = self._ensure_manager()
+            request = Request(
+                request_id=data.req_id,
+                prompt_token_ids=data.prompt_token_ids,
+                sampling_params=sampling_params,
+                pooling_params=data.pooling_params,
+            )
+            manager.grammar_init(request)
+            structured = request.structured_output_request
+            assert structured is not None
+            grammar = structured.grammar
+            if isinstance(grammar, Exception):
+                raise grammar
+            if not isinstance(grammar, StructuredOutputGrammar):
+                raise RuntimeError(f"grammar for request {data.req_id} is not ready")
+            self.requests[data.req_id] = request
+            draft_grammar = manager._create_grammar(request)
+            self.draft_grammars[data.req_id] = draft_grammar
+            self.verified_tokens[data.req_id] = []
+        except Exception as error:
+            self.remove_request(data.req_id)
+            logger.warning(
+                "Grammar mirror init failed for request %s; speculative "
+                "drafting runs unconstrained (target enforcement is "
+                "unaffected): %s",
+                data.req_id,
+                error,
+            )
 
     def remove_request(self, req_id: str) -> None:
         self.requests.pop(req_id, None)
@@ -193,7 +257,10 @@ class DraftStructuredOutputState:
         # this request's drafts and leave validation to the scheduler.
         grammar.reset()
         history = [*self.verified_tokens[req_id], *tokens]
-        if not history or grammar.accept_tokens(req_id, history):
+        # history is never empty here (tokens is non-empty by the caller's
+        # construction); a failed replay must disable, not pass silently —
+        # returning True on an unaccepted token would desync the mirror.
+        if grammar.accept_tokens(req_id, history):
             return True
         self._disable(
             req_id,
@@ -235,7 +302,7 @@ class DraftStructuredOutputState:
     def _mask_rows_by_request(
         input_batch: InputBatch,
         grammar_output: GrammarOutput | None,
-    ) -> dict[str, np.ndarray]:
+    ) -> dict[str, tuple[np.ndarray, np.ndarray | None]]:
         if grammar_output is None:
             return {}
 
@@ -243,16 +310,23 @@ class DraftStructuredOutputState:
             req_id: index for index, req_id in enumerate(input_batch.req_ids)
         }
         cu_num_logits = input_batch.cu_num_logits_np
-        rows_by_request: dict[str, np.ndarray] = {}
+        apply_rows = getattr(grammar_output, "apply_rows", None)
+        rows_by_request: dict[str, tuple[np.ndarray, np.ndarray | None]] = {}
         offset = 0
         for req_id in grammar_output.structured_output_request_ids:
             req_index = req_id_to_index.get(req_id)
             if req_index is None:
                 continue
             num_rows = int(cu_num_logits[req_index + 1] - cu_num_logits[req_index])
-            rows_by_request[req_id] = grammar_output.grammar_bitmask[
-                offset : offset + num_rows
-            ]
+            request_flags = (
+                apply_rows[offset : offset + num_rows]
+                if apply_rows is not None
+                else None
+            )
+            rows_by_request[req_id] = (
+                grammar_output.grammar_bitmask[offset : offset + num_rows],
+                request_flags,
+            )
             offset += num_rows
         return rows_by_request
 
@@ -263,6 +337,12 @@ class DraftStructuredOutputState:
         num_sampled: torch.Tensor,
         grammar_output: GrammarOutput | None,
     ) -> None:
+        # Nothing to mirror without structured requests. This early-out is
+        # load-bearing: the .cpu() calls below are host-blocking device
+        # syncs sitting between the async-output copy and the drafter, and
+        # they must not tax plain-text serving.
+        if not self.requests:
+            return
         mask_rows = self._mask_rows_by_request(input_batch, grammar_output)
         counts = num_sampled.cpu().tolist()
         rows = sampled_token_ids.cpu().tolist()
@@ -271,10 +351,10 @@ class DraftStructuredOutputState:
             if request is None or count <= 0:
                 continue
             new_tokens = row[:count]
-            request.append_output_token_ids(new_tokens)
-            request_masks = mask_rows.get(req_id)
-            if request_masks is None:
+            request_entry = mask_rows.get(req_id)
+            if request_entry is None:
                 continue
+            request_masks, request_flags = request_entry
 
             if count > len(request_masks):
                 self._disable(
@@ -284,11 +364,23 @@ class DraftStructuredOutputState:
                 )
                 continue
 
-            grammar_tokens = [
-                token
-                for token, mask in zip(new_tokens, request_masks[:count])
-                if not self._is_unconstrained(mask)
-            ]
+            if request_flags is not None:
+                # Authoritative per-row constrained flags from the
+                # scheduler: a genuinely permissive grammar state can fill
+                # an all-ones mask that is bit-identical to the
+                # unrestricted sentinel, so the sentinel sniff below is
+                # only a fallback for producers that predate the flags.
+                grammar_tokens = [
+                    token
+                    for token, constrained in zip(new_tokens, request_flags[:count])
+                    if constrained
+                ]
+            else:
+                grammar_tokens = [
+                    token
+                    for token, mask in zip(new_tokens, request_masks[:count])
+                    if not self._is_unconstrained(mask)
+                ]
             if not grammar_tokens or req_id in self.draft_disabled:
                 continue
             if not self._accept_verified(req_id, grammar_tokens):
@@ -316,6 +408,7 @@ class DraftStructuredOutputState:
             grammars.append(grammar)
         if not rows:
             return None
+        assert self.manager is not None  # rows exist only after add_request
         return DraftGrammarBatch(
             self.manager,
             self.worker,
@@ -331,4 +424,10 @@ class DraftStructuredOutputState:
         self.verified_tokens.clear()
         self.draft_active.clear()
         self.draft_disabled.clear()
-        self.manager.clear_backend()
+        if self.manager is not None:
+            self.manager.clear_backend()
+            for executor_name in ("executor", "executor_for_fillmask"):
+                executor = getattr(self.manager, executor_name, None)
+                if executor is not None:
+                    executor.shutdown(wait=False)
+            self.manager = None


### PR DESCRIPTION
Independent review follow-up to #4 (10 finder angles, ~50 candidates deduped to 20 mechanisms; 7 confirmed, 1 plausible, 4 refuted, 1 sweep finding). All confirmed findings fixed; design-level items recorded as follow-ups in the notebook.

## Fixed

- **Engine crash**: `DraftGrammarBatch` no longer fills or advances a matcher that terminated mid-draft-block — xgrammar raises a native RuntimeError from `fill_next_token_bitmask` on a terminated matcher (reproduced on xgrammar 0.2.3), so any structured payload completing at a non-final draft step killed the engine. The terminating advancement stays counted for rollback.
- **Silent BOS corruption**: a grammar state admitting no token inside the (reduced) draft vocabulary masked its row to all `-inf`; the argmax picked target token 0 (BOS) and the `-inf` draft logits rode the rejection sampler's `isnan(ratio)→1.0` guard into the constrained payload even with target `p(BOS)=0`. Rows without draft-vocab support are now left unmasked and disabled (sync-free CPU check against a load-time id copy); the probabilistic branch passes the draft-vocab restriction too, since its scatter buffer is `-inf` outside draft columns.
- **Hot path**: `advance_verified` early-returns when no structured requests exist — its two `.cpu()` syncs sat between the async-output copy and `propose()` on every step of every DSpark deployment, structured requests or not.
- **Robustness**: worker-side grammar admission failures degrade the one request to unconstrained drafting instead of raising engine-wide; the empty-history replay dead-guard no longer turns a failed replay into silent success; the mirror's `StructuredOutputManager` is built lazily on first use (was: per-rank tokenizer + executors at model load) and its executors close on shutdown; `draft_grammar` is threaded through `propose()` as a parameter instead of transient attribute smuggling.
- **Sentinel ambiguity**: the scheduler ships authoritative per-row constrained flags (`GrammarOutput.apply_rows`, recorded where the fill decision is made) — a permissive grammar state fills an all-ones mask bit-identical to the unrestricted sentinel, so the worker mirror's sniff misclassified those rows and permanently self-disabled on exactly the permissive grammars. Sniff retained as fallback for producers without the field.
- **Guidance backend**: `reset()` clears `terminated`/`rollback_lag` (the same latent bug #4 fixed for xgrammar), and a rejected speculative EOS no longer marks the grammar terminated.

## Deferred (recorded in the notebook)

Preemption/re-add mirror resync, `need_eager` granularity (one structured request forces the whole draft batch — and via the DP min-mode all-reduce, every replica — eager), off-thread mirror compilation, and special-token repair at the tokenizer wrapper.

## Validation

16 draft-grammar/xgrammar tests pass (5 new: terminated mid-block, empty-support full+reduced vocab, no-sync early-out sentinel, contained admission failure, apply_rows-over-sniff); tests/v1 passes; ruff clean. Throughput not re-measured here; the dsv4 tok/s gate on the serving box remains the open validation item — now without the unconditional per-step sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved grammar-constrained generation reliability, including correct EOS handling, matcher resets, and terminated grammar states.
  - Prevented invalid tokens and corrupted outputs when grammars are incompatible with the draft vocabulary.
  - Isolated grammar-admission failures so they affect only the relevant request.
  - Fixed structured-output verification and token-history handling during speculative decoding.

- **Performance**
  - Reduced unnecessary synchronization when structured-output requests are not active.
  - Improved grammar handling for speculative decoding with more efficient per-request and lazy resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->