### PR TITLE
metal: NaN-watch on MPS; cross-reference the q2_K sum-rows rule

### DIFF
--- a/csrc/quixicore/tm_metal/qc_metal_serving.mm
+++ b/csrc/quixicore/tm_metal/qc_metal_serving.mm
@@ -2059,6 +2059,9 @@ at::Tensor ggml_moe_a8_vec_sum(const at::Tensor& x, const at::Tensor& w,
   const int K = static_cast<int>(x.size(1));
   // Tail simdgroups of the mr grid read weight rows past a non-multiple N
   // before the store guards run; there is no one-row fallback here.
+  // Rule triplicated by necessity: gguf/fused_moe.py's
+  // _metal_q2k_sum_rows_supported routes around this check, and the native
+  // step tape below mirrors it — change all three together.
   const int sum_rows = x.scalar_type() != at::kBFloat16 ? 32 : 8;
   TORCH_CHECK(N % sum_rows == 0,
               "sum-folded q2_K kernel needs N divisible "
@@ -3193,8 +3196,10 @@ at::Tensor qc_tape_layer_forward(int64_t idx, const at::Tensor& x,
       ggml_moe_a8_vec_swiglu(h, L.w13_qw, topk_ids, L.top_k, L.w13_qt,
                              L.w13_row, T, L.swiglu_limit, L.w13_soa);
   // Sum-folded down projection (mirrors the Python route in
-  // gguf/fused_moe.py): one kernel instead of down vec + reshape +
-  // weighted sum. Shapes outside the folded kernel take the unfused chain.
+  // gguf/fused_moe.py _metal_q2k_sum_rows_supported; the sum-folded op's
+  // TORCH_CHECK above is the safety authority — change all three
+  // together). One kernel instead of down vec + reshape + weighted sum.
+  // Shapes outside the folded kernel take the unfused chain.
   at::Tensor fused;
   const bool tape_sum_dtype =
       h.scalar_type() == at::kHalf || h.scalar_type() == at::kBFloat16;

--- a/vllm/model_executor/layers/quantization/gguf/fused_moe.py
+++ b/vllm/model_executor/layers/quantization/gguf/fused_moe.py
@@ -59,7 +59,12 @@ def _qc_mm_min_tokens() -> int:
 
 
 def _metal_q2k_sum_rows_supported(rows: int, dtype: torch.dtype) -> bool:
-    """The folded kernel has no output-row tail; its unfused parent does."""
+    """The folded kernel has no output-row tail; its unfused parent does.
+
+    This rule lives in three places that must change together: this route
+    guard, the TORCH_CHECK in qc_metal_serving.mm's sum-folded q2_K op
+    (the safety authority), and the native step tape's admission mirror
+    in the same file."""
     if dtype == torch.float16:
         return rows % 32 == 0
     if dtype == torch.bfloat16:

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1213,8 +1213,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                         )
                 self._nan_watch_pending = None
         if self._nan_watch_pending is None:
+            # Metal has no pinned host allocator and no torch.cuda; the
+            # native mps event polls through the same .query() protocol.
+            on_mps = logits.device.type == "mps"
             nan_mask = torch.isnan(logits).any(dim=-1)
-            host = torch.empty(nan_mask.shape, dtype=nan_mask.dtype, pin_memory=True)
+            host = torch.empty(
+                nan_mask.shape, dtype=nan_mask.dtype, pin_memory=not on_mps
+            )
             host.copy_(nan_mask, non_blocking=True)
             ids_host = None
             if input_batch is not None:
@@ -1223,10 +1228,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 # is the drafter's deepest draft token).
                 row_ids = input_batch.input_ids[input_batch.logits_indices]
                 ids_host = torch.empty(
-                    row_ids.shape, dtype=row_ids.dtype, pin_memory=True
+                    row_ids.shape, dtype=row_ids.dtype, pin_memory=not on_mps
                 )
                 ids_host.copy_(row_ids, non_blocking=True)
-            event = torch.cuda.Event()
+            event = torch.mps.Event() if on_mps else torch.cuda.Event()
             event.record()
             self._nan_watch_pending = (
                 host,


### PR DESCRIPTION
Two hygiene items from the review backlog.

- **`VLLM_NAN_WATCH=1` crashed any Metal boot**: the diagnostic allocated pinned host memory and recorded a `torch.cuda.Event` unconditionally. Now platform-aware — plain host tensors and a native `torch.mps.Event` on MPS, polled through the same `.query()` protocol. Mechanism verified on-box detecting a planted NaN row.
- **q2_K sum-rows rule triplication**: the admission rule necessarily lives in the Python route guard, the host op's TORCH_CHECK (the safety authority), and the native step tape's mirror; each site now names the other two.

Skipped with reason from the cut list: the `all_greedy` callers' `np.all` (numpy over ≤ max_num_seqs CPU floats, no device sync — not worth restructuring) and the SwiGLU scalar-guard breadth (relaxing it needs the M1 Ultra bit-parity oracle).

Comment-only in csrc — no metallib/extension behavior change. Dispatch-guard tests pass; ruff clean.