### PR TITLE
metal: harden kernels against the QuixiCore-Metal PR #3 review findings

### DIFF
--- a/csrc/quixicore/metal/kernels/attention/paged_attn_v2/paged_attn_v2.metal
+++ b/csrc/quixicore/metal/kernels/attention/paged_attn_v2/paged_attn_v2.metal
@@ -116,6 +116,9 @@ kernel void paged_attention_partition(
 // its per-row causal boundary (row i sees ctx_len - m + i + 1) and window.
 // Partials layout matches paged_attention_partition, so the existing reduce
 // merges them unchanged (rows act as B). Grid: (H, 1, P), threads m*32.
+// No logit soft-capping: paged_attention_partition applies `softcap`, this
+// kernel takes none, so hosts must not route soft-capped models here
+// (SlimServe's Metal attention backend rejects them at construction).
 // ---------------------------------------------------------------------------
 
 template <typename T, int D>
@@ -159,6 +162,7 @@ kernel void paged_attention_verify(
 
     threadgroup T kt[TILE][D];
     threadgroup T vt[TILE][D];
+    threadgroup int kvalid[TILE];  // block >= 0 for the staged token
 
     const long q_base = ((long)row * num_heads + head) * D;
     const long stat_idx = ((long)row * num_heads + head) * num_partitions + part;
@@ -183,6 +187,7 @@ kernel void paged_attention_verify(
             const int block_col = tok / block_size;
             const int slot = tok - block_col * block_size;
             const int block = block_table[block_col];
+            if (d == 0) kvalid[tt] = (block >= 0) ? 1 : 0;
             if (block >= 0) {
                 const long cb = (long)block * (long)kv_block_stride +
                     ((long)slot * num_kv_heads + kv_head) * D;
@@ -196,7 +201,9 @@ kernel void paged_attention_verify(
         threadgroup_barrier(metal::mem_flags::mem_threadgroup);
         for (int tt = 0; tt < tile_n; ++tt) {
             const int tok = t0 + tt;
-            if (tok >= row_start && tok < row_end) {
+            // skip unmapped blocks like paged_attention_partition does,
+            // rather than scoring the zero tile they were staged as
+            if (tok >= row_start && tok < row_end && kvalid[tt] != 0) {
                 float partial = 0.0f;
                 for (int i = 0; i < VALUES_PER_LANE; ++i) {
                     const int d = (int)lane + 32 * i;

--- a/csrc/quixicore/metal/kernels/common/tk_launch.h
+++ b/csrc/quixicore/metal/kernels/common/tk_launch.h
@@ -4757,6 +4757,9 @@ void launch_paged_attention_partition(
 // Multi-query verify partition: the m expanded rows cooperate per (head,
 // partition) threadgroup, staging each K/V tile once. Partial layout matches
 // paged_attention_partition with batch == m, so the same reduce merges.
+// Unlike launch_paged_attention_partition there is no softcap argument:
+// the verify kernel never soft-caps, so callers must not route
+// soft-capped models through it.
 template <class E>
 void launch_paged_attention_verify(
     E& e, typename E::in_t q, typename E::in_t key_cache,

--- a/csrc/quixicore/metal/kernels/linear_attention/gdn/gdn.metal
+++ b/csrc/quixicore/metal/kernels/linear_attention/gdn/gdn.metal
@@ -226,7 +226,9 @@ kernel void gdn_recur_spec(device const T *q            [[buffer(0)]],
             y_[dv_idx] = T(out);
         }
 
-        const long ckpt_slot = slots[t];
+        // slots holds table_stride entries per request; positions past
+        // the table have no checkpoint rather than reading the next row
+        const long ckpt_slot = (t < table_stride) ? slots[t] : 0;
         if (ckpt_slot > 0) {
             device float *ckpt = state_pool + ckpt_slot * (long)state_stride +
                 ((long)hv_idx * Dv + dv_idx) * DK;
@@ -594,7 +596,14 @@ kernel void gdn_fused_prepare(
   // step can rewind to any accepted point. Non-spec keeps the front ring.
   int read_off = 0;
   if (spec_mode != 0) {
-    read_off = num_accepted[request] - 1;
+    // num_accepted < 1 would start the history window before the state
+    // row, and a window past state_cols would read the next channel's
+    // columns; the hosts validate dtype/shape only, so bound it here.
+    const int na = num_accepted[request];
+    if (na < 1 || na - 1 + hist_len > state_cols) {
+      return;
+    }
+    read_off = na - 1;
   }
 
   if (lrow == 2 * Hk + Hv) {

--- a/csrc/quixicore/metal/kernels/quantization/qgemm_sm/qgemm_sm.metal
+++ b/csrc/quixicore/metal/kernels/quantization/qgemm_sm/qgemm_sm.metal
@@ -74,9 +74,13 @@ kernel void qgemm_sm(
     const int kb_end = metal::min(steps_total, kb_beg + chunk);
 
     // prologue: stage the slice's first step
-    G::load(sX[kb_beg & 1], gl_x, {0, 0, kb_beg, 0}, tid);
-    dequant_into_shared<FMT, RPW, BK>(sW[kb_beg & 1][warp], Wq, N, K, rb,
-                                      kb_beg, 32, lane);
+    // empty K-slice (steps_total < SPLIT_K * chunk): nothing to stage;
+    // the zeroed accumulators still write this slice's partials
+    if (kb_beg < kb_end) {
+        G::load(sX[kb_beg & 1], gl_x, {0, 0, kb_beg, 0}, tid);
+        dequant_into_shared<FMT, RPW, BK>(sW[kb_beg & 1][warp], Wq, N, K, rb,
+                                          kb_beg, 32, lane);
+    }
     threadgroup_barrier(metal::mem_flags::mem_threadgroup);
 
     for (int kb = kb_beg; kb < kb_end; kb++) {
@@ -245,9 +249,13 @@ kernel void qgemm_sm_p(
     const int kb_beg = (int)tgid.z * chunk;
     const int kb_end = metal::min(steps_total, kb_beg + chunk);
 
-    G::load(sX[kb_beg & 1], gl_x, {0, 0, kb_beg, 0}, tid);
-    dequant_into_shared_paired<FMT>(sW[kb_beg & 1][warp], Wq, N, K, rb,
-                                    kb_beg, lane);
+    // empty K-slice (steps_total < SPLIT_K * chunk): nothing to stage;
+    // the zeroed accumulators still write this slice's partials
+    if (kb_beg < kb_end) {
+        G::load(sX[kb_beg & 1], gl_x, {0, 0, kb_beg, 0}, tid);
+        dequant_into_shared_paired<FMT>(sW[kb_beg & 1][warp], Wq, N, K, rb,
+                                        kb_beg, lane);
+    }
     threadgroup_barrier(metal::mem_flags::mem_threadgroup);
 
     for (int kb = kb_beg; kb < kb_end; kb++) {
@@ -427,9 +435,13 @@ kernel void qgemm_sm_t(
         if (cT.is_valid_element(i)) cT[i] = 0.0f;
     }
 
-    G::load(sX[kb_beg & 1], gl_x, {0, 0, kb_beg, 0}, tid);
-    sm_t_stager<FMT, PAIRED>::stage(sW[kb_beg & 1][warp], Wq, N, K, rb,
-                                    kb_beg, lane);
+    // empty K-slice (steps_total < SPLIT_K * chunk): nothing to stage;
+    // the zeroed accumulators still write this slice's partials
+    if (kb_beg < kb_end) {
+        G::load(sX[kb_beg & 1], gl_x, {0, 0, kb_beg, 0}, tid);
+        sm_t_stager<FMT, PAIRED>::stage(sW[kb_beg & 1][warp], Wq, N, K, rb,
+                                        kb_beg, lane);
+    }
     threadgroup_barrier(metal::mem_flags::mem_threadgroup);
 
     for (int kb = kb_beg; kb < kb_end; kb++) {
@@ -505,12 +517,16 @@ kernel void qgemm_sm_t2(
         if (cT.is_valid_element(i)) cT[i] = 0.0f;
     }
 
-    sm_t_stager<FMT, PAIRED>::stage(sW[kb_beg & 1][warp], Wq, N, K, rb,
-                                    kb_beg, lane);
-    if (ABLATE == 1) {
-        sm_t_stager<FMT, PAIRED>::stage(
-            sW[(kb_beg & 1) ^ 1][warp], Wq, N, K, rb,
-            metal::min(kb_beg + 1, steps_total - 1), lane);
+    // empty K-slice (steps_total < SPLIT_K * chunk): nothing to stage;
+    // the zeroed accumulators still write this slice's partials
+    if (kb_beg < kb_end) {
+        sm_t_stager<FMT, PAIRED>::stage(sW[kb_beg & 1][warp], Wq, N, K, rb,
+                                        kb_beg, lane);
+        if (ABLATE == 1) {
+            sm_t_stager<FMT, PAIRED>::stage(
+                sW[(kb_beg & 1) ^ 1][warp], Wq, N, K, rb,
+                metal::min(kb_beg + 1, steps_total - 1), lane);
+        }
     }
     threadgroup_barrier(metal::mem_flags::mem_threadgroup);
 
@@ -964,22 +980,26 @@ kernel void qgemm_sm_pa(
 
     // prologue: stage once; the "staged once" ablations fill BOTH double
     // buffers with real data so the loop reads valid halves (no NaN skew)
-    G::load(sX[kb_beg & 1], gl_x, {0, 0, kb_beg, 0}, tid);
-    if (ABLATE == 1) {
-        G::load(sX[(kb_beg & 1) ^ 1], gl_x,
-                {0, 0, metal::min(kb_beg + 1, steps_total - 1), 0}, tid);
-    }
-    if (ABLATE == 2) {
-        dequant_paired_raw<FMT>(sW[kb_beg & 1][warp], Wq, N, K, rb, kb_beg,
-                                lane);
-    } else {
-        dequant_into_shared_paired<FMT>(sW[kb_beg & 1][warp], Wq, N, K, rb,
-                                        kb_beg, lane);
-    }
-    if (ABLATE == 4) {
-        dequant_into_shared_paired<FMT>(
-            sW[(kb_beg & 1) ^ 1][warp], Wq, N, K, rb,
-            metal::min(kb_beg + 1, steps_total - 1), lane);
+    // empty K-slice (steps_total < SPLIT_K * chunk): nothing to stage;
+    // the zeroed accumulators still write this slice's partials
+    if (kb_beg < kb_end) {
+        G::load(sX[kb_beg & 1], gl_x, {0, 0, kb_beg, 0}, tid);
+        if (ABLATE == 1) {
+            G::load(sX[(kb_beg & 1) ^ 1], gl_x,
+                    {0, 0, metal::min(kb_beg + 1, steps_total - 1), 0}, tid);
+        }
+        if (ABLATE == 2) {
+            dequant_paired_raw<FMT>(sW[kb_beg & 1][warp], Wq, N, K, rb, kb_beg,
+                                    lane);
+        } else {
+            dequant_into_shared_paired<FMT>(sW[kb_beg & 1][warp], Wq, N, K, rb,
+                                            kb_beg, lane);
+        }
+        if (ABLATE == 4) {
+            dequant_into_shared_paired<FMT>(
+                sW[(kb_beg & 1) ^ 1][warp], Wq, N, K, rb,
+                metal::min(kb_beg + 1, steps_total - 1), lane);
+        }
     }
     threadgroup_barrier(metal::mem_flags::mem_threadgroup);
 
@@ -1149,10 +1169,14 @@ kernel void qgemm_sm_t4_q5_K(
         if (cT.is_valid_element(i)) cT[i] = 0.0f;
     }
 
-    dequant_paired_q5k_bk128(sW[kb_beg & 1][warp], Wq, N, K, rb, 2 * kb_beg,
-                             0, lane);
-    dequant_paired_q5k_bk128(sW[kb_beg & 1][warp], Wq, N, K, rb,
-                             2 * kb_beg + 1, 64, lane);
+    // empty K-slice (steps_total < SPLIT_K * chunk): nothing to stage;
+    // the zeroed accumulators still write this slice's partials
+    if (kb_beg < kb_end) {
+        dequant_paired_q5k_bk128(sW[kb_beg & 1][warp], Wq, N, K, rb,
+                                 2 * kb_beg, 0, lane);
+        dequant_paired_q5k_bk128(sW[kb_beg & 1][warp], Wq, N, K, rb,
+                                 2 * kb_beg + 1, 64, lane);
+    }
     threadgroup_barrier(metal::mem_flags::mem_threadgroup);
 
     for (int kb = kb_beg; kb < kb_end; kb++) {
@@ -1247,10 +1271,14 @@ kernel void qgemm_sm_rm(
     const int kb_beg = (int)tgid.z * chunk;
     const int kb_end = metal::min(steps_total, kb_beg + chunk);
 
-    qgemm_sm_rm_stage_x<BK, M_PAD, GROUP_THREADS>(sX[kb_beg & 1], X, K, M,
-                                                   kb_beg, tid);
-    dequant_into_shared<FMT, RPW, BK>(sW[kb_beg & 1][warp], Wq, N, K, rb,
-                                      kb_beg, 32, lane);
+    // empty K-slice (steps_total < SPLIT_K * chunk): nothing to stage;
+    // the zeroed accumulators still write this slice's partials
+    if (kb_beg < kb_end) {
+        qgemm_sm_rm_stage_x<BK, M_PAD, GROUP_THREADS>(sX[kb_beg & 1], X, K, M,
+                                                       kb_beg, tid);
+        dequant_into_shared<FMT, RPW, BK>(sW[kb_beg & 1][warp], Wq, N, K, rb,
+                                          kb_beg, 32, lane);
+    }
     threadgroup_barrier(metal::mem_flags::mem_threadgroup);
 
     for (int kb = kb_beg; kb < kb_end; kb++) {

--- a/csrc/quixicore/metal/kernels/serving/indexer/indexer.metal
+++ b/csrc/quixicore/metal/kernels/serving/indexer/indexer.metal
@@ -669,10 +669,17 @@ METAL_FUNC void dsv4_indexer_topk_decode_body(
         idxtk_sort(keys, vals, tid);
     }
 
+    // Every merge round re-ranks only keys[0, IDXTK_KEEP); the upper half
+    // is the next tile's staging area. Once a merge has run, ranks at or
+    // past IDXTK_KEEP hold unranked survivors, so emit -1 for them. The
+    // host contract (width <= IDXTK_WIDTH or k_eff <= IDXTK_KEEP) keeps
+    // this a no-op for served shapes.
+    const int k_lim = (n_cand > IDXTK_WIDTH)
+                          ? metal::min(k_eff, IDXTK_KEEP) : k_eff;
     device int *out_row = out + (long)token * out_stride;
     for (int k = tid; k < out_stride; k += 256) {
         out_row[k] =
-            (k < k_eff && keys[k] != -INFINITY) ? vals[k] : -1;
+            (k < k_lim && keys[k] != -INFINITY) ? vals[k] : -1;
     }
 }
 

--- a/csrc/quixicore/metal/kernels/serving/qk_norm_rope_gate/qk_norm_rope_gate.metal
+++ b/csrc/quixicore/metal/kernels/serving/qk_norm_rope_gate/qk_norm_rope_gate.metal
@@ -31,6 +31,7 @@ using namespace metal;
 namespace qc_qkr {
 constant constexpr int THREADS = 256;
 constant constexpr int SIMDGROUPS = THREADS / 32;
+constant constexpr int MAX_HEAD_DIM = 256;  // yv[] threadgroup scratch
 }  // namespace qc_qkr
 
 template <typename T, typename IT>
@@ -43,6 +44,9 @@ inline void qk_norm_rope_gate_body(
     threadgroup T* yv) {
   const bool is_q = (int)head < num_q_heads;
   const int D = head_dim;
+  // yv is MAX_HEAD_DIM wide; the host rejects larger heads, and the whole
+  // threadgroup returns here (before any barrier) if one gets through.
+  if (D < 1 || D > qc_qkr::MAX_HEAD_DIM) return;
   const ulong row_base = (ulong)token * (ulong)qkv_row;
   device const T* x;
   device const T* w;
@@ -136,7 +140,7 @@ inline void qk_norm_rope_gate_body(
       uint sg [[simdgroup_index_in_threadgroup]],                            \
       uint lane [[thread_index_in_simdgroup]]) {                             \
     threadgroup float shm[qc_qkr::SIMDGROUPS];                               \
-    threadgroup T yv[256];                                                   \
+    threadgroup T yv[qc_qkr::MAX_HEAD_DIM];                                  \
     qk_norm_rope_gate_body<T, IT>(qkv, q_w, k_w, cos_sin, positions, q_out, \
                                   gate_out, k_out, num_q_heads,              \
                                   num_k_heads, head_dim, rot_dim, eps,       \

--- a/csrc/quixicore/metal/kernels/serving_glue/dflash_prepare.metal
+++ b/csrc/quixicore/metal/kernels/serving_glue/dflash_prepare.metal
@@ -48,7 +48,12 @@ kernel void prepare_dflash_inputs(
     const int ctx_start = tgt_qsl[req_idx];
     const int ctx_end = tgt_qsl[req_idx + 1];
     const int num_ctx = ctx_end - ctx_start;
-    const int valid_ctx_end = ctx_end - num_rejected[req_idx];
+    // The bonus/anchor token is always accepted, so at least one context
+    // position is valid; clamp so a producer bug can never read before
+    // ctx_start (the Triton reference reads tgt_pos[valid_ctx_end - 1]
+    // unguarded).
+    const int valid_ctx_end =
+        metal::max(ctx_start + 1, ctx_end - num_rejected[req_idx]);
     const int bonus = num_sampled[req_idx] > 0
                           ? (int)last_sampled[req_state_idx]
                           : next_prefill[req_state_idx];

--- a/csrc/quixicore/metal/kernels/serving_glue/gdn_step.metal
+++ b/csrc/quixicore/metal/kernels/serving_glue/gdn_step.metal
@@ -91,7 +91,12 @@ kernel void qwen_gdn_conv_step(
     if (c >= conv_dim) return;
     const int slot = conv_slot[n];
     if (slot <= 0) return;  // NULL entry: the scan kernel zeroes the output
+    // S and width index the fixed local windows below. The host checks
+    // 1 <= S <= MAX_S and 2 <= width <= MAX_WIDTH; a violation degrades to
+    // a no-op here instead of writing past the stack arrays.
+    if (S < 1 || S > MAX_S || width < 1 || width > MAX_WIDTH) return;
     const int off = use_accepted ? (num_accepted[n] - 1) : 0;
+    if (off < 0) return;  // num_accepted < 1: no history window to read
     const int w1 = width - 1;
 
     device TC* st = conv_state + (long)slot * cs_slot + (long)c * cs_chan;

--- a/perf/optimization_status.md
+++ b/perf/optimization_status.md
@@ -18019,3 +18019,88 @@ perf/results/2026-08-29/a100-bf16-kvtier/ and
   attention views ('[544, 64, 256]' vs 262144 elements). The rtx3090
   GDN+attention profile uses the dedicated CSA-linear planner; generalizing
   that to KDA+MLA and running the eviction acceptance is the follow-up.
+
+### Metal kernel hardening from the QuixiCore-Metal PR #3 review (2026-09-01)
+
+- Status: retained (sources + tests). End-to-end re-gate and the metallib
+  rebuild are owed on a macOS 26 box; see NOT DONE below.
+- Baseline: origin/main e848ed5f7, whose `csrc/quixicore/metal` tree is
+  byte-identical to QuixiCore-Metal PR #3 head cf4860a. CodeRabbit left 11
+  open threads on that PR: 9 on kernel files shared with this tree, 2 on
+  upstream-only docs. Fixed here first, then re-ported, so the twin stays
+  exact (same loop as 2026-08-17: 5452dc24b <-> upstream 6e64069).
+- Hypothesis: each kernel finding is a latent out-of-bounds access on a
+  host-invariant violation or a defensive-path inconsistency. In-kernel
+  guards that are no-ops on every served shape fix all of them without
+  changing a single served output bit.
+- Changes (in-kernel unless noted):
+  - `qgemm_sm.metal`: every split-K prologue (7 kernels) stages tile
+    `kb_beg` only when `kb_beg < kb_end`. The real bug of the set: with
+    K only required to be a multiple of 32, a K that does not fill
+    SPLIT_K chunks made the last threadgroup read one X/Wq tile past K.
+    Served K values divide evenly, which is why it never showed.
+  - `paged_attn_v2.metal` verify: stages a per-token validity flag and
+    skips unmapped blocks like `paged_attention_partition` does, instead of
+    scoring the zero tile (inflated denominator). Documents that verify
+    takes no softcap; `tk_launch.h` launcher comment says the same.
+  - `metal_attn.py` (host): raises NotImplementedError when a model asks
+    for attention logit soft-capping. Every Metal route passed softcap=0
+    and the value was silently dropped.
+  - `gdn.metal`: `gdn_fused_prepare` spec window bounded
+    (`num_accepted >= 1` and `read_off + hist_len <= state_cols`);
+    `gdn_recur_spec` checkpoint store bounded by `table_stride`.
+  - `gdn_step.metal`: S/width clamped to MAX_S/MAX_WIDTH; `off < 0`
+    (num_accepted < 1) returns.
+  - `indexer.metal`: after any 512-way merge, ranks past IDXTK_KEEP emit
+    -1 instead of unranked survivors (host already forbids that k_eff;
+    shared body, so prefill and decode both).
+  - `qk_norm_rope_gate.metal`: `MAX_HEAD_DIM` constant, whole-threadgroup
+    return before any barrier when head_dim exceeds it.
+  - `dflash_prepare.metal`: `valid_ctx_end` clamped to `ctx_start + 1`
+    (the Triton reference reads `tgt_pos[valid_ctx_end - 1]` unguarded).
+- Correctness, this box (M3 Max 128 GB, macOS 15.7.9, Xcode 26.3,
+  MetalToolchain 17.3.7003.10):
+  - Built extension + metallib at `-std=metal3.1` through a LOCAL,
+    uncommitted `cmake/metal.cmake` tweak: this toolchain has no
+    `metal::uint4b_format`, so the committed `-std=metal4.0` recipe fails in
+    the u4/u8 tensor kernels before anything else is compiled.
+  - Existing oracles (`test_qwen_gdn_metal`, `test_metal_indexer_topk_prefill`,
+    `test_metal_prefill_fa`): 5/5 before, 5/5 after.
+  - New `tests/kernels/test_metal_paged_attention_verify.py` (dense fp32
+    reference, bf16 D=128, bf16+fp16 D=256, m=1 and m=32, unmapped-block
+    case): before 3/4 with the unmapped case off by 0.195 max abs (the
+    finding reproduced); after 4/4.
+  - New `tests/kernels/test_metal_indexer_topk_decode.py` (direct 1,024
+    sort and 512-way streaming merge, exact vs torch.topk): 2/2 before and
+    after.
+  - GDN probe (`ab_gdn.py`: `gdn_fused_prepare` spec and plain,
+    `gdn_recur_spec` with wide and seq_len-tight slot tables, num_accepted
+    1..4 against the 6-column conv state mamba_utils allocates for
+    kernel 4 + num_spec 3): 16/16 tensors bit-exact before vs after.
+  - `qgemm_sm.metal` under `-std=metal4.0 -ferror-limit=0`: identical
+    14-error set before and after (all `uint4b_format` in the untouched
+    u4/u8 kernels). The guard edits inside the `__HAVE_TENSOR__` kernels
+    are compile-checked only to that extent.
+- NOT DONE: no end-to-end profile gate ran. `qc_metal_serving.mm` selects
+  the `mpp::tensor_ops` variants unconditionally (verify band 15/16/17,
+  Muse lm_head 16) and Metal 4 tensor ops need macOS 26; on 15.7 the
+  pipeline lookup would fail, so no Metal profile can serve here. The
+  tracked `vllm/quixicore_metal.metallib` is therefore NOT rebuilt in this
+  change and is stale against the sources until a macOS 26 box rebuilds it.
+- Throughput: not measured. The guards are a threadgroup-uniform predicate
+  outside the K loop and one threadgroup int per staged tile; expected
+  neutral, to be confirmed by the pins.
+- Side finding: a TORCH_CHECK failure inside an `encode` block (GCD
+  dispatch_sync) escapes as an uncaught C++ exception and aborts the
+  process instead of raising; seen when asking for
+  `paged_attention_verify_float16_128`, which is not instantiated (the
+  metallib carries bf16 at 128 and both dtypes at 256).
+- Next, on a macOS 26 Metal box: `uv pip install -e . --no-deps
+  --no-build-isolation`; run the three test files above; serve
+  `qwen38-nvfp4-1` and re-pin c1 1000x256 (sha 467b35c3) and 2500x64
+  (sha aa448847) with `benchmark_dsv4_exact.py` + m2_source.txt; serve
+  `muse-kdyn-1` under the rested protocol; commit the rebuilt metallib.
+- Raw: perf/results/2026-09-01/hardening_baseline/ (baseline build logs,
+  oracle and test logs, metal4.0 error sets) and
+  perf/results/2026-09-01/hardening_patched/ (patched build, tests,
+  `ab_gdn_compare.log`, `apply_hardening.py`, `ab_gdn.py`).

--- a/tests/kernels/test_metal_indexer_topk_decode.py
+++ b/tests/kernels/test_metal_indexer_topk_decode.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Oracle for the native decode indexer top-k (dsv4_indexer_topk_decode).
+
+Decode twin of test_metal_indexer_topk_prefill: one token per row, each row
+carrying its own block-table row. Covers the direct 1,024-wide sort and the
+512-way streaming merge above it, which is the path where only the first
+IDXTK_KEEP ranks stay valid.
+
+Run directly: .venv/bin/python tests/kernels/test_metal_indexer_topk_decode.py
+"""
+import torch
+
+try:  # collected by pytest in CI; hand-run on the serving box without it
+    import pytest
+
+    pytestmark = pytest.mark.skipif(
+        not torch.backends.mps.is_available(),
+        reason="requires Apple Metal (MPS)",
+    )
+except ModuleNotFoundError:
+    pass
+
+DEV = "mps"
+H, D = 64, 128
+TOPK = 512
+BS = 256  # kv block size
+
+
+def _lut() -> torch.Tensor:
+    lut = torch.arange(256, dtype=torch.uint8).view(torch.float8_e4m3fn).to(torch.float32)
+    return torch.nan_to_num(lut, nan=0.0).to(DEV)
+
+
+def _cache(n_blocks: int, seed: int) -> torch.Tensor:
+    torch.manual_seed(seed)
+    cache = torch.randint(0, 255, (n_blocks, BS, 132), dtype=torch.uint8)
+    cache[..., :128] &= 0x7E
+    cache[0, ::3, 5] = 0x7F  # e4m3 NaN codes the writer never emits
+    cache[1 % n_blocks, 1::4, 77] = 0xFF
+    scales = (torch.rand(n_blocks, BS, 1) * 0.5 + 0.5).to(torch.float32)
+    cache[..., 128:132] = scales.view(torch.uint8).reshape(n_blocks, BS, 4)
+    return cache.to(DEV)
+
+
+def _reference(q, w, cache, bt_row, n: int, k: int, lut) -> torch.Tensor:
+    j = torch.arange(n, device=DEV)
+    packed = cache[bt_row[j // BS].long(), j % BS]
+    kval = lut[packed[..., :128].long()]
+    kscale = packed[..., 128:].contiguous().view(torch.float32).reshape(n)
+    score = torch.einsum("hd,kd->hk", q.float(), kval)
+    logits = torch.einsum("hk,h->k", torch.relu(score), w) * kscale
+    return torch.topk(logits, min(k, n)).indices.cpu()
+
+
+def _run(width: int, cands: list[int], seed: int) -> None:
+    from vllm.quixicore.ops import quixicore_ops
+
+    lut = _lut()
+    tokens = len(cands)
+    blocks_per_row = (width + BS - 1) // BS
+    cache = _cache(blocks_per_row * tokens, seed)
+    torch.manual_seed(seed + 1)
+    q = (torch.randn(tokens, H, D, dtype=torch.float16, device=DEV) * 0.3).contiguous()
+    w = (torch.rand(tokens, H, dtype=torch.float32, device=DEV) + 0.1).contiguous()
+    # each decode row owns a disjoint block-table row
+    bt = torch.arange(blocks_per_row * tokens, dtype=torch.int32, device=DEV)
+    bt = bt.reshape(tokens, blocks_per_row).contiguous()
+    cand = torch.tensor(cands, dtype=torch.int32, device=DEV)
+    k_eff = min(TOPK, width)
+    out = torch.full((tokens, TOPK), -1, dtype=torch.int32, device=DEV)
+    quixicore_ops.dsv4_indexer_topk_decode(q, w, cache, bt, cand, out, width, k_eff)
+    out2 = torch.full((tokens, TOPK), -1, dtype=torch.int32, device=DEV)
+    quixicore_ops.dsv4_indexer_topk_decode(q, w, cache, bt, cand, out2, width, k_eff)
+    torch.mps.synchronize()
+    assert torch.equal(out, out2), "decode indexer top-k is not deterministic"
+    for t, n in enumerate(cands):
+        ref = _reference(q[t], w[t], cache, bt[t], n, k_eff, lut)
+        got = out[t, : ref.numel()].long().cpu()
+        assert torch.equal(got, ref), f"row {t}: top-k order differs"
+        assert (out[t, min(k_eff, n):] == -1).all().item(), f"row {t}: pad not -1"
+
+
+def test_decode_direct_sort_width() -> None:
+    # every candidate count fits the 1,024-wide direct sort
+    _run(width=1024, cands=[1024, 700, 513, 512, 17, 1], seed=0)
+
+
+def test_decode_streaming_merge() -> None:
+    # above 1,024 candidates the kernel streams 512-way merges; k_eff stays
+    # at IDXTK_KEEP, the only k the host allows past the direct width
+    _run(width=1537, cands=[1537, 1518, 1025], seed=3)
+
+
+def main() -> None:
+    test_decode_direct_sort_width()
+    print("decode indexer top-k: direct sort exact")
+    test_decode_streaming_merge()
+    print("decode indexer top-k: streaming merge exact")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kernels/test_metal_paged_attention_verify.py
+++ b/tests/kernels/test_metal_paged_attention_verify.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Oracle for the multi-query verify attention kernel (paged_attention_verify).
+
+The m rows of a speculative verify block share one request's KV cache; row i
+sees context positions [0, ctx - m + i + 1). The kernel must match a dense
+fp32 reference on that causal window, and it must treat an unmapped block
+(block_table entry < 0) the way paged_attention_partition does: skip the
+tokens, rather than score a zero tile and inflate the softmax denominator.
+
+Run directly: .venv/bin/python tests/kernels/test_metal_paged_attention_verify.py
+"""
+import math
+
+import torch
+
+try:  # collected by pytest in CI; hand-run on the serving box without it
+    import pytest
+
+    pytestmark = pytest.mark.skipif(
+        not torch.backends.mps.is_available(),
+        reason="requires Apple Metal (MPS)",
+    )
+except ModuleNotFoundError:
+    pass
+
+DEV = "mps"
+
+
+def _case(
+    *,
+    m: int,
+    heads: int,
+    kv_heads: int,
+    head_dim: int,
+    block_size: int,
+    ctx_base: int,
+    dtype: torch.dtype,
+    unmapped_blocks: tuple[int, ...] = (),
+    seed: int = 0,
+):
+    torch.manual_seed(seed)
+    ctx = ctx_base + m
+    n_slots = (ctx + block_size - 1) // block_size
+    n_blocks = n_slots + 4
+    # non-identity block table so a stride bug cannot hide behind block == col
+    perm = torch.randperm(n_blocks)[:n_slots].to(torch.int32)
+    block_table = perm.clone()
+    for col in unmapped_blocks:
+        block_table[col] = -1
+    block_table = block_table[None, :].contiguous().to(DEV)
+    key_cache = torch.randn(n_blocks, block_size, kv_heads, head_dim).to(dtype).to(DEV)
+    value_cache = torch.randn(n_blocks, block_size, kv_heads, head_dim).to(dtype).to(DEV)
+    q = torch.randn(m, heads, head_dim).to(dtype).to(DEV)
+    context_lens = torch.tensor([ctx], dtype=torch.int32, device=DEV)
+    scale = 1.0 / math.sqrt(head_dim)
+    return q, key_cache, value_cache, block_table, context_lens, scale
+
+
+def _reference(q, key_cache, value_cache, block_table, ctx: int, scale: float):
+    """Dense fp32 attention over the mapped tokens of each row's causal window."""
+    m, heads, head_dim = q.shape
+    kv_heads = key_cache.shape[2]
+    block_size = key_cache.shape[1]
+    group = heads // kv_heads
+    bt = block_table[0].cpu()
+    tokens = torch.arange(ctx)
+    blocks = bt[tokens // block_size]
+    mapped = blocks >= 0
+    slots = tokens % block_size
+    k = key_cache.cpu().float()[blocks.clamp(min=0), slots]  # [ctx, KV, D]
+    v = value_cache.cpu().float()[blocks.clamp(min=0), slots]
+    qf = q.cpu().float()
+    out = torch.zeros(m, heads, head_dim)
+    for row in range(m):
+        row_end = ctx - m + row + 1
+        keep = mapped[:row_end]
+        for h in range(heads):
+            kh = h // group
+            kk = k[:row_end, kh][keep]
+            vv = v[:row_end, kh][keep]
+            s = (kk @ qf[row, h]) * scale
+            p = torch.softmax(s, dim=0)
+            out[row, h] = p @ vv
+    return out
+
+
+def _tol(dtype: torch.dtype) -> tuple[float, float]:
+    # output is rounded to the activation dtype once; bf16 keeps ~3 digits
+    return (2e-2, 2e-2) if dtype == torch.bfloat16 else (5e-3, 5e-3)
+
+
+def _run(**kw):
+    from vllm.quixicore.ops import quixicore_ops
+
+    q, kc, vc, bt, cl, scale = _case(**kw)
+    out = quixicore_ops.paged_attention_verify(q, kc, vc, bt, cl, scale)
+    out2 = quixicore_ops.paged_attention_verify(q, kc, vc, bt, cl, scale)
+    torch.mps.synchronize()
+    assert torch.equal(out, out2), "verify kernel is not deterministic"
+    ref = _reference(q, kc, vc, bt, int(cl[0]), scale)
+    atol, rtol = _tol(kw["dtype"])
+    torch.testing.assert_close(out.cpu().float(), ref, atol=atol, rtol=rtol)
+    return out
+
+
+def test_verify_matches_reference_d128() -> None:
+    # the metallib instantiates bf16 at D=128 and both dtypes at D=256
+    _run(m=4, heads=8, kv_heads=2, head_dim=128, block_size=16,
+         ctx_base=700, dtype=torch.bfloat16)
+
+
+def test_verify_matches_reference_d256() -> None:
+    # Qwen3.8's full-attention layers: bf16 KV at head_dim 256, m up to k+1;
+    # the fp16 twin is the Muse-Glimmer route
+    for dtype in (torch.bfloat16, torch.float16):
+        _run(m=4, heads=4, kv_heads=2, head_dim=256, block_size=16,
+             ctx_base=1100, dtype=dtype)
+
+
+def test_verify_single_row_and_max_rows() -> None:
+    _run(m=1, heads=8, kv_heads=2, head_dim=128, block_size=16,
+         ctx_base=40, dtype=torch.bfloat16)
+    _run(m=32, heads=4, kv_heads=4, head_dim=256, block_size=16,
+         ctx_base=520, dtype=torch.float16)
+
+
+def test_verify_skips_unmapped_blocks() -> None:
+    # An unmapped block inside the context is a host-invariant violation, but
+    # the kernel's defensive behaviour must agree with paged_attention_partition:
+    # skip those tokens. Scoring the zero tile they were staged as would add
+    # exp(0 - max) per token to the denominator and attenuate every row.
+    # short context so the two unmapped blocks are ~30% of the window and
+    # the attenuation is far outside the bf16 tolerance
+    _run(m=4, heads=8, kv_heads=2, head_dim=128, block_size=16,
+         ctx_base=100, dtype=torch.bfloat16, unmapped_blocks=(1, 4))
+
+
+def main() -> None:
+    test_verify_matches_reference_d128()
+    test_verify_matches_reference_d256()
+    test_verify_single_row_and_max_rows()
+    print("verify kernel matches the dense reference on mapped context")
+    test_verify_skips_unmapped_blocks()
+    print("verify kernel skips unmapped blocks like the partition kernel")
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/v1/attention/backends/metal_attn.py
+++ b/vllm/v1/attention/backends/metal_attn.py
@@ -293,6 +293,11 @@ class MetalAttentionImpl(AttentionImpl):
             raise NotImplementedError("Attention sinks require TurboQuant on Metal.")
         if alibi_slopes is not None:
             raise NotImplementedError("ALiBi has no Metal attention path.")
+        if self.logits_soft_cap:
+            raise NotImplementedError(
+                "Attention logit soft-capping has no Metal path: every Metal "
+                "attention route passes softcap=0 and the multi-query verify "
+                "kernel takes none.")
         # Sliding windows ride the paged-attention kernel's `window` argument
         # on the decode path and a banded mask on the SDPA fallback.
         if attn_type != AttentionType.DECODER:


### PR DESCRIPTION
## Why

CodeRabbit left 11 open threads on [QuixiCore-Metal PR #3](https://github.com/QuixiAI/QuixiCore-Metal/pull/3), the upstream port of this tree. Nine are on kernel files that exist in both repos. Fixing them on the PR branch would have un-twinned the two trees, so this PR fixes them here first; the port branch is refreshed from this commit byte for byte.

## What changed

| File | Fix |
| --- | --- |
| `qgemm_sm.metal` | Every split-K prologue stages tile `kb_beg` only when `kb_beg < kb_end`. With K only required to be a multiple of 32, a K that does not fill SPLIT_K chunks made the last threadgroup read one X/Wq tile past K. Served K values divide evenly, which is why it never showed. The one real bug of the set. |
| `paged_attn_v2.metal` (verify) | Per-token validity flag; unmapped blocks are skipped like `paged_attention_partition` does instead of scored as a zero tile (inflated denominator). Documents that verify takes no softcap. |
| `metal_attn.py` | Raises `NotImplementedError` when a model asks for attention logit soft-capping. Every Metal route passed `softcap=0` and the value was silently dropped. |
| `gdn.metal` | Spec conv window bounded (`num_accepted >= 1`, `read_off + hist_len <= state_cols`); checkpoint store bounded by `table_stride`. |
| `gdn_step.metal` | S/width clamped to the fixed local arrays; `num_accepted < 1` returns. |
| `indexer.metal` | After a 512-way merge, ranks past IDXTK_KEEP emit -1 instead of unranked survivors (shared body: prefill and decode). |
| `qk_norm_rope_gate.metal` | `MAX_HEAD_DIM` constant, whole-threadgroup return before any barrier. |
| `dflash_prepare.metal` | `valid_ctx_end` clamped to `ctx_start + 1`; the Triton reference reads `tgt_pos[valid_ctx_end - 1]` unguarded. |
| `tk_launch.h` | Comment only: verify launcher takes no softcap. |

Every guard is a no-op on served shapes. New tests: `tests/kernels/test_metal_paged_attention_verify.py` (dense fp32 reference, bf16 D=128, bf16+fp16 D=256, m=1/32, unmapped-block case) and `tests/kernels/test_metal_indexer_topk_decode.py` (decode twin of the prefill oracle, direct sort and streaming merge).

## Gated on an M3 Max (macOS 15.7, Xcode 26.3)

- Existing oracles: 5/5 before and after.
- New tests: before, the unmapped-block verify case fails by 0.195 max abs (the finding reproduced); after, 6/6.
- GDN probe (`gdn_fused_prepare` spec/plain, `gdn_recur_spec` wide/tight tables, num_accepted 1..4 against the 6-column conv state mamba_utils allocates): 16/16 tensors bit-exact before vs after.
- `qgemm_sm.metal` under `-std=metal4.0`: identical 14-error set before and after (all pre-existing `metal::uint4b_format` in the untouched u4/u8 kernels; this toolchain lacks the type).

## NOT done, and needed before merge

- **No end-to-end profile gate.** The serving path selects the `mpp::tensor_ops` kernel variants unconditionally and Metal 4 needs macOS 26; this box cannot serve any Metal profile. Owed on a macOS 26 box: build, run the three test files, re-pin `qwen38-nvfp4-1` c1 1000x256 (sha 467b35c3) and 2500x64 (sha aa448847), and `muse-kdyn-1` under the rested protocol.
- **`vllm/quixicore_metal.metallib` is not rebuilt** (needs the macOS 26 toolchain for `-std=metal4.0`). The tracked binary is unchanged and stale against these sources until that box rebuilds and commits it.
- The guard edits inside the `__HAVE_TENSOR__` kernels are compile-checked only as far as the error-set comparison above.

Side finding, not fixed here: a `TORCH_CHECK` failure inside an `encode` block escapes the GCD `dispatch_sync` as an uncaught C++ exception and aborts the process instead of raising (seen asking for `paged_attention_verify_float16_128`, which is not instantiated).

Notebook: `perf/optimization_status.md`, entry "Metal kernel hardening from the QuixiCore-Metal PR #3 review (2026-09-01)". Raw logs under `perf/results/2026-09-01/hardening_{baseline,patched}/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speculative decoding reliability by validating history windows, checkpoint access, and context bounds.
  * Prevented invalid memory reads and incorrect results for empty GEMM partitions, unmapped attention blocks, and unsupported tensor dimensions.
  * Corrected top-k output padding after large merge operations.
  * Attention now clearly rejects unsupported logit soft-capping instead of silently ignoring it.

* **Tests**
  * Added coverage for paged attention verification and top-k decoding, including determinism, unmapped blocks, ordering, and padding behavior.
  * Documented kernel hardening results and validation outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->