### PR TITLE
[4/5] GLM53 indexer and routing qualification

### DIFF
--- a/benchmarks/analyze_glm53_indexer_precision.py
+++ b/benchmarks/analyze_glm53_indexer_precision.py
@@ -1,0 +1,495 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU arithmetic experiments on the completed indexer LayerNorm128 matrix.
+
+These are explicitly rounded CPU models, NOT reproductions of Triton reduction
+trees, GPU rsqrt, compiler contraction, or saved kernel outputs. Consuming a
+completed audit does not rerun its expired source freeze. No GPU initialization,
+kernel installation, timing, tolerance change, or production qualification.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+from itertools import product
+from pathlib import Path
+
+from benchmarks.analyze_glm53_reduction_receipts import sha
+from benchmarks.kernels.check_glm53_attention_norms import (
+    MAGNITUDES,
+    ROWS,
+    SEEDS,
+    WEIGHTS,
+    layernorm_oracle,
+    load_checked,
+    load_weights,
+    mismatch_examples,
+    packed_inputs,
+    require,
+)
+from benchmarks.kernels.check_glm53_cached_rmsnorm import compare, tensor_sha
+
+ROOT = Path(__file__).resolve().parents[1]
+RESULTS = ROOT / "perf/results/2026-09-10"
+PINS = {
+    "summary": (
+        "attention-norm-rank-private-probe/summary.json",
+        "64c60102d391baffa7a4391257a9b742ed6932e6aea63cdb8cae77a478880c78",
+    ),
+    "audit": (
+        "attention-norm-rank-private-probe/analysis.json",
+        "0da742b0b8d7eb08651be0b32fff0b7c874aaa87781d01d47ce2ca3877e06bdb",
+    ),
+    "manifest": (
+        "runtime-control/attention-rank-private-manifest.json",
+        "29f934cd1cd6d695e0b62ba840926e31e6c7cc0212ae46d493269ee53736a12a",
+    ),
+    "supplement": (
+        "runtime-control/attention-rank-private-supplement.json",
+        "ca1f301a402d655b0e42db598437615864444b927ac723df4cb7db3f5d283f85",
+    ),
+}
+MODELS = {
+    "fp32_separate": "FP32 moments, centering, rsqrt, normalization, multiply/add.",
+    "fp32_fused_affine": (
+        "FP32 normalized value; affine in FP64 then rounded to FP32. "
+        "Fused-affine emulation for these bounded BF16 weights, not GPU FMA."
+    ),
+    "fp32_norm_fp64_affine": "FP32 normalized value; FP64 multiply/add.",
+    "fp32_moments_fp64_tail": (
+        "FP32 mean/centered variance; recenter input and compute rsqrt, "
+        "normalization and affine in FP64, including epsilon addition."
+    ),
+    "fp64_norm_rounded_fp32": (
+        "FP64 moments/normalization; round normalized value to FP32, then FP64 affine."
+    ),
+    "fp64_control": "Full FP64 oracle arithmetic; reference/control only.",
+}
+# Fixed before the screen: these are detection thresholds, not ULP tolerances.
+CANCELLATION_EXPONENTS = (-16, -12, -8)
+SCREEN_MODELS = ("fp32_separate", "fp32_fused_affine")
+PRECISION_BASELINE = RESULTS / "runtime-control/indexer-precision-analysis-v1.json"
+PRECISION_BASELINE_SHA = (
+    "358f4a155dbeea926e4e6e3f7b192c8c9e3ded3a0f4ee5b857d1951af7502764"
+)
+
+
+def joined_cases(summary, audit, manifest, supplement):
+    """Validate the closed evidence's joins; never call a frozen-source reader."""
+    require(audit["status"] == supplement["status"] == "complete", "unclosed audit")
+    require(summary["status"] == "failed", "historical failed probe required")
+    require(audit["numerical_pass"] is False, "failed oracle must remain failed")
+    for document in (summary, audit, supplement):
+        require(document["manifest_sha256"] == PINS["manifest"][1], "manifest join")
+    for document in (audit, supplement):
+        require(document["summary_sha256"] == PINS["summary"][1], "summary join")
+    require(supplement["audit_sha256"] == PINS["audit"][1], "audit join")
+    require(summary["weights"] == manifest["weight_sha256"], "weight receipt join")
+    require(
+        (manifest["rows"], manifest["seeds"], manifest["magnitudes"])
+        == (list(ROWS), list(SEEDS), list(MAGNITUDES)),
+        "historical matrix changed",
+    )
+    checks = summary["checks"]
+    keys = [(r["rank"], r["rows"], r["seed"], r["magnitude"]) for r in checks]
+    require(keys == list(product(range(4), ROWS, SEEDS, MAGNITUDES)), "matrix order")
+    require(audit["pairs"] == manifest["expected_pairs"] == len(checks), "pair count")
+    require(
+        all(r["repeat_graph_guards_mutation_pass"] is True for r in checks),
+        "historical replay/guard failure",
+    )
+    failed = []
+    for r in checks:
+        passed = all(
+            m["max_bf16_ulp"] <= 1
+            for phases in r["oracle"].values()
+            for phase in phases
+            for m in phase
+        )
+        require(r["passed"] is passed, "historical pass flag disagrees")
+        if not passed:
+            failed.append({k: r[k] for k in ("rank", "rows", "seed", "magnitude")})
+    require(failed == audit["failed_cases"], "failed-case join")
+    require(len(failed) == supplement["failed_pairs"] == 20, "failed-case count")
+    per_rank = [
+        [{k: v for k, v in r.items() if k != "rank"} for r in checks if r["rank"] == i]
+        for i in range(4)
+    ]
+    require(all(r == per_rank[0] for r in per_rank[1:]), "rank numerical drift")
+    require(supplement["all_four_rank_records_exact"] is True, "rank join")
+    return [r for r in checks if r["rank"] == 0]
+
+
+def arithmetic_models(x, weight, bias):
+    """Eager CPU tensor operations; each operation rounds to its tensor dtype."""
+    import torch
+
+    require(
+        all(
+            t.device.type == "cpu" and t.dtype == torch.bfloat16
+            for t in (x, weight, bias)
+        ),
+        "CPU BF16 inputs required",
+    )
+    require(
+        x.ndim == 2
+        and x.shape[0] > 0
+        and x.shape[1] == 128
+        and weight.shape == bias.shape == (128,),
+        "LayerNorm128 shape required",
+    )
+    require(all(torch.isfinite(t).all() for t in (x, weight, bias)), "finite inputs")
+    x32, w32, b32 = x.float(), weight.float(), bias.float()
+    mean32 = x32.mean(-1, keepdim=True)
+    centered32 = x32 - mean32
+    var32 = centered32.square().mean(-1, keepdim=True)
+    norm32 = centered32 * torch.rsqrt(var32 + 1e-6)
+    x64, w64, b64 = x.double(), weight.double(), bias.double()
+    centered64 = x64 - x64.mean(-1, keepdim=True)
+    norm64 = centered64 * torch.rsqrt(centered64.square().mean(-1, keepdim=True) + 1e-6)
+    affine64 = norm32.double() * w64 + b64
+    tail64 = (x64 - mean32.double()) * torch.rsqrt(var32.double() + 1e-6)
+    return {
+        "fp32_separate": norm32 * w32 + b32,
+        "fp32_fused_affine": affine64.float(),
+        "fp32_norm_fp64_affine": affine64,
+        "fp32_moments_fp64_tail": tail64 * w64 + b64,
+        "fp64_norm_rounded_fp32": norm64.float().double() * w64 + b64,
+        "fp64_control": norm64 * w64 + b64,
+    }
+
+
+def modeled_outputs(x, weight, bias):
+    import torch
+
+    outputs = {name: torch.empty_like(x) for name in MODELS}
+    for start in range(0, len(x), 128):
+        values = arithmetic_models(x[start : start + 128], weight, bias)
+        for name, value in values.items():
+            outputs[name][start : start + 128].copy_(value.bfloat16())
+    return outputs
+
+
+def retained_examples(case, phase, x, weight, bias, reference):
+    """Reconstruct every retained failing scalar, without inventing GPU values."""
+    evidence = []
+    for arm in ("combo", "split"):
+        failures = case["mismatch_examples"][arm][phase][2]
+        if failures is None:
+            continue
+        # The saved file keeps at most 16; this matrix's failures all fit.
+        require(
+            failures["count"] == len(failures["worst"]), "truncated historical failures"
+        )
+        for example in failures["worst"]:
+            row, col = example["row"], example["column"]
+            require(
+                float(reference[row, col]) == example["reference"],
+                "oracle scalar drift",
+            )
+            values = arithmetic_models(x[row : row + 1], weight, bias)
+            exact = float(values["fp64_control"][0, col])
+            b = float(bias[col])
+            evidence.append(
+                dict(
+                    arm=arm,
+                    **example,
+                    fp64_result=exact,
+                    cancellation_ratio=(abs(exact - b) + abs(b)) / abs(exact)
+                    if exact
+                    else None,
+                    cpu_models={
+                        name: dict(
+                            unrounded=float(v[0, col]), bf16=float(v.bfloat16()[0, col])
+                        )
+                        for name, v in values.items()
+                    },
+                )
+            )
+    return evidence
+
+
+def cancellation_mask(output, bias, exponent):
+    """Output/bias-only detector; no oracle, input moments or FP64 arithmetic.
+
+    Reconstruct the affine term approximately as output - bias. A zero output with
+    nonzero bias is cancellation-prone; zero output AND bias is not cancellation.
+    The future GPU path must validate actual branch arithmetic independently.
+    """
+    import torch
+
+    require(exponent in CANCELLATION_EXPONENTS, "prescribed detector threshold")
+    require(
+        all(
+            t.device.type == "cpu" and t.dtype == torch.bfloat16 for t in (output, bias)
+        ),
+        "CPU BF16 detector inputs required",
+    )
+    require(output.ndim == 2 and bias.shape == (output.shape[1],), "detector shape")
+    require(
+        all(torch.isfinite(t).all() for t in (output, bias)), "finite detector inputs"
+    )
+    y, b = output.float(), bias.float()
+    scale = (y - b).abs() + b.abs()
+    return (scale > 0) & (y.abs() <= (2.0**exponent) * scale)
+
+
+def above_one_ulp(actual, reference):
+    import torch
+
+    def ordered(t):
+        bits = t.view(torch.int16).int() & 0xFFFF
+        return torch.where(bits >= 0x8000, -(bits & 0x7FFF), bits & 0x7FFF)
+
+    return (ordered(actual) - ordered(reference)).abs() > 1
+
+
+def screen_cancellation(outputs, reference, bias, historical):
+    """Coverage/cost estimate only, not a recomputation kernel test."""
+    import torch
+
+    result = {}
+    for exponent in CANCELLATION_EXPONENTS:
+        models = {}
+        for name in SCREEN_MODELS:
+            output = outputs[name]
+            selected = cancellation_mask(output, bias, exponent)
+            failures = above_one_ulp(output, reference)
+            models[name] = dict(
+                elements=output.numel(),
+                rows=len(output),
+                selected_elements=int(selected.sum()),
+                selected_rows=int(selected.any(-1).sum()),
+                failures=int(failures.sum()),
+                detected_failures=int((failures & selected).sum()),
+                missed_failures=int((failures & ~selected).sum()),
+            )
+        historical_by_arm = {}
+        for arm in ("combo", "split"):
+            examples = [p for p in historical if p["arm"] == arm]
+            detected = []
+            for point in examples:
+                output = torch.tensor([[point["actual"]]], dtype=torch.bfloat16)
+                b = bias[point["column"] : point["column"] + 1]
+                detected.append(bool(cancellation_mask(output, b, exponent)[0, 0]))
+            historical_by_arm[arm] = dict(
+                examples=len(examples),
+                detected=sum(detected),
+                missed=[
+                    {k: p[k] for k in ("row", "column", "actual", "bf16_ulp")}
+                    for p, found in zip(examples, detected)
+                    if not found
+                ],
+            )
+        result[str(exponent)] = dict(
+            cpu_models=models, historical_gpu_failures=historical_by_arm
+        )
+    return result
+
+
+def aggregate_screen(records):
+    result = {}
+    for exponent in CANCELLATION_EXPONENTS:
+        screens = [r["cancellation_screen"][str(exponent)] for r in records]
+        models = {}
+        for name in SCREEN_MODELS:
+            metrics = [r["cpu_models"][name] for r in screens]
+            counts = {key: sum(m[key] for m in metrics) for key in metrics[0]}
+            models[name] = dict(
+                **counts,
+                selected_element_fraction=counts["selected_elements"]
+                / counts["elements"],
+                selected_row_fraction=counts["selected_rows"] / counts["rows"],
+            )
+        result[str(exponent)] = dict(
+            threshold=2.0**exponent,
+            cpu_models=models,
+            historical_gpu_failures={
+                arm: dict(
+                    examples=sum(
+                        r["historical_gpu_failures"][arm]["examples"] for r in screens
+                    ),
+                    detected=sum(
+                        r["historical_gpu_failures"][arm]["detected"] for r in screens
+                    ),
+                    missed=sum(
+                        len(r["historical_gpu_failures"][arm]["missed"])
+                        for r in screens
+                    ),
+                )
+                for arm in ("combo", "split")
+            },
+        )
+    return result
+
+
+def analyze(*, cancellation_screen=False):
+    import torch
+
+    require(os.environ.get("CUDA_VISIBLE_DEVICES") == "", "hide GPUs explicitly")
+    require(not torch.cuda.is_initialized(), "CUDA must remain uninitialized")
+    torch.set_num_threads(1)
+    receipts = {str(RESULTS / name): digest for name, digest in PINS.values()}
+    baseline = None
+    if cancellation_screen:
+        baseline = load_checked(PRECISION_BASELINE, PRECISION_BASELINE_SHA)
+        require(baseline["status"] == "complete", "incomplete precision baseline")
+        receipts[str(PRECISION_BASELINE)] = PRECISION_BASELINE_SHA
+    documents = {
+        key: load_checked(RESULTS / name, digest)
+        for key, (name, digest) in PINS.items()
+    }
+    cases = joined_cases(**documents)
+    weights = load_weights()
+    weight_hashes = {name: tensor_sha(w) for name, w in zip(WEIGHTS, weights)}
+    require(weight_hashes == documents["summary"]["weights"], "real weight drift")
+    weight, bias = weights[2:]
+    records = []
+    for case in cases:
+        for phase in range(2):
+            packed = packed_inputs(
+                case["rows"], case["seed"] + 100 * phase, case["magnitude"]
+            )
+            digest = tensor_sha(packed)
+            require(digest == case["inputs"][phase], "packed input drift")
+            x = packed[:, 2048:2176]
+            reference = layernorm_oracle(x, weight, bias)
+            outputs = modeled_outputs(x, weight, bias)
+            require(
+                torch.equal(outputs["fp64_control"], reference), "FP64 control drift"
+            )
+            records.append(
+                dict(
+                    rows=case["rows"],
+                    seed=case["seed"],
+                    magnitude=case["magnitude"],
+                    phase=phase,
+                    packed_sha256=digest,
+                    indexer_sha256=tensor_sha(x),
+                    oracle_sha256=tensor_sha(reference),
+                    models={
+                        name: dict(
+                            **compare(value, reference),
+                            **mismatch_examples(value, reference),
+                            sha256=tensor_sha(value),
+                        )
+                        for name, value in outputs.items()
+                    },
+                    historical_examples=retained_examples(
+                        case, phase, x, weight, bias, reference
+                    ),
+                )
+            )
+            if cancellation_screen:
+                records[-1]["cancellation_screen"] = screen_cancellation(
+                    outputs, reference, bias, records[-1]["historical_examples"]
+                )
+        print(json.dumps({"completed_unique_cases": len(records) // 2}), flush=True)
+    worst = documents["supplement"]["worst_example"]
+    (case,) = [
+        r
+        for r in records
+        if all(r[k] == worst[k] for k in ("rows", "seed", "magnitude", "phase"))
+    ]
+    (point,) = [
+        r
+        for r in case["historical_examples"]
+        if all(r[k] == worst[k] for k in ("arm", "row", "column"))
+    ]
+    require(
+        point["fp64_result"]
+        == documents["supplement"]["worst_cancellation"]["fp64_result"],
+        "worst FP64 scalar drift",
+    )
+    aggregate = {
+        name: dict(
+            elements=sum(r["models"][name]["elements"] for r in records),
+            bit_mismatches=sum(r["models"][name]["bit_mismatches"] for r in records),
+            above_one_ulp=sum(r["models"][name]["count"] for r in records),
+            failed_phases=sum(r["models"][name]["count"] > 0 for r in records),
+            max_bf16_ulp=max(r["models"][name]["max_bf16_ulp"] for r in records),
+        )
+        for name in MODELS
+    }
+    if baseline is not None:
+        unscreened = [
+            {k: v for k, v in r.items() if k != "cancellation_screen"} for r in records
+        ]
+        require(unscreened == baseline["records"], "CPU precision baseline drift")
+        require(aggregate == baseline["aggregate"], "CPU aggregate drift")
+    require(not torch.cuda.is_initialized(), "unexpected CUDA initialization")
+    for path, digest in receipts.items():
+        require(sha(path) == digest, "completed receipt changed during analysis")
+    sources = [
+        Path(__file__),
+        ROOT / "benchmarks/kernels/check_glm53_attention_norms.py",
+        ROOT / "benchmarks/kernels/check_glm53_cached_rmsnorm.py",
+        ROOT / "benchmarks/analyze_glm53_reduction_receipts.py",
+    ]
+    return dict(
+        status="complete",
+        scope=__doc__,
+        receipts=receipts,
+        source_sha256={str(p): sha(p) for p in sources},
+        source_commit=subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True
+        ).strip(),
+        tracked_worktree_diff_sha256=hashlib.sha256(
+            subprocess.check_output(["git", "diff", "HEAD"], cwd=ROOT)
+        ).hexdigest(),
+        torch=torch.__version__,
+        threads=torch.get_num_threads(),
+        device="cpu",
+        weights=weight_hashes,
+        unique_cases=len(cases),
+        phases=len(records),
+        all_four_rank_records_exact=True,
+        historical_indexer_oracle_pass=False,
+        production_qualified=False,
+        gpu_run=False,
+        model_descriptions=MODELS,
+        aggregate=aggregate,
+        cancellation_screen=aggregate_screen(records) if cancellation_screen else None,
+        cancellation_screen_limitation=(
+            "Coverage on CPU proxy outputs and retained GPU failing scalars only. "
+            "CPU row/element fractions are not GPU counts, timings or a bound "
+            "for unseen inputs. No extended-precision recomputation kernel "
+            "has been implemented or qualified."
+        )
+        if cancellation_screen
+        else None,
+        worst_historical_point=point,
+        records=records,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--screen-cancellation", action="store_true")
+    args = parser.parse_args()
+    # Exclusive reservation preserves even failed attempts; do not overwrite.
+    with args.output.open("x") as stream:
+        try:
+            result = analyze(cancellation_screen=args.screen_cancellation)
+        except BaseException as error:
+            json.dump({"status": "failed", "error": repr(error)}, stream, indent=2)
+            stream.write("\n")
+            raise
+        json.dump(result, stream, indent=2, allow_nan=False)
+        stream.write("\n")
+    print(
+        json.dumps(
+            {
+                "output": str(args.output),
+                "sha256": sha(args.output),
+                "aggregate": result["aggregate"],
+                "cancellation_screen": result["cancellation_screen"],
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/analyze_routing_journal.py
+++ b/benchmarks/analyze_routing_journal.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Summarize observed expert reuse in actual concurrent decode steps.
+
+Optional bytes are unique weight footprint, NOT measured DRAM traffic, effective
+bandwidth, or a physical serving ceiling. Use hardware counters for those claims.
+"""
+
+import argparse
+import collections
+import json
+import statistics
+from pathlib import Path
+
+
+def distribution(values):
+    return {
+        "count": len(values),
+        "min": min(values),
+        "median": statistics.median(values),
+        "mean": statistics.mean(values),
+        "max": max(values),
+    }
+
+
+def analyze(path, per_expert_bytes=None):
+    groups = collections.defaultdict(list)
+    kinds = collections.Counter()
+    header = None
+    with path.open() as stream:
+        for line in stream:
+            row = json.loads(line)
+            kind = row["kind"]
+            kinds[kind] += 1
+            if kind == "header":
+                if header is not None or row["schema"] != 1:
+                    raise ValueError("unsupported or repeated journal header")
+                header = row
+            elif kind == "invalid":
+                raise ValueError(f"invalid routing capture retained in {path}")
+            elif kind == "decode":
+                if header is None:
+                    raise ValueError("decode record before header")
+                routes = row["routes"]
+                batch = len(row["request_ids"])
+                layers = header["num_layers"] - header["first_moe_layer"]
+                top_k = header["top_k"]
+                if len(routes) != batch or any(len(r) != layers for r in routes):
+                    raise ValueError("invalid recorded routing dimensions")
+                uniques, max_loads, padded = [], [], []
+                for layer in range(layers):
+                    selected = [r[layer] for r in routes]
+                    if any(
+                        len(ids) != top_k
+                        or len(set(ids)) != top_k
+                        or any(not 0 <= e < header["num_experts"] for e in ids)
+                        for ids in selected
+                    ):
+                        raise ValueError("invalid recorded expert IDs")
+                    counts = collections.Counter(e for ids in selected for e in ids)
+                    uniques.append(len(counts))
+                    max_loads.append(max(counts.values()))
+                    # Current BF16-input Marlin small-decode tile is eight rows.
+                    padded.append(sum((n + 7) // 8 * 8 for n in counts.values()))
+                groups[batch].append(
+                    {
+                        "step": row["step"],
+                        "unique_experts_by_layer": uniques,
+                        "max_tokens_per_expert_by_layer": max_loads,
+                        "marlin_m8_padded_rows_by_layer": padded,
+                    }
+                )
+    if header is None:
+        raise ValueError("empty routing journal")
+    summary = {}
+    for batch, rows in sorted(groups.items()):
+        unique_totals = [sum(r["unique_experts_by_layer"]) for r in rows]
+        item = {
+            "steps": len(rows),
+            "unique_experts_per_layer": distribution(
+                [v for r in rows for v in r["unique_experts_by_layer"]]
+            ),
+            "sum_layer_unique_experts": distribution(unique_totals),
+            "max_tokens_per_expert": max(
+                v for r in rows for v in r["max_tokens_per_expert_by_layer"]
+            ),
+            "marlin_m8_route_utilization": distribution(
+                [
+                    batch
+                    * header["top_k"]
+                    * len(r["unique_experts_by_layer"])
+                    / sum(r["marlin_m8_padded_rows_by_layer"])
+                    for r in rows
+                ]
+            ),
+        }
+        if per_expert_bytes is not None:
+            item["unique_weight_footprint_bytes_not_dram"] = distribution(
+                [total * per_expert_bytes for total in unique_totals]
+            )
+        summary[batch] = item
+    return {
+        "path": str(path),
+        "header": header,
+        "record_kinds": dict(kinds),
+        "assumed_bytes_per_expert_per_layer_per_rank": per_expert_bytes,
+        "summary": summary,
+        "steps": dict(groups),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("journal", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--per-expert-bytes", type=int)
+    args = parser.parse_args()
+    if args.output.exists():
+        parser.error("output already exists")
+    if args.per_expert_bytes is not None and args.per_expert_bytes < 1:
+        parser.error("per-expert bytes must be positive")
+    result = analyze(args.journal, args.per_expert_bytes)
+    with args.output.open("x") as stream:
+        json.dump(result, stream, indent=2)
+        stream.write("\n")
+    print(json.dumps(result["summary"], indent=2))
+    if not result["summary"]:
+        raise SystemExit("no decode observations captured; summary retained")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/analyze_routing_journal.py
+++ b/benchmarks/analyze_routing_journal.py
@@ -31,6 +31,10 @@ def analyze(path, per_expert_bytes=None):
         for line in stream:
             row = json.loads(line)
             kind = row["kind"]
+            if kind not in {
+                "header", "decode", "invalid", "skip", "limit", "step_limit"
+            }:
+                raise ValueError(f"unsupported schema-1 routing record kind: {kind!r}")
             kinds[kind] += 1
             if kind == "header":
                 if header is not None or row["schema"] != 1:

--- a/benchmarks/kernels/audit_glm53_indexer_correction_graphs.py
+++ b/benchmarks/kernels/audit_glm53_indexer_correction_graphs.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Inspect the actual AOT target dispatch, static image and selection arena."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from benchmarks.analyze_glm53_quality_pair import require
+from benchmarks.kernels.audit_glm53_geometry_graphs import graph_inventory
+from benchmarks.kernels.glm53_indexer_correction_loader import (
+    SCHEMA,
+    BoundIndexerCorrection,
+    check_adapter,
+)
+from benchmarks.kernels.glm53_kv_loader import check_launcher, check_source
+from slimserve.rmsnorm_diagnostic import single_launcher_receipt
+
+
+def inventory(modules, manifest, rank, mode, observer):
+    require(
+        manifest["schema"] == SCHEMA and mode in ("control", "correction"),
+        "invalid correction audit",
+    )
+
+    def check_target(tuner, target):
+        private = Path(manifest["private_namespace"])
+        check_source(target, private)
+        check_source(target["correction"], private)
+        combo = tuner.launchers[0]
+        check_launcher(tuner.compile_results[0], combo, target, observer)
+        run = vars(tuner).get("run")
+        require(
+            run is not None
+            and getattr(tuner, "_cached_launcher", None) is None
+            and tuner.save_cache_hook is None,
+            "correction direct dispatch missing",
+        )
+        if mode == "control":
+            require(run is combo, "control does not directly launch original")
+            return dict(dispatch="direct_combo", appended=None)
+        adapter = getattr(run, "__self__", None)
+        require(
+            getattr(run, "__func__", None) is BoundIndexerCorrection.run,
+            "correction adapter bypassed",
+        )
+        extra = getattr(adapter, "correction", None)
+        check_adapter(adapter, combo, extra, manifest["selection_capacity"])
+        kernel = getattr(
+            getattr(extra, "__globals__", {}).get("runner"), "__self__", None
+        )
+        require(kernel is not None, "correction has no actual static runner")
+        compiled = SimpleNamespace(kernel=kernel)
+        check_launcher(compiled, extra, target["correction"], observer)
+        require(str(adapter.device) == f"cuda:{rank}", "selection arena on wrong rank")
+        return dict(
+            dispatch="combo_then_indexer_correction",
+            appended=dict(
+                source=target["correction"]["relative"],
+                source_sha256=target["correction"]["source_sha256"],
+                selected=single_launcher_receipt(extra),
+                cubin_sha256=observer.digest(compiled),
+                observed_binary_index=observer.records[id(kernel)]["index"],
+                selection_capacity=adapter.capacity,
+                selection_bytes=adapter.storage.numel(),
+                selection_dtype="uint8",
+                selection_device=str(adapter.device),
+            ),
+        )
+
+    return graph_inventory(modules, manifest, rank, observer, check_target)

--- a/benchmarks/kernels/audit_glm53_indexer_correction_loader.py
+++ b/benchmarks/kernels/audit_glm53_indexer_correction_loader.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Independent correction AOT graph/driver/leaf joins; CPU only."""
+
+import argparse
+import sys
+from pathlib import Path
+
+from benchmarks.kernels import audit_glm53_kv_loader as common
+from benchmarks.kernels.check_glm53_attention_norms import require
+from benchmarks.kernels.check_glm53_indexer_correction_loader import (
+    ORDER as ORDER,
+)
+from benchmarks.kernels.check_glm53_indexer_correction_loader import (
+    prior_receipts as prior_receipts,
+)
+from benchmarks.kernels.check_glm53_indexer_correction_loader import (
+    read_manifest as read_manifest,
+)
+from benchmarks.kernels.glm53_indexer_bound_leaves import (
+    audit_leaf,
+    expected_bindings,
+    expected_cases,
+)
+from slimserve.rmsnorm_diagnostic import sha
+
+CANDIDATE_MODE = EXTRA_KEY = "correction"
+EVENT_PREFIX = "indexer_correction"
+DISPATCH = "combo_then_indexer_correction"
+LOADER_SOURCE = Path(__file__).with_name("glm53_indexer_correction_loader.py")
+RUNNER_SOURCE = Path(__file__).with_name("check_glm53_indexer_correction_loader.py")
+PAIR_FIELDS = ("leaf_cases",)
+EXPECTED_WEIGHTS = 4
+SCOPE = (
+    "Actual AOT/driver/binding and synthetic leaf replay qualification; "
+    "not model/TPS qualification."
+)
+
+
+def check_extra(extra, manifest):
+    capacity = manifest["selection_capacity"]
+    require(
+        extra["selection_capacity"] == capacity
+        and extra["selection_bytes"] == (capacity + 2) * 128
+        and extra["selection_dtype"] == "uint8"
+        and extra["selection_device"] == f"cuda:{manifest['rank']}",
+        "selection arena receipt differs",
+    )
+
+
+def check_leaf(manifest, graphs, summary, read):
+    output = Path(manifest["cache_root"]).parent / "run"
+    path = output / "bound-leaves.json"
+    leaves = read(path)
+    bindings, cases = expected_bindings(graphs), expected_cases(manifest)
+    require(
+        leaves["status"] == "complete"
+        and leaves["bindings"] == bindings
+        and len(bindings) == 2
+        and len(cases) == 30
+        and leaves["cases"] == len(leaves["records"]) == 60
+        and summary["leaf_qualification"] == dict(cases=60, sha256=sha(path)),
+        "bound-leaf qualification incomplete",
+    )
+    for index, (binding, case) in enumerate((b, c) for b in bindings for c in cases):
+        receipt = leaves["records"][index]
+        name = f"leaf-{index:03d}.json"
+        require(
+            receipt["path"] == name and sha(output / name) == receipt["sha256"],
+            "leaf receipt changed/reordered",
+        )
+        audit_leaf(read(output / name), binding, case, manifest["mode"])
+    return dict(leaf_cases=60, leaf_phase_observations=300)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("audit", "compare"))
+    parser.add_argument("path", type=Path)
+    args = parser.parse_args()
+    if args.action == "audit":
+        raise SystemExit(
+            0 if common.audit(args.path, workflow=sys.modules[__name__]) else 1
+        )
+    common.compare(args.path.resolve(), workflow=sys.modules[__name__])
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_glm53_indexer_order_fusion.py
+++ b/benchmarks/kernels/benchmark_glm53_indexer_order_fusion.py
@@ -1,0 +1,434 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qualify and time the native selected-pool ordering fusion, not serving TPS.
+
+Replay mode: actual layer23 inputs on each original GPU; both arms receive one
+warmup, five eager and five graph calls, all88 outputs archived. Timing mode:
+GPU0, fixed five A/B/A rounds for actual prefill and synthetic decode geometry,
+both warm-cache graph throughput and separately eviction-conditioned latency.
+No automatic retries, source edits, frequency changes or serving activation.
+"""
+
+import argparse
+import json
+import statistics
+import subprocess
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.compare_cuda_sass import body_sha, function_bodies
+from benchmarks.kernels.replay_glm53_indexer import sha, tensor_sha, verified_selection
+from benchmarks.kernels.replay_glm53_indexer_ties import (
+    canonical_selection,
+    replay_device,
+)
+
+
+def verify_assertion_only_changes(before, after):
+    """Exact exception for relocated assertion metadata, never selection math."""
+    assert before.keys() == after.keys()
+    changed = [pc for pc in before if before[pc] != after[pc]]
+    assert changed == [0xF0, 0x100, 0x110, 0x130], changed
+    assert "@!P0 BRA P1, 0x200" in before[0xE0]
+    assert "CALL.ABS.NOINC R2" in before[0x1E0]
+    # The unchanged valid-input branch skips [0xf0,0x200). All other instructions
+    # and ALL scheduling/control words, including these four, must stay exact.
+    for pc in changed:
+        assert before[pc].split("\n")[1] == after[pc].split("\n")[1]
+    return [dict(pc=hex(pc), before=before[pc], after=after[pc]) for pc in changed]
+
+
+def verify_generic_decode_qualification(control, candidate, proof, test_source):
+    """Accept only the fixed matched test corpus on the exact two binaries."""
+    cases = []
+    for path, arm in ((control, "before"), (candidate, "candidate")):
+        root = ET.parse(path).getroot()
+        for suite in root.iter("testsuite"):
+            assert all(
+                int(suite.get(key, 0)) == 0 for key in ("failures", "errors", "skipped")
+            )
+        tests = list(root.iter("testcase"))
+        assert len(tests) == 32
+        for test in tests:
+            assert not any(
+                test.find(key) is not None for key in ("failure", "error", "skipped")
+            )
+            props = {
+                p.attrib["name"]: p.attrib["value"]
+                for p in test.findall("./properties/property")
+            }
+            assert props["native_sha256"] == proof[arm + "_binary"]["sha256"]
+            assert props["test_source_sha256"] == sha(test_source)
+            assert test.attrib["name"].startswith(
+                "test_single_block_decode_changed_inputs["
+            )
+        cases.append(sorted((t.attrib["classname"], t.attrib["name"]) for t in tests))
+        assert len(set(cases[-1])) == 32
+    assert cases[0] == cases[1]
+    return dict(
+        tests_per_binary=32,
+        scope=(
+            "generic insertion/radix score sets, bounds and changed-input graphs; "
+            "not GLM serving"
+        ),
+        sources={str(p): sha(p) for p in (control, candidate, test_source)},
+    )
+
+
+def verify_native_comparison(proof, directory, generic_qualification=None):
+    assert not proof["removed_functions"]
+    name = "arch = sm_120f _ZN4vllm22glm53TopKPerRowPrefillEPKfPKiS3_Pii"
+    added = "arch = sm_120f _ZN4vllm22glm53TopKPerRowOrderedEPKfPKiS3_Pii"
+    assert proof["before_functions"] == 4188 and proof["candidate_functions"] == 4189
+    extra = set(proof["changed_common_functions"]) - {name}
+    if extra:
+        expected = {
+            f"arch = sm_120f _ZN4vllm16topKPerRowDecodeILi512ELb{radix}"
+            "ELb0ELb0EEEvPKfPKiPiiiiiiPfiS4_"
+            for radix in (0, 1)
+        }
+        assert extra == expected and generic_qualification is not None
+    assert proof["identical_common_functions"] == 4187 - len(extra)
+    assert set(proof["changed_common_functions"]) == {name} | extra
+    assert set(proof["added_functions"]) == {name, added} | extra
+
+    def read_body(path, arm):
+        with path.open() as stream:
+            for symbol, body in function_bodies(stream):
+                if symbol == name:
+                    assert proof["bodies"][name][arm + "_instances"] == {
+                        body_sha(body): 1
+                    }
+                    return body
+        raise AssertionError("missing captured selector body")
+
+    before = read_body(directory / "before.sass", "before")
+    after = read_body(directory / "candidate.sass", "candidate")
+    assert sha(directory / "before.sass") == proof["before_sass"]["sha256"]
+    assert sha(directory / "candidate.sass") == proof["candidate_sass"]["sha256"]
+    return dict(
+        all4187_other_function_copies_identical=not extra,
+        identical_other_function_copies=4187 - len(extra),
+        generic_decode_codegen_changes=sorted(extra),
+        generic_decode_qualification=generic_qualification,
+        valid_input_selector_instructions_identical=True,
+        assertion_only_changes=verify_assertion_only_changes(before, after),
+        raw_sha256={
+            name: sha(directory / name) for name in ("before.sass", "candidate.sass")
+        },
+    )
+
+
+def load_capture(run, device):
+    matches = []
+    for path in (run / "trace").glob("index-*.jsonl"):
+        events = [json.loads(line) for line in path.read_text().splitlines()]
+        forward = next(e for e in events if e["kind"] == "forward_begin")
+        if forward["device"] == f"cuda:{device}":
+            matches.append((path, events))
+    assert len(matches) == 1
+    path, events = matches[0]
+    assert events[0]["capture_layer"] == 23
+    assert events[0]["selection_ties"] == "smaller-pool-id"
+    assert len([e for e in events if e["kind"] == "request_complete"]) == 3
+    captured, files = {}, []
+    for stage in ("logits", "starts", "ends", "indices"):
+        items = [
+            e
+            for e in events
+            if e["kind"] == "tensor"
+            and e["chunk"] == 1
+            and e["stage"] == f"layer-23.call-0.{stage}"
+        ]
+        assert [e["match"] for e in items] == [1, 2, 3]
+        assert len({e["sha256"] for e in items}) == 1
+        item = items[0]
+        archive = Path(item["archive"]["path"])
+        assert sha(archive) == item["archive"]["sha256"]
+        assert archive.stat().st_size == item["archive"]["bytes"]
+        value = torch.load(archive, weights_only=True, map_location="cpu")
+        assert tensor_sha(value) == item["sha256"]
+        captured[stage] = value
+        files.append(dict(stage=stage, path=str(archive), sha256=sha(archive)))
+    _, ties = verified_selection(**captured)
+    assert ties == 1 and captured["logits"].shape == (7616, 1904)
+    expected = canonical_selection(*(captured[k] for k in ("logits", "starts", "ends")))
+    assert torch.equal(expected, captured["indices"])
+    return (
+        captured,
+        expected,
+        dict(
+            journal=str(path),
+            journal_sha256=sha(path),
+            inputs=files,
+            canonical_oracle_sha256=tensor_sha(expected),
+        ),
+    )
+
+
+def replay(args, result, save, operations, canonicalize):
+    for device in range(4):
+        captured, expected, provenance = load_capture(args.run, device)
+        observations, outputs = [], []
+        for label, operation in operations.items():
+            rows, matrices = replay_device(
+                captured,
+                expected,
+                device,
+                "canonical-ties",
+                operation,
+                canonicalize if label == "post-sort" else lambda _: None,
+            )
+            # Both arms require exact CPU-oracle equality in the shared replay.
+            for row in rows:
+                row["selector"] = label
+            observations.extend(rows)
+            outputs.extend(matrices)
+        archive = args.output / f"gpu-{device}-all22-outputs.pt"
+        with archive.open("xb") as stream:
+            torch.save(torch.stack(outputs), stream)
+        result["replays"].append(
+            dict(
+                device=device,
+                **provenance,
+                observations=observations,
+                output_archive=dict(
+                    path=str(archive), sha256=sha(archive), bytes=archive.stat().st_size
+                ),
+            )
+        )
+        save()
+        print(
+            json.dumps(dict(device=device, verified_calls=len(observations))),
+            flush=True,
+        )
+
+
+def timing_cases(captured):
+    # Actual first prefill chunk and last583 rows: preserve the real cutoff tie.
+    for begin, end in ((0, 7616), (7033, 7616)):
+        yield (
+            f"actual-prefill-{end - begin}",
+            {k: captured[k][begin:end].clone() for k in ("logits", "starts", "ends")},
+        )
+    # Registered decode has physical262144 columns even for a short context.
+    # These are synthetic score distributions, not captured decode inputs.
+    for rows in (1, 8, 16, 64):
+        for visible in (250, 8192, 32768, 262144):
+            generator = torch.Generator().manual_seed(9711 + rows + visible)
+            logits = torch.zeros(rows, 262144)
+            logits[:, :visible] = torch.randn(rows, visible, generator=generator)
+            yield (
+                f"synthetic-decode-{rows}-visible-{visible}",
+                dict(
+                    logits=logits,
+                    starts=torch.zeros(rows, dtype=torch.int32),
+                    ends=torch.full((rows,), visible, dtype=torch.int32),
+                ),
+            )
+
+
+def make_call(operation, label, logits, starts, ends, output, canonicalize):
+    rows, columns = logits.shape
+
+    def call():
+        operation(logits, starts, ends, output, rows, columns, 1, 512)
+        if label == "post-sort":
+            canonicalize(output)
+
+    return call
+
+
+def measure(args, result, save, operations, canonicalize):
+    captured, _, provenance = load_capture(args.run, 0)
+    result["timing_input_provenance"] = provenance
+    eviction = torch.zeros(256 * 2**20 // 4, device="cuda", dtype=torch.float32)
+    for name, values in timing_cases(captured):
+        expected = canonical_selection(
+            *(values[k] for k in ("logits", "starts", "ends"))
+        )
+        logits, starts, ends = (values[k].cuda() for k in ("logits", "starts", "ends"))
+        output = torch.empty_like(expected, device="cuda")
+        rows, columns = logits.shape
+        graphs = {}
+        for label, operation in operations.items():
+            call = make_call(
+                operation, label, logits, starts, ends, output, canonicalize
+            )
+            call()
+            assert torch.equal(output.cpu(), expected)
+            for count in (1, 20):
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph):
+                    for _ in range(count):
+                        call()
+                graph.replay()
+                assert torch.equal(output.cpu(), expected)
+                graphs[label, count] = graph
+        item = dict(
+            name=name,
+            shape=[rows, columns],
+            expected_sha256=tensor_sha(expected),
+            visible_range=[int(ends.min()), int(ends.max())],
+            rounds=[],
+        )
+        result["timings"].append(item)
+        for repeat in range(5):
+            record = dict(repeat=repeat + 1)
+            item["rounds"].append(record)
+            for phase, label in (
+                ("A", "post-sort"),
+                ("B", "fused"),
+                ("A2", "post-sort"),
+            ):
+                for _ in range(3):
+                    graphs[label, 20].replay()
+                start, end = (torch.cuda.Event(enable_timing=True) for _ in range(2))
+                start.record()
+                for _ in range(5):
+                    graphs[label, 20].replay()
+                end.record()
+                end.synchronize()
+                warm_us = start.elapsed_time(end) * 1000 / 100
+                cold_us = []
+                for _ in range(10):
+                    # Same stream, outside timing: read/write twice the L2 size.
+                    # Report as eviction-conditioned, not measured DRAM traffic.
+                    eviction.add_(1)
+                    start.record()
+                    graphs[label, 1].replay()
+                    end.record()
+                    end.synchronize()
+                    cold_us.append(start.elapsed_time(end) * 1000)
+                assert torch.equal(output.cpu(), expected)
+                record[phase] = dict(warm_us=warm_us, eviction_conditioned_us=cold_us)
+                save()
+        item["median_us"] = {
+            phase: dict(
+                warm=statistics.median(r[phase]["warm_us"] for r in item["rounds"]),
+                eviction_conditioned=statistics.median(
+                    v
+                    for r in item["rounds"]
+                    for v in r[phase]["eviction_conditioned_us"]
+                ),
+            )
+            for phase in ("A", "B", "A2")
+        }
+        print(json.dumps(dict(name=name, median_us=item["median_us"])), flush=True)
+        save()
+        del graphs, graph, call, values, logits, starts, ends, output
+    torch.cuda.synchronize()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=("replay", "timing"))
+    parser.add_argument("--run", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--native-comparison", required=True, type=Path)
+    parser.add_argument("--generic-decode-control-tests", type=Path)
+    parser.add_argument("--generic-decode-candidate-tests", type=Path)
+    args = parser.parse_args()
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"],
+        text=True,
+    ).strip()
+    assert not active, f"GPU compute processes already active: {active}"
+    from slimserve.canonical_indexer import canonicalize, enabled
+    from vllm import _custom_ops as ops
+
+    assert not enabled()
+    assert torch.cuda.device_count() == 4
+    assert all(torch.cuda.get_device_capability(i) == (12, 0) for i in range(4))
+    torch.set_num_threads(1)
+    torch.cuda.set_device(0)
+    root = Path(__file__).resolve().parents[2]
+    native = root / "vllm/_C_stable_libtorch.abi3.so"
+    receipt = json.loads((args.run / "summary.json").read_text())
+    assert receipt["status"] == "complete" and receipt["diagnostic_only"]
+    assert receipt["git_commit"] == "8f79f3b5cb45d6ea11d9451938bc43c1791cccda"
+    proof = json.loads(args.native_comparison.read_text())
+    assert (
+        proof["before_binary"]["sha256"]
+        == receipt["runtime"]["native_sha256"][str(native.relative_to(root))]
+    )
+    assert proof["candidate_binary"]["sha256"] == sha(native)
+    generic_qualification = None
+    if args.generic_decode_control_tests or args.generic_decode_candidate_tests:
+        assert args.generic_decode_control_tests and args.generic_decode_candidate_tests
+        generic_qualification = verify_generic_decode_qualification(
+            args.generic_decode_control_tests,
+            args.generic_decode_candidate_tests,
+            proof,
+            root / "tests/kernels/test_sparse_topk_indices.py",
+        )
+    binary_check = verify_native_comparison(
+        proof, args.native_comparison.parent, generic_qualification
+    )
+    args.output.mkdir(parents=True, exist_ok=False)
+    sources = (
+        "benchmarks/kernels/benchmark_glm53_indexer_order_fusion.py",
+        "benchmarks/kernels/compare_cuda_sass.py",
+        "benchmarks/kernels/replay_glm53_indexer_ties.py",
+        "benchmarks/kernels/replay_glm53_indexer.py",
+        "slimserve/canonical_indexer.py",
+        "slimserve/canonical_indexer_kernel.py",
+        "csrc/libtorch_stable/sampler.cu",
+        "tests/kernels/test_sparse_topk_indices.py",
+        "vllm/_custom_ops.py",
+    )
+
+    def environment():
+        return subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-gpu=index,name,temperature.gpu,clocks.sm,clocks.mem,power.draw",
+                "--format=csv,noheader",
+            ],
+            text=True,
+        )
+
+    result = dict(
+        status="running",
+        diagnostic_only=True,
+        mode=args.mode,
+        protocol=__doc__,
+        git_commit=subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True
+        ).strip(),
+        git_status=subprocess.check_output(["git", "status", "--short"], text=True),
+        sources={name: sha(root / name) for name in sources},
+        native_sha256=sha(native),
+        torch=torch.__version__,
+        source_receipt=dict(
+            path=str(args.run / "summary.json"), sha256=sha(args.run / "summary.json")
+        ),
+        native_comparison=dict(
+            path=str(args.native_comparison), sha256=sha(args.native_comparison)
+        ),
+        binary_check=binary_check,
+        environment_before=environment(),
+        replays=[],
+        timings=[],
+    )
+
+    def save():
+        (args.output / "summary.json").write_text(json.dumps(result, indent=2) + "\n")
+
+    save()
+    operations = {
+        "post-sort": ops.glm53_top_k_per_row_prefill,
+        "fused": ops.glm53_top_k_per_row_ordered,
+    }
+    (replay if args.mode == "replay" else measure)(
+        args, result, save, operations, canonicalize
+    )
+    assert sha(native) == result["native_sha256"]
+    assert all(sha(root / name) == digest for name, digest in result["sources"].items())
+    result.update(status="complete", environment_after=environment())
+    save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_glm53_indexer_shard.py
+++ b/benchmarks/kernels/benchmark_glm53_indexer_shard.py
@@ -156,6 +156,26 @@ def measure(call, group):
     return values
 
 
+def compare_outputs(a, b, group):
+    """Collect every rank's independent pool-set, tail and ordering checks."""
+    local = {
+        "pool_sets_equal": torch.equal(
+            a[:, :2048].sort(1).values, b[:, :2048].sort(1).values
+        ),
+        "tail_equal": torch.equal(a[:, 2048:], b[:, 2048:]),
+        "order_equal": torch.equal(a, b),
+    }
+    ranks = [None] * group.world_size
+    dist.all_gather_object(ranks, local, group=group.cpu_group)
+    return {
+        "per_rank": ranks,
+        "rank0_order_equal": ranks[0]["order_equal"],
+        "sets_and_tail_exact_all_ranks": all(
+            row["pool_sets_equal"] and row["tail_equal"] for row in ranks
+        ),
+    }
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output", type=Path, required=True)
@@ -211,19 +231,26 @@ def main():
             candidate()
             # Existing selector has unordered atomic publication; require exact
             # selected sets AND exact tail, report ordering separately.
-            torch.testing.assert_close(
-                a[:, :2048].sort(1).values, b[:, :2048].sort(1).values, rtol=0, atol=0
-            )
-            torch.testing.assert_close(a[:, 2048:], b[:, 2048:], rtol=0, atol=0)
-            ordering_equal = torch.equal(a, b)
+            row = {
+                "rows": rows,
+                "context": context,
+                "ragged": ragged,
+                **compare_outputs(a, b, group),
+                "samples": [],
+            }
+            result["cases"].append(row)
+            save()
+            assert row["sets_and_tail_exact_all_ranks"], row["per_rank"]
             if ragged:
                 data[0].mul_(0.5)
                 control()
                 candidate()
-                torch.testing.assert_close(
-                    a.sort(1).values, b.sort(1).values, rtol=0, atol=0
+                row["changed_input"] = compare_outputs(a, b, group)
+                save()
+                assert row["changed_input"]["sets_and_tail_exact_all_ranks"], (
+                    row["changed_input"]["per_rank"]
                 )
-            samples = []
+            samples = row["samples"]
             if not ragged:
                 for _ in range(3):
                     samples.append(
@@ -233,20 +260,11 @@ def main():
                             "after_ms": measure(control, group),
                         }
                     )
-            row = {
-                "rows": rows,
-                "context": context,
-                "ragged": ragged,
-                "rank0_order_equal": ordering_equal,
-                "sets_and_tail_exact_all_ranks": True,
-                "samples": samples,
-            }
             if samples:
                 row["median_slowest_rank_ms"] = {
                     name: statistics.median(max(s[name]) for s in samples)
                     for name in samples[0]
                 }
-            result["cases"].append(row)
             if rank == 0:
                 print(json.dumps(row), flush=True)
             save()

--- a/benchmarks/kernels/benchmark_glm53_indexer_shard.py
+++ b/benchmarks/kernels/benchmark_glm53_indexer_shard.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Phase4.5 complete TP4 prefill indexer: row ownership + pool-ID exchange.
+
+Precedent: vLLM #54951, b466281a9ab20e483444736f85d650418ca40d44.
+Adaptation: exchange 512 pool IDs before 4x expansion, once per forward, with
+equal contiguous row ownership and padded all-gather. Preserve every arithmetic
+kernel. Fixed 7616-row/32K and /128K windows, three A/B/A rounds x five repeats.
+Synthetic replicated Q/cache/weights; not serving TPS or a model-quality result.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import statistics
+import subprocess
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+import torch.distributed as dist
+
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.distributed import (
+    destroy_distributed_environment,
+    destroy_model_parallel,
+    get_tp_group,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from vllm.model_executor.layers import glm5_next_indexer as gi
+
+
+def sharded_prefill(q, weights, ape, cache, chunks, output, group):
+    """Probe implementation; chunks use global query offsets and original req IDs."""
+    rows = q.shape[0]
+    owned = (rows + group.world_size - 1) // group.world_size
+    start = group.rank_in_group * owned
+    stop = min(start + owned, rows)
+    local = torch.full((owned, 512), -1, device=q.device, dtype=torch.int32)
+    for chunk in chunks:
+        lo, hi = max(start, chunk.start), min(stop, chunk.stop)
+        if lo >= hi:
+            continue
+        offset = slice(lo - chunk.start, hi - chunk.start)
+        logits = torch.empty((hi - lo, chunk.pools), device=q.device)
+        local[lo - start : hi - start] = gi._pooled_topk(
+            q[lo:hi],
+            weights[lo:hi],
+            ape,
+            cache,
+            chunk.block_table,
+            chunk.row_req[offset],
+            chunk.visible[offset],
+            logits,
+            chunk.pools,
+            64,
+            128**-0.5,
+            512,
+            4,
+            by_request=True,
+        )
+    gathered = group.all_gather(local, dim=0)
+    # Each original chunk keeps its own visibility/tail, including request edges.
+    for chunk in chunks:
+        selected = gathered[chunk.start : chunk.stop]
+        gi._expand_topk_kernel[(chunk.stop - chunk.start,)](
+            selected,
+            chunk.visible,
+            output[chunk.start : chunk.stop],
+            selected.stride(0),
+            KP=4,
+            KSEL=512,
+            OUT_W=2051,
+            BLOCK_S=64,
+        )
+
+
+def baseline(q, weights, ape, cache, chunks, output):
+    for c in chunks:
+        rows = c.stop - c.start
+        gi._pooled_select(
+            q[c.start : c.stop],
+            weights[c.start : c.stop],
+            ape,
+            cache,
+            c.block_table,
+            c.row_req,
+            c.visible,
+            torch.empty((rows, c.pools), device=q.device),
+            c.pools,
+            64,
+            128**-0.5,
+            512,
+            output[c.start : c.stop],
+            4,
+            by_request=True,
+        )
+
+
+def make_case(rows, context, ragged=False):
+    dev = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+    q = torch.randn(rows, 32, 128, device=dev, dtype=torch.bfloat16)
+    weights = torch.rand(rows, 32, device=dev) * (32**-0.5)
+    ape = torch.randn(4, 128, device=dev)
+    requests = 2 if ragged else 1
+    blocks = (context + 63) // 64
+    # A noncontiguous page view catches accidental flat-cache assumptions.
+    cache = torch.randn(
+        requests * blocks, 2, 64, 256, device=dev, dtype=torch.bfloat16
+    )[:, 0]
+    block_table = torch.arange(requests * blocks, device=dev, dtype=torch.int32).view(
+        requests, blocks
+    )
+    visible = torch.arange(
+        context - rows + 1, context + 1, device=dev, dtype=torch.int32
+    )
+    row_req = torch.zeros(rows, device=dev, dtype=torch.int32)
+    if ragged:
+        boundary = rows // 3
+        row_req[boundary:] = 1
+        visible[:boundary] = torch.arange(1, boundary + 1, device=dev)
+    # The metadata's 512 MiB limit uses unpooled token extents; our pooled
+    # score allocation is 4x narrower (128 MiB), matching recorded subchunks.
+    chunk_rows = max(1, (128 * 1024 * 1024) // (4 * (context // 4)))
+    chunks = [
+        SimpleNamespace(
+            start=i,
+            stop=min(rows, i + chunk_rows),
+            pools=context // 4,
+            block_table=block_table,
+            row_req=row_req[i : i + chunk_rows],
+            visible=visible[i : i + chunk_rows],
+        )
+        for i in range(0, rows, chunk_rows)
+    ]
+    return q, weights, ape, cache, chunks
+
+
+def measure(call, group):
+    # Eager prefill: wall time includes launches, allocation and the real TP
+    # collective. Synchronize each whole window, not its individual kernels.
+    for _ in range(2):
+        call()
+    torch.cuda.synchronize()
+    dist.barrier(group=group.cpu_group)
+    start = time.perf_counter()
+    for _ in range(5):
+        call()
+        torch.cuda.synchronize()
+    elapsed = (time.perf_counter() - start) * 1000 / 5
+    values = [None] * group.world_size
+    dist.all_gather_object(values, elapsed, group=group.cpu_group)
+    return values
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    rank = int(os.environ["RANK"])
+    if args.output.exists():
+        parser.error("NEW output required")
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    torch.set_num_threads(2)
+    torch.manual_seed(4501)
+    assert torch.cuda.get_device_capability() == (12, 0)
+    assert (gi._ROW_TILE, gi._POOL_TILE) == (2, 128)
+    init_distributed_environment()
+    with set_current_vllm_config(VllmConfig()):
+        initialize_model_parallel(tensor_model_parallel_size=4)
+    group = get_tp_group()
+    assert group.world_size == 4
+    result = {
+        "status": "running",
+        "roadmap": "4.5",
+        "method": __doc__,
+        "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "source_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        "indexer_sha256": hashlib.sha256(Path(gi.__file__).read_bytes()).hexdigest(),
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "cases": [],
+    }
+
+    def save():
+        if rank == 0:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(json.dumps(result, indent=2) + "\n")
+
+    save()
+    try:
+        for rows, context, ragged in (
+            (2177, 32768, True),
+            (7616, 32768, False),
+            (7616, 131072, False),
+        ):
+            data = make_case(rows, context, ragged)
+            a = torch.empty(rows, 2051, device="cuda", dtype=torch.int32)
+            b = torch.empty_like(a)
+
+            def control(data=data, a=a):
+                baseline(*data, a)
+
+            def candidate(data=data, b=b):
+                sharded_prefill(*data, b, group)
+
+            control()
+            candidate()
+            # Existing selector has unordered atomic publication; require exact
+            # selected sets AND exact tail, report ordering separately.
+            torch.testing.assert_close(
+                a[:, :2048].sort(1).values, b[:, :2048].sort(1).values, rtol=0, atol=0
+            )
+            torch.testing.assert_close(a[:, 2048:], b[:, 2048:], rtol=0, atol=0)
+            ordering_equal = torch.equal(a, b)
+            if ragged:
+                data[0].mul_(0.5)
+                control()
+                candidate()
+                torch.testing.assert_close(
+                    a.sort(1).values, b.sort(1).values, rtol=0, atol=0
+                )
+            samples = []
+            if not ragged:
+                for _ in range(3):
+                    samples.append(
+                        {
+                            "before_ms": measure(control, group),
+                            "candidate_ms": measure(candidate, group),
+                            "after_ms": measure(control, group),
+                        }
+                    )
+            row = {
+                "rows": rows,
+                "context": context,
+                "ragged": ragged,
+                "rank0_order_equal": ordering_equal,
+                "sets_and_tail_exact_all_ranks": True,
+                "samples": samples,
+            }
+            if samples:
+                row["median_slowest_rank_ms"] = {
+                    name: statistics.median(max(s[name]) for s in samples)
+                    for name in samples[0]
+                }
+            result["cases"].append(row)
+            if rank == 0:
+                print(json.dumps(row), flush=True)
+            save()
+            del data, a, b, control, candidate
+        result["status"] = "complete"
+    except BaseException as error:
+        result["status"] = "failed"
+        result["error"] = str(error)
+        raise
+    finally:
+        save()
+        destroy_model_parallel()
+        destroy_distributed_environment()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_glm53_indexer_tiles.py
+++ b/benchmarks/kernels/benchmark_glm53_indexer_tiles.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Isolated tile sweep for GLM pooled-indexer scoring on SM120.
+
+Uses the installed serving Triton function, BF16 synthetic queries/pooled keys,
+FP32 head weights, actual long-prefill dimensions and fixed A/B/A rounds.
+Rotating inputs exceed L2. No model, quantization or serving dispatcher changes.
+Correctness requires all visible scores within rtol/atol 1e-5 of the original
+tile, sampled scores within the same tolerance of an independent CPU FP64
+oracle, and identical top-512 sets on predetermined rows. Unsupported configs
+and every failed gate remain in the output; they are never timed as winners.
+"""
+
+import argparse
+import hashlib
+import itertools
+import json
+import statistics
+import subprocess
+from pathlib import Path
+
+import torch
+
+BASELINE = (8, 64, 4)
+
+
+def configurations():
+    return list(itertools.product((1, 2, 4, 8, 16), (32, 64, 128), (4, 8)))
+
+
+def oracle(q, weights, keys, visible, rows, columns):
+    query = q[rows].cpu().double()
+    weight = weights[rows].cpu().double()
+    pooled = keys[0, columns].cpu().double()
+    dots = torch.einsum("rhd,pd->rhp", query, pooled) * (128**-0.5)
+    values = (dots.clamp_min(0) * weight[:, :, None]).sum(1)
+    valid = torch.tensor(columns)[None, :] < (visible[rows].cpu() // 4)[:, None]
+    return values, valid
+
+
+def selected_pools(scores, visible):
+    # Early prefill rows can have fewer than 512 complete pools, including
+    # zero. Never compare arbitrary top-k positions drawn from masked -inf.
+    return [
+        row[:count].topk(min(512, count)).indices.sort().values
+        for row, count in zip(scores, (visible.cpu() // 4).tolist())
+    ]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--rows", type=int, default=2202)
+    parser.add_argument("--pools", type=int, default=15232)
+    parser.add_argument("--prefix", type=int, default=53312)
+    parser.add_argument("--fixtures", type=int, default=8)
+    parser.add_argument("--rounds", type=int, default=3)
+    parser.add_argument("--replays", type=int, default=5)
+    parser.add_argument("--changed-inputs", type=int, default=0)
+    parser.add_argument("--config", type=int, nargs=3, action="append")
+    args = parser.parse_args()
+    if args.output.exists() or not args.output.parent.is_dir():
+        parser.error("new output in an existing directory required")
+    if min(args.rows, args.pools, args.fixtures, args.rounds, args.replays) < 1:
+        parser.error("positive dimensions/counts required")
+    if args.prefix < 0 or args.prefix + args.rows > 4 * args.pools:
+        parser.error("visibility must fit the pooled-key context")
+    if args.changed_inputs < 0:
+        parser.error("changed-input replay count cannot be negative")
+    configs = [tuple(c) for c in args.config] if args.config else configurations()
+    if any(c not in configurations() for c in configs):
+        parser.error("unsupported requested geometry")
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"], text=True
+    ).strip()
+    if active:
+        parser.error(f"GPUs already have compute processes: {active}")
+    torch.set_num_threads(4)
+    from triton.compiler.errors import CompilationError
+    from triton.runtime.errors import OutOfResources
+
+    from vllm.model_executor.layers import glm5_next_indexer as gi
+
+    if BASELINE[:2] != (gi._ROW_TILE, gi._POOL_TILE):
+        raise RuntimeError("serving baseline changed; update the experiment explicitly")
+    visible = torch.arange(1, args.rows + 1, device="cuda", dtype=torch.int32)
+    visible += args.prefix
+    samples = sorted({0, 1, 3, 7, args.rows // 4, args.rows // 2, args.rows - 1})
+    samples = [r for r in samples if r < args.rows]
+    columns = sorted({0, 1, 31, 32, 63, 64, 127, 128, 511, args.pools - 1})
+    columns = [p for p in columns if p < args.pools]
+    fixtures = []
+    for i in range(args.fixtures):
+        generator = torch.Generator(device="cuda").manual_seed(8103 + i)
+        q = torch.randn(
+            (args.rows, 32, 128), generator=generator, device="cuda"
+        ).bfloat16()
+        weights = torch.rand((args.rows, 32), generator=generator, device="cuda") * (
+            32**-0.5
+        )
+        keys = torch.randn(
+            (1, args.pools, 128), generator=generator, device="cuda"
+        ).bfloat16()
+        expected = oracle(q, weights, keys, visible, samples, columns)
+        fixtures.append((q, weights, keys, expected))
+    input_bytes = sum(t.numel() * t.element_size() for row in fixtures for t in row[:3])
+    if input_bytes <= 128 * 1024**2:
+        parser.error("rotating inputs must exceed the SM120 128 MiB L2")
+    tables = {}
+    for rt in {c[0] for c in [BASELINE, *configs]}:
+        tiles = ((gi.triton.cdiv(args.rows, rt) + 1 + 15) // 16) * 16
+        start = torch.arange(tiles, device="cuda", dtype=torch.int32) * rt
+        end = torch.clamp(start + rt, max=args.rows)
+        start = torch.where(start < args.rows, start, 0)
+        end = torch.where(end > start, end, 0)
+        # Empty padded programs must have no query rows, not repeat row zero.
+        end[gi.triton.cdiv(args.rows, rt) :] = 0
+        tables[rt] = (start, end, torch.zeros_like(start))
+
+    record = {
+        "status": "running",
+        "diagnostic_only": True,
+        "method": __doc__,
+        "settings": {
+            k: str(v) if isinstance(v, Path) else v for k, v in vars(args).items()
+        },
+        "input_bytes": input_bytes,
+        "sample_rows": samples,
+        "oracle_columns": columns,
+        "baseline": BASELINE,
+        "source_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        "kernel_source_sha256": hashlib.sha256(
+            Path(gi.__file__).read_bytes()
+        ).hexdigest(),
+        "torch": torch.__version__,
+        "triton": gi.triton.__version__,
+        "gpu": torch.cuda.get_device_name(),
+        "results": [],
+    }
+    with args.output.open("x") as stream:
+        json.dump(record, stream, indent=2)
+
+    def save():
+        args.output.write_text(json.dumps(record, indent=2) + "\n")
+
+    def call(config, fixture, output):
+        rt, pt, warps = config
+        q, weights, keys, _ = fixture
+        starts, ends, requests = tables[rt]
+        return gi._pooled_logits_matmul_kernel[
+            (len(starts), gi.triton.cdiv(args.pools, pt))
+        ](
+            q,
+            weights,
+            keys,
+            starts,
+            ends,
+            requests,
+            visible,
+            output,
+            args.pools,
+            128**-0.5,
+            H=32,
+            D=128,
+            KP=4,
+            RT=rt,
+            PT=pt,
+            num_warps=warps,
+            num_stages=3,
+        )
+
+    def capture(config):
+        outputs = [
+            torch.empty((args.rows, args.pools), device="cuda") for _ in fixtures
+        ]
+        compiled = None
+        for data, output in zip(fixtures, outputs):
+            output.fill_(float("nan"))
+            compiled = call(config, data, output)
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            for data, output in zip(fixtures, outputs):
+                call(config, data, output)
+        return graph, outputs, compiled
+
+    def validate(reference, actual):
+        maximum = 0.0
+        for fixture, expected, got in zip(fixtures, reference, actual):
+            for start in range(0, args.rows, 64):
+                stop = min(start + 64, args.rows)
+                valid = (
+                    torch.arange(args.pools, device="cuda")[None, :]
+                    < (visible[start:stop] // 4)[:, None]
+                )
+                a, b = expected[start:stop][valid], got[start:stop][valid]
+                torch.testing.assert_close(a, b, atol=1e-5, rtol=1e-5)
+                if a.numel():
+                    maximum = max(maximum, (a - b).abs().max().item())
+            values, valid = fixture[3]
+            observed = got[samples][:, columns].cpu().double()
+            torch.testing.assert_close(
+                values[valid], observed[valid], atol=1e-5, rtol=1e-5
+            )
+            wanted = selected_pools(expected[samples], visible[samples])
+            selected = selected_pools(got[samples], visible[samples])
+            if not all(torch.equal(a, b) for a, b in zip(wanted, selected)):
+                raise AssertionError("top-512 sets changed on predetermined rows")
+        return {"max_abs": maximum, "top512_sets_exact": True, "oracle_pass": True}
+
+    def time_graph(graph):
+        start, end = (
+            torch.cuda.Event(enable_timing=True),
+            torch.cuda.Event(enable_timing=True),
+        )
+        start.record()
+        for _ in range(args.replays):
+            graph.replay()
+        end.record()
+        end.synchronize()
+        return start.elapsed_time(end) * 1000 / (args.replays * args.fixtures)
+
+    try:
+        baseline_graph, reference, _ = capture(BASELINE)
+        baseline_graph.replay()
+        torch.cuda.synchronize()
+        record["baseline_check"] = validate(reference, reference)
+        save()
+        for config in configs:
+            row = {"config": config, "status": "running"}
+            record["results"].append(row)
+            save()
+            try:
+                graph, outputs, compiled = capture(config)
+            except (OutOfResources, CompilationError) as error:
+                row.update(status="unsupported", error=str(error))
+                save()
+                print(json.dumps(row), flush=True)
+                continue
+            row["resources"] = {
+                "registers": compiled.n_regs,
+                "spills": compiled.n_spills,
+                "shared_bytes": compiled.metadata.shared,
+            }
+            graph.replay()
+            torch.cuda.synchronize()
+            try:
+                row["check"] = validate(reference, outputs)
+                row["changed_input_checks"] = []
+                for replay in range(args.changed_inputs):
+                    for i, (q, weights, keys, _) in enumerate(fixtures):
+                        generator = torch.Generator(device="cuda").manual_seed(
+                            17103 + replay * 97 + i
+                        )
+                        q.normal_(generator=generator)
+                        keys.normal_(generator=generator)
+                        weights.uniform_(0, 32**-0.5, generator=generator)
+                        expected = oracle(q, weights, keys, visible, samples, columns)
+                        fixtures[i] = (q, weights, keys, expected)
+                    baseline_graph.replay()
+                    graph.replay()
+                    torch.cuda.synchronize()
+                    row["changed_input_checks"].append(validate(reference, outputs))
+            except AssertionError as error:
+                row.update(status="failed_gates", error=str(error))
+                del graph, outputs
+                save()
+                print(json.dumps(row), flush=True)
+                continue
+            for _ in range(3):
+                baseline_graph.replay()
+                graph.replay()
+            torch.cuda.synchronize()
+            timings = []
+            for i in range(args.rounds):
+                a, b, a2 = (
+                    time_graph(baseline_graph),
+                    time_graph(graph),
+                    time_graph(baseline_graph),
+                )
+                timings.append(
+                    {
+                        "round": i,
+                        "a_us": a,
+                        "b_us": b,
+                        "a2_us": a2,
+                        "speedup": (a + a2) / (2 * b) - 1,
+                    }
+                )
+            row.update(
+                status="complete",
+                timings=timings,
+                median_speedup=statistics.median(r["speedup"] for r in timings),
+            )
+            save()
+            print(json.dumps(row), flush=True)
+            del graph, outputs
+        record["status"] = (
+            "complete_with_rejections"
+            if any(r["status"] != "complete" for r in record["results"])
+            else "complete"
+        )
+        save()
+    except Exception as error:
+        record.update(status="failed", error=repr(error))
+        save()
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_glm53_stable_align.py
+++ b/benchmarks/kernels/benchmark_glm53_stable_align.py
@@ -1,0 +1,350 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fixed large-M alignment A/B/A, isolated warm-cache graph latency only.
+
+14 sizes x random/skew plus the first actual M640 route from each of four
+ranks: 32 cases. Compare installed alignment alone and alignment plus canonical
+sort separately with the stable probe. Five A/B/A rounds, three warmup graph
+replays and five timed 20-call replays per arm: 4,800 samples, no exclusions.
+With --parallel-count, use 1024 counting threads instead of 256 and add the
+original 256-thread stable path as a third A/B/A control: 7,200 samples total.
+With --direct-count, use 1024 threads without warp aggregation and retain both
+original stable counters as controls: four comparisons, 9,600 samples total.
+With --parallel-scatter, use 512 scatter threads with direct counting fixed,
+adding direct-stable as the fifth control: 12,000 samples total.
+With --native, test the installed selected M17..32/M33..8192 dispatch against
+atomic and atomic-plus-sort only: 4,800 samples, no probe loaded or rebuilt.
+Routing scores/IDs, weights and GEMM arithmetic are outside this experiment.
+All buffers are hot; this does not establish model cache effects or serving TPS.
+"""
+
+import argparse
+import json
+import statistics
+import subprocess
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.glm53_stable_align_probe import build
+from benchmarks.kernels.replay_glm53_indexer import sha, tensor_sha
+from slimserve.canonical_moe import canonicalize
+from tests.kernels.test_glm53_canonical_moe import expected_alignment
+from tests.kernels.test_glm53_stable_align import inputs
+from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
+    moe_align_block_size,
+)
+from vllm.model_executor.layers.fused_moe.router.glm_route_align import (
+    marlin_block_size_m,
+)
+
+
+def graph_for(call):
+    call()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        outputs = [call() for _ in range(20)]
+    return graph, outputs
+
+
+def measure(graph):
+    for _ in range(3):
+        graph.replay()
+    torch.cuda.synchronize()
+    samples = []
+    for _ in range(5):
+        begin = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        begin.record()
+        graph.replay()
+        end.record()
+        end.synchronize()
+        samples.append(begin.elapsed_time(end) * 1000 / 20)
+    return samples
+
+
+def cases():
+    for tokens in (17, 31, 32, 33, 63, 64, 65, 129, 256, 640, 1024, 4096, 7616, 8192):
+        for pattern, ids in zip(("random", "skew"), inputs(tokens)[:2]):
+            yield pattern, ids, None
+    trace = Path("perf/results/2026-09-09/stable-route-quality-diagnostic/trace")
+    paths = sorted(trace.glob("model-*.jsonl"))
+    assert len(paths) == 4
+    for rank, path in enumerate(paths):
+        rows = [json.loads(line) for line in path.read_text().splitlines()]
+        (row,) = [
+            r
+            for r in rows
+            if r["kind"] == "moe_snapshot"
+            and r["stage"] == "moe3.router.ids"
+            and r["match"] == 1
+        ]
+        archive = Path(row["path"])
+        assert sha(archive) == row["file_sha256"]
+        ids = torch.load(archive, map_location="cpu", weights_only=True)
+        assert ids.shape == (640, 8)
+        yield (
+            f"actual-worker-{rank}",
+            ids,
+            dict(
+                path=str(archive),
+                sha256=sha(archive),
+                trace=str(path),
+                trace_sha256=sha(path),
+            ),
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--parallel-count", action="store_true")
+    parser.add_argument("--direct-count", action="store_true")
+    parser.add_argument("--parallel-scatter", action="store_true")
+    parser.add_argument("--native", action="store_true")
+    args = parser.parse_args()
+    if args.native and (
+        args.parallel_count or args.direct_count or args.parallel_scatter
+    ):
+        parser.error(
+            "--native selects its own shape policy; probe flags cannot combine"
+        )
+    if args.parallel_scatter:
+        args.direct_count = True
+    if args.direct_count:
+        args.parallel_count = True
+    args.output.mkdir(parents=True, exist_ok=False)
+    torch.set_num_threads(1)
+    torch.cuda.set_device(0)
+    assert torch.cuda.get_device_capability() == (12, 0)
+    if args.native:
+        import vllm._quixicore_C as probe
+
+        from vllm.model_executor.layers.fused_moe.router.glm_stable_align import align
+    else:
+        probe = build()
+    import vllm._C_stable_libtorch as core
+    import vllm._moe_C_stable_libtorch as moe
+
+    sources = [
+        Path(__file__),
+        Path(probe.__file__),
+        Path(core.__file__),
+        Path(moe.__file__),
+    ]
+    sources += list(
+        map(
+            Path,
+            [
+                "benchmarks/kernels/glm53_stable_align_probe.cu",
+                "benchmarks/kernels/glm53_stable_align_probe.py",
+                "benchmarks/kernels/benchmark_mhc_output_parallel.py",
+                "benchmarks/kernels/replay_glm53_indexer.py",
+                "csrc/quixicore/serving/glm_moe_stable_align.cuh",
+                "csrc/libtorch_stable/moe/moe_align_sum_kernels.cu",
+                "tests/kernels/test_glm53_stable_align.py",
+                "tests/kernels/test_glm53_canonical_moe.py",
+                "slimserve/canonical_moe.py",
+                "slimserve/canonical_moe_kernel.py",
+                "vllm/model_executor/layers/fused_moe/moe_align_block_size.py",
+                "vllm/model_executor/layers/fused_moe/router/glm_route_align.py",
+                "vllm/_custom_ops.py",
+            ],
+        )
+    )
+    if args.native:
+        sources += [
+            Path(name)
+            for name in (
+                "csrc/quixicore/tm_cuda/tm_cuda_serving.cu",
+                "vllm/quixicore/ops.py",
+                "vllm/model_executor/layers/fused_moe/router/glm_stable_align.py",
+                "tests/kernels/test_glm53_stable_align_native.py",
+            )
+        ]
+    hashes = {str(p): sha(p) for p in sources}
+    result = dict(
+        status="running",
+        implementation="native-selected" if args.native else "probe",
+        native_dispatch="M17..32=count256/scatter256; M33..8192=direct1024/scatter512"
+        if args.native
+        else None,
+        count_threads=None if args.native else 1024 if args.parallel_count else 256,
+        aggregate=None if args.native else not args.direct_count,
+        scatter_threads=None if args.native else 512 if args.parallel_scatter else 256,
+        diagnostic_only=True,
+        protocol=__doc__,
+        source_sha256=hashes,
+        torch_version=torch.__version__,
+        cuda_version=torch.version.cuda,
+        device_properties=str(torch.cuda.get_device_properties(0)),
+        git_commit=subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True
+        ).strip(),
+        git_status=subprocess.check_output(["git", "status", "--porcelain"], text=True),
+        hardware=subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-gpu=name,uuid,driver_version,power.limit",
+                "--format=csv,noheader",
+            ],
+            text=True,
+        ),
+        cases=[],
+    )
+
+    def save():
+        (args.output / "summary.json").write_text(json.dumps(result, indent=2) + "\n")
+
+    save()
+    for pattern, cpu_ids, provenance in cases():
+        tokens = len(cpu_ids)
+        block = marlin_block_size_m(tokens, 8, 288)
+        ids = cpu_ids.cuda()
+        expected = expected_alignment(cpu_ids, block)
+
+        def atomic(ids=ids, block=block):
+            return moe_align_block_size(ids, block, 288)
+
+        def ordered(atomic=atomic, tokens=tokens, block=block):
+            out = atomic()
+            canonicalize(*out, tokens=tokens, block_size=block)
+            return out
+
+        def stable(ids=ids, block=block):
+            if args.native:
+                return align(ids, block)
+            return probe.run(
+                ids,
+                block,
+                args.parallel_count,
+                not args.direct_count,
+                args.parallel_scatter,
+            )
+
+        graphs = {
+            name: graph_for(call)
+            for name, call in [
+                ("atomic", atomic),
+                ("atomic-plus-sort", ordered),
+                ("stable", stable),
+            ]
+        }
+        if args.parallel_count:
+            graphs["original-stable"] = graph_for(
+                lambda ids=ids, block=block: probe.run(ids, block, False)
+            )
+        if args.direct_count:
+            graphs["parallel-stable"] = graph_for(
+                lambda ids=ids, block=block: probe.run(ids, block, True, True)
+            )
+        if args.parallel_scatter:
+            graphs["direct-stable"] = graph_for(
+                lambda ids=ids, block=block: probe.run(ids, block, True, False, False)
+            )
+
+        def check(
+            graphs=graphs,
+            expected=expected,
+            tokens=tokens,
+            block=block,
+            ids=ids,
+            cpu_ids=cpu_ids,
+        ):
+            for name, (graph, outputs) in graphs.items():
+                graph.replay()
+                for output in outputs:
+                    assert all(
+                        torch.equal(a.cpu(), b)
+                        for a, b in zip(output[1:], expected[1:])
+                    )
+                    if name != "atomic":
+                        assert torch.equal(output[0].cpu(), expected[0])
+                    else:
+                        # Audit atomic alignment semantically without pretending
+                        # its assignment order is stable or timing the audit.
+                        copy = output[0].clone()
+                        canonicalize(
+                            copy, output[1], output[2], tokens=tokens, block_size=block
+                        )
+                        assert torch.equal(copy.cpu(), expected[0])
+            assert torch.equal(ids.cpu(), cpu_ids)
+
+        check()
+        case = dict(
+            tokens=tokens,
+            policy=dict(
+                count_threads=256
+                if args.native and tokens <= 32
+                else 1024
+                if args.native or args.parallel_count
+                else 256,
+                aggregate=tokens <= 32 if args.native else not args.direct_count,
+                scatter_threads=256
+                if args.native and tokens <= 32
+                else 512
+                if args.native or args.parallel_scatter
+                else 256,
+            ),
+            block_size=block,
+            pattern=pattern,
+            input_sha256=tensor_sha(cpu_ids),
+            provenance=provenance,
+            comparisons=[],
+        )
+        baselines = ["atomic", "atomic-plus-sort"]
+        if args.parallel_count:
+            baselines.append("original-stable")
+        if args.direct_count:
+            baselines.append("parallel-stable")
+        if args.parallel_scatter:
+            baselines.append("direct-stable")
+        for baseline in baselines:
+            rounds = []
+            for repeat in range(5):
+                rounds.append(
+                    dict(
+                        repeat=repeat + 1,
+                        control=measure(graphs[baseline][0]),
+                        candidate=measure(graphs["stable"][0]),
+                        return_control=measure(graphs[baseline][0]),
+                    )
+                )
+            medians = {
+                arm: statistics.median(v for r in rounds for v in r[arm])
+                for arm in ("control", "candidate", "return_control")
+            }
+            case["comparisons"].append(
+                dict(
+                    baseline=baseline,
+                    candidate="stable",
+                    rounds=rounds,
+                    medians_us=medians,
+                )
+            )
+            print(
+                json.dumps(
+                    dict(
+                        tokens=tokens,
+                        pattern=pattern,
+                        baseline=baseline,
+                        medians_us=medians,
+                    )
+                ),
+                flush=True,
+            )
+        check()
+        case["correctness"] = (
+            "all graph outputs, canonical atomic semantics and input bytes pass"
+        )
+        result["cases"].append(case)
+        save()
+        del graphs, ids
+    assert len(result["cases"]) == 32
+    assert hashes == {str(p): sha(p) for p in sources}, "frozen source/native changed"
+    result["status"] = "complete"
+    save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_glm53_stable_route.py
+++ b/benchmarks/kernels/benchmark_glm53_stable_route.py
@@ -28,19 +28,10 @@ from vllm.model_executor.layers.fused_moe.router.glm_route_align import (
 )
 from vllm.quixicore.ops import quixicore_ops as qc
 
+ROOT = Path(__file__).resolve().parents[2]
 
-def main():
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--output", required=True, type=Path)
-    parser.add_argument("--native", action="store_true")
-    args = parser.parse_args()
-    args.output.mkdir(parents=True, exist_ok=False)
-    torch.set_num_threads(1)
-    torch.cuda.set_device(0)
-    assert torch.cuda.get_device_capability() == (12, 0)
-    probe = None if args.native else build()
-    import vllm._quixicore_C as native
 
+def source_paths(native, probe=None):
     sources = [
         Path(__file__),
         Path(native.__file__),
@@ -58,6 +49,22 @@ def main():
     ]
     if probe is not None:
         sources.append(Path(probe.__file__))
+    return [ROOT / path for path in sources]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--native", action="store_true")
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=False)
+    torch.set_num_threads(1)
+    torch.cuda.set_device(0)
+    assert torch.cuda.get_device_capability() == (12, 0)
+    probe = None if args.native else build()
+    import vllm._quixicore_C as native
+
+    sources = source_paths(native, probe)
     hashes = {str(p): sha(p) for p in sources}
     result = dict(
         status="running",
@@ -69,9 +76,11 @@ def main():
         device_properties=str(torch.cuda.get_device_properties(0)),
         source_sha256=hashes,
         git_commit=subprocess.check_output(
-            ["git", "rev-parse", "HEAD"], text=True
+            ["git", "rev-parse", "HEAD"], text=True, cwd=ROOT
         ).strip(),
-        git_status=subprocess.check_output(["git", "status", "--porcelain"], text=True),
+        git_status=subprocess.check_output(
+            ["git", "status", "--porcelain"], text=True, cwd=ROOT
+        ),
         hardware=subprocess.check_output(
             [
                 "nvidia-smi",

--- a/benchmarks/kernels/benchmark_glm53_stable_route.py
+++ b/benchmarks/kernels/benchmark_glm53_stable_route.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fixed isolated A/B/A of origin-stable small-M routing, NOT serving TPS.
+
+32 synthetic shapes: M1..16, random/skew, sigmoid/renormalize/scale2.5/BM8.
+Three separate comparisons: installed native -> synchronized atomic probe;
+synchronized atomic -> stable probe; synchronized atomic + sort -> stable.
+Each uses five A/B/A rounds, three warmup graph replays, and five timed 20-call
+graph replays per arm/round. All samples retained; no retries. Both probe
+policies contain the warp synchronization repair, isolating it from ordering.
+With --native, both policies use the installed repaired library: only the last
+two comparisons run (4800 samples), avoiding a redundant native/self control.
+"""
+
+import argparse
+import json
+import statistics
+import subprocess
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.glm53_stable_route_probe import build
+from benchmarks.kernels.replay_glm53_indexer import sha, tensor_sha
+from slimserve.canonical_moe import canonicalize
+from tests.kernels.test_glm53_canonical_moe import expected_alignment
+from vllm.model_executor.layers.fused_moe.router.glm_route_align import (
+    alignment_geometry,
+)
+from vllm.quixicore.ops import quixicore_ops as qc
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--native", action="store_true")
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=False)
+    torch.set_num_threads(1)
+    torch.cuda.set_device(0)
+    assert torch.cuda.get_device_capability() == (12, 0)
+    probe = None if args.native else build()
+    import vllm._quixicore_C as native
+
+    sources = [
+        Path(__file__),
+        Path(native.__file__),
+        Path("csrc/quixicore/serving/glm_moe_routing.cuh"),
+        Path("csrc/quixicore/tm_cuda/tm_cuda_serving.cu"),
+        Path("benchmarks/kernels/glm53_stable_route_probe.cu"),
+        Path("benchmarks/kernels/glm53_stable_route_probe.py"),
+        Path("benchmarks/kernels/benchmark_mhc_output_parallel.py"),
+        Path("benchmarks/kernels/replay_glm53_indexer.py"),
+        Path("tests/kernels/test_glm53_canonical_moe.py"),
+        Path("slimserve/canonical_moe.py"),
+        Path("slimserve/canonical_moe_kernel.py"),
+        Path("vllm/model_executor/layers/fused_moe/router/glm_route_align.py"),
+        Path("vllm/quixicore/ops.py"),
+    ]
+    if probe is not None:
+        sources.append(Path(probe.__file__))
+    hashes = {str(p): sha(p) for p in sources}
+    result = dict(
+        status="running",
+        diagnostic_only=True,
+        implementation="native" if args.native else "probe",
+        protocol=__doc__,
+        torch_version=torch.__version__,
+        cuda_version=torch.version.cuda,
+        device_properties=str(torch.cuda.get_device_properties(0)),
+        source_sha256=hashes,
+        git_commit=subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True
+        ).strip(),
+        git_status=subprocess.check_output(["git", "status", "--porcelain"], text=True),
+        hardware=subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-gpu=name,uuid,driver_version,power.limit",
+                "--format=csv,noheader",
+            ],
+            text=True,
+        ),
+        cases=[],
+    )
+
+    def save():
+        (args.output / "summary.json").write_text(json.dumps(result, indent=2) + "\n")
+
+    save()
+
+    def bits_equal(a, b):
+        assert a.dtype == b.dtype and a.shape == b.shape
+        assert torch.equal(
+            a.contiguous().view(torch.uint8).cpu(),
+            b.contiguous().view(torch.uint8).cpu(),
+        )
+
+    def graph_for(call):
+        call()
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            outputs = [call() for _ in range(20)]
+        return graph, outputs
+
+    def measure(graph):
+        for _ in range(3):
+            graph.replay()
+        torch.cuda.synchronize()
+        samples = []
+        for _ in range(5):
+            start, end = (
+                torch.cuda.Event(enable_timing=True),
+                torch.cuda.Event(enable_timing=True),
+            )
+            start.record()
+            graph.replay()
+            end.record()
+            end.synchronize()
+            samples.append(start.elapsed_time(end) * 1000 / 20)
+        return samples
+
+    for tokens in range(1, 17):
+        for pattern in ("random", "skew"):
+            gen = torch.Generator().manual_seed(53100 + tokens)
+            cpu_logits = torch.randn(tokens, 288, generator=gen) * 2
+            cpu_bias = torch.randn(288, generator=gen) * 0.5
+            if pattern == "skew":
+                cpu_logits = cpu_logits[:1].expand_as(cpu_logits).clone()
+            logits, bias = cpu_logits.cuda(), cpu_bias.cuda()
+            capacity, blocks = alignment_geometry(tokens, 8, 288, 8)
+
+            def native_call(logits=logits, bias=bias, capacity=capacity, blocks=blocks):
+                return qc.glm_route_align(
+                    logits, bias, 8, 0, True, 2.5, 8, capacity, blocks
+                )
+
+            def atomic_call(logits=logits, bias=bias, capacity=capacity, blocks=blocks):
+                if args.native:
+                    return qc.glm_route_align(
+                        logits, bias, 8, 0, True, 2.5, 8, capacity, blocks
+                    )
+                return probe.run(logits, bias, 0, True, 2.5, 8, False)
+
+            def sorted_call(atomic_call=atomic_call, tokens=tokens):
+                out = atomic_call()
+                canonicalize(*out[2:], tokens=tokens, block_size=8)
+                return out
+
+            def stable_call(logits=logits, bias=bias, capacity=capacity, blocks=blocks):
+                if args.native:
+                    return qc.glm_route_align(
+                        logits, bias, 8, 0, True, 2.5, 8, capacity, blocks, stable=True
+                    )
+                return probe.run(logits, bias, 0, True, 2.5, 8, True)
+
+            reference = native_call()
+            expected = expected_alignment(reference[1], 8)
+            callbacks = [
+                ("synchronized-atomic", atomic_call),
+                ("synchronized-atomic-plus-sort", sorted_call),
+                ("stable", stable_call),
+            ]
+            if not args.native:
+                callbacks.insert(0, ("native", native_call))
+            graphs = {name: graph_for(call) for name, call in callbacks}
+
+            def check(
+                graphs=graphs,
+                reference=reference,
+                expected=expected,
+                logits=logits,
+                bias=bias,
+                cpu_logits=cpu_logits,
+                cpu_bias=cpu_bias,
+            ):
+                for name, (graph, outputs) in graphs.items():
+                    graph.replay()
+                    for out in outputs:
+                        for a, b in zip(out[:2], reference[:2]):
+                            bits_equal(a, b)
+                        for a, b in zip(out[3:], reference[3:]):
+                            bits_equal(a, b)
+                        if name in ("synchronized-atomic-plus-sort", "stable"):
+                            for a, b in zip(out[2:], expected):
+                                bits_equal(a, b)
+                bits_equal(logits, cpu_logits)
+                bits_equal(bias, cpu_bias)
+
+            check()
+            case = dict(
+                tokens=tokens,
+                pattern=pattern,
+                block_size=8,
+                logits_sha256=tensor_sha(cpu_logits),
+                bias_sha256=tensor_sha(cpu_bias),
+                comparisons=[],
+            )
+            comparisons = [
+                ("synchronized-atomic", "stable"),
+                ("synchronized-atomic-plus-sort", "stable"),
+            ]
+            if not args.native:
+                comparisons.insert(0, ("native", "synchronized-atomic"))
+            for baseline, candidate in comparisons:
+                rounds = []
+                for repeat in range(5):
+                    rounds.append(
+                        dict(
+                            repeat=repeat + 1,
+                            control=measure(graphs[baseline][0]),
+                            candidate=measure(graphs[candidate][0]),
+                            return_control=measure(graphs[baseline][0]),
+                        )
+                    )
+                medians = {
+                    arm: statistics.median([v for r in rounds for v in r[arm]])
+                    for arm in ("control", "candidate", "return_control")
+                }
+                case["comparisons"].append(
+                    dict(
+                        baseline=baseline,
+                        candidate=candidate,
+                        rounds=rounds,
+                        medians_us=medians,
+                    )
+                )
+                print(
+                    json.dumps(
+                        dict(
+                            tokens=tokens,
+                            pattern=pattern,
+                            baseline=baseline,
+                            candidate=candidate,
+                            medians_us=medians,
+                        )
+                    ),
+                    flush=True,
+                )
+            check()
+            case["correctness"] = "all graph outputs/ID/weight bits/input bytes pass"
+            result["cases"].append(case)
+            save()
+            del graphs, reference, logits, bias
+    assert {str(p): sha(p) for p in sources} == hashes, "frozen source/native changed"
+    assert len(result["cases"]) == 32
+    result["status"] = "complete"
+    save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/check_glm53_indexer_correction.py
+++ b/benchmarks/kernels/check_glm53_indexer_correction.py
@@ -1,0 +1,654 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fixed all-rank selective LayerNorm correction probe, not a serving change."""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from benchmarks import analyze_glm53_indexer_precision as precision
+from benchmarks.analyze_glm53_quality_pair import require
+from benchmarks.analyze_glm53_reduction_receipts import sha
+from benchmarks.kernels import check_glm53_attention_norms as norms
+from benchmarks.kernels import check_glm53_attention_overwrite as previous
+from benchmarks.kernels import check_glm53_kda_gate as common
+from benchmarks.kernels.glm53_rmsnorm_geometry import binary_sha
+from slimserve.rmsnorm_diagnostic import single_launcher_receipt
+
+ROOT = norms.ROOT
+SCREEN = precision.RESULTS / "runtime-control/indexer-cancellation-analysis-v1.json"
+SCREEN_SHA = "3474f6692e98b1be257174827dd5387d8d08dedadd647f8c2935a0a18ec25a24"
+SCHEMA = "glm53-indexer-correction-v1"
+TIMING_ROWS = (1, 16, 640, 7616)
+TIMING = dict(rank=0, seed=530901, magnitude=1.0, repeats=3, graph_calls=32, warmup=10)
+
+
+def prepare(path):
+    from benchmarks.kernels import glm53_indexer_correction as kernel
+
+    require(not path.exists(), "preserve prior manifest")
+    screen = norms.load_checked(SCREEN, SCREEN_SHA)
+    require(
+        screen["status"] == "complete" and not screen["gpu_run"], "CPU screen required"
+    )
+    documents = {
+        key: norms.load_checked(precision.RESULTS / name, digest)
+        for key, (name, digest) in precision.PINS.items()
+    }
+    precision.joined_cases(**documents)
+    old = documents["manifest"]
+    mapped = norms.load_checked(previous.CONTRACTS, previous.CONTRACTS_SHA)
+    sources = {}
+    for name, digest in {**old["sources"], **mapped["receipts"]}.items():
+        current = sha(name)
+        if (
+            name in mapped["receipts"]
+            or "/site-packages/" in name
+            or not name.endswith((".py", ".md"))
+        ):
+            require(
+                current == digest,
+                f"historical compiler/native/evidence changed: {name}",
+            )
+        sources[name] = current
+    records = [r for r in old["records"] if r["arm"] == "combo"]
+    require(
+        [r["rank"] for r in records] == list(range(4)), "four original bundles required"
+    )
+    for record in records:
+        for field in ("source", "debug_source", "ptx"):
+            require(
+                sha(record[field]) == record[field + "_sha256"],
+                "original provenance changed",
+            )
+        require(
+            sha(Path(record["ptx"]).with_suffix(".cubin")) == record["cubin_sha256"],
+            "original binary changed",
+        )
+    paths = [
+        Path(__file__),
+        Path(kernel.__file__),
+        Path(precision.__file__),
+        Path(previous.__file__),
+        Path(common.__file__),
+        ROOT / "perf/glm53-indexer-correction-protocol.md",
+        SCREEN,
+        previous.CONTRACTS,
+        *[precision.RESULTS / p for p, _ in precision.PINS.values()],
+    ]
+    site = Path(sys.prefix) / "lib/python3.12/site-packages"
+    for folder in (
+        "triton/runtime",
+        "triton/compiler",
+        "triton/language",
+        "triton/language/extra/cuda",
+        "triton/backends/nvidia",
+    ):
+        paths.extend((site / folder).glob("*.py"))
+    paths.extend(
+        site / p
+        for p in (
+            "triton/_C/libtriton.so",
+            "triton/backends/nvidia/bin/ptxas",
+            "triton/backends/nvidia/bin/ptxas-blackwell",
+        )
+    )
+    sources.update({str(p.resolve()): sha(p) for p in paths})
+    manifest = dict(
+        schema=SCHEMA,
+        sources=sources,
+        records=records,
+        cases=previous.matrix(),
+        exponent=kernel.EXPONENT,
+        options=kernel.OPTIONS,
+        timing=TIMING,
+        timing_rows=list(TIMING_ROWS),
+        historical_summary=str(precision.RESULTS / precision.PINS["summary"][0]),
+        historical_summary_sha256=precision.PINS["summary"][1],
+        original_namespace=old["original_namespace"],
+        original_files=old["original_files"],
+        weight_sha256=old["weight_sha256"],
+        git_commit=subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True
+        ).strip(),
+    )
+    verify(manifest)
+    common.save_new(path, manifest)
+    print(f"Prepared {len(manifest['cases'])} cases; {len(sources)} frozen receipts")
+
+
+def verify(manifest):
+    from benchmarks.kernels import glm53_indexer_correction as kernel
+
+    require(
+        manifest["schema"] == SCHEMA and manifest["cases"] == previous.matrix(),
+        "matrix changed",
+    )
+    require(
+        manifest["exponent"] == kernel.EXPONENT == -12
+        and manifest["options"] == kernel.OPTIONS,
+        "precision policy changed",
+    )
+    require(
+        manifest["timing"] == TIMING and manifest["timing_rows"] == list(TIMING_ROWS),
+        "timing policy changed",
+    )
+    norms.verify(manifest)
+
+
+def compile_launchers(manifest, output, summary):
+    import torch
+    import triton
+    from triton.compiler import ASTSource
+
+    from benchmarks.kernels.glm53_indexer_correction import OPTIONS, correct_indexer
+
+    launchers = {}
+    for rank, record in enumerate(manifest["records"]):
+        require(record["rank"] == rank, "rank order")
+        with torch.cuda.device(rank), triton.knobs.cache.scope():
+            triton.knobs.cache.dir = str(norms.rank_cache(output, rank))
+            copied = output / f"source-{rank}" / Path(record["source"]).name
+            copied.parent.mkdir()
+            shutil.copyfile(record["source"], copied)
+            template = norms.load_preserving_provenance(
+                copied,
+                Path(record["source"]),
+                record["info"]["kernel"],
+                f"indexer_combo_{rank}",
+                debug_source=Path(record["debug_source"]),
+            )
+            saved = record["selected"]["config"]
+            config = triton.Config(
+                {
+                    k: v
+                    for k, v in saved.items()
+                    if k not in ("num_warps", "num_stages")
+                },
+                num_warps=saved["num_warps"],
+                num_stages=saved["num_stages"],
+            )
+            original = template._precompile_config(config)
+            require(
+                binary_sha(original) == record["cubin_sha256"],
+                "original in-memory binary differs",
+            )
+            combo = original.make_launcher()
+            require(
+                single_launcher_receipt(combo) == record["selected"],
+                "original key/config differs",
+            )
+            cubin = (
+                norms.rank_cache(output, rank)
+                / record["selected"]["hash"]
+                / (record["info"]["kernel"] + ".cubin")
+            )
+            require(
+                sha(cubin) == record["cubin_sha256"], "original disk binary differs"
+            )
+            correction = triton.compile(
+                ASTSource(
+                    correct_indexer,
+                    signature=dict(
+                        Packed="*bf16",
+                        Gamma="*bf16",
+                        Bias="*bf16",
+                        Output="*bf16",
+                        Selected="*u8",
+                        N="i32",
+                    ),
+                ),
+                options=OPTIONS,
+            )
+            folder = output / f"correction-{rank}"
+            folder.mkdir()
+            artifacts = {}
+            for kind in ("cubin", "ptx", "ttir"):
+                value = correction.asm[kind]
+                path = folder / f"kernel.{kind}"
+                path.write_bytes(value if isinstance(value, bytes) else value.encode())
+                artifacts[str(path.relative_to(output))] = sha(path)
+            summary["binaries"].append(
+                dict(
+                    rank=rank,
+                    original_source=str(copied.relative_to(output)),
+                    original_source_sha256=sha(copied),
+                    original_cubin=str(cubin.relative_to(output.resolve())),
+                    original_cubin_sha256=sha(cubin),
+                    original_selected=record["selected"],
+                    correction_hash=correction.hash,
+                    correction_artifacts=artifacts,
+                    correction_metadata={
+                        k: getattr(correction.metadata, k) for k in OPTIONS
+                    },
+                )
+            )
+            launchers[rank] = (combo, correction)
+    return launchers
+
+
+def guarded_candidate(combo, correction, data, changed, weights):
+    """Original/repeated/changed/replayed inputs with separate selection guards."""
+    import torch
+
+    from benchmarks.kernels.glm53_indexer_correction import IndexerOnlyCorrection
+
+    rows = len(data)
+    storage = torch.full((rows + 2, 2336), 123.0, dtype=torch.bfloat16, device="cuda")
+    x = storage[1:-1]
+    wg = [w.cuda() for w in weights]
+    buffers = [
+        torch.full((rows + 2, stride), 123.0, dtype=torch.bfloat16, device="cuda")
+        for _, stride in norms.LAYOUTS.values()
+    ]
+    outputs = [b[1:-1, :width] for b, width in zip(buffers, norms.LAYOUTS)]
+    flags = torch.full((rows + 2, 128), 171, dtype=torch.uint8, device="cuda")
+    selected = flags[1:-1]
+    adapted = IndexerOnlyCorrection(combo, correction[(rows, 1, 1)], selected)
+
+    def launch():
+        adapted(
+            x,
+            *wg,
+            *outputs,
+            rows,
+            rows,
+            rows,
+            stream=torch.cuda.current_stream().cuda_stream,
+        )
+
+    def snapshot(expected):
+        require(torch.equal(x.cpu(), expected), "packed input mutated")
+        require(torch.all(storage[[0, -1]] == 123).item(), "input guard mutated")
+        require(
+            all(torch.equal(w.cpu(), ref) for w, ref in zip(wg, weights)),
+            "weights mutated",
+        )
+        for buffer, width in zip(buffers, norms.LAYOUTS):
+            require(
+                torch.all(buffer[[0, -1]] == 123).item(), "output row guard mutated"
+            )
+            require(
+                torch.all(buffer[1:-1, width:] == 123).item(),
+                "output stride/gate guard mutated",
+            )
+        require(torch.all(flags[[0, -1]] == 171).item(), "selection guard mutated")
+        mask = selected.cpu()
+        require(torch.all(mask <= 1).item(), "selection values invalid")
+        return [t.cpu() for t in outputs], mask
+
+    def exact(a, b):
+        require(
+            all(torch.equal(x, y) for x, y in zip(a[0], b[0]))
+            and torch.equal(a[1], b[1]),
+            "candidate output/selection replay drift",
+        )
+
+    x.copy_(data)
+    launch()
+    first = snapshot(data)
+    launch()
+    exact(first, snapshot(data))
+    graph = torch.cuda.CUDAGraph()
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.graph(graph, stream=stream):
+        launch()
+    torch.cuda.current_stream().wait_stream(stream)
+    x.copy_(changed)
+    graph.replay()
+    second = snapshot(changed)
+    launch()
+    exact(second, snapshot(changed))
+    x.copy_(data)
+    graph.replay()
+    exact(first, snapshot(data))
+    require(
+        all(not torch.equal(a, b) for a, b in zip(first[0], second[0])),
+        "vacuous changed-input replay",
+    )
+    require(
+        adapted.combo_calls == adapted.correction_calls == 4, "adapter host-call count"
+    )
+    return first, second
+
+
+def phase_metrics(baseline, candidate, selected, reference, bias):
+    import torch
+
+    expected_mask = precision.cancellation_mask(baseline[2], bias, -12)
+    require(
+        torch.equal(selected.bool(), expected_mask),
+        "GPU detector disagrees with CPU predicate",
+    )
+    require(
+        all(torch.equal(a, b) for a, b in zip(baseline[:2], candidate[:2])),
+        "Q/KV changed",
+    )
+    require(
+        torch.equal(candidate[2][~expected_mask], baseline[2][~expected_mask]),
+        "unselected indexer values changed",
+    )
+    failures = precision.above_one_ulp(baseline[2], reference)
+    return dict(
+        baseline_sha256=[norms.tensor_sha(t) for t in baseline],
+        candidate_sha256=[norms.tensor_sha(t) for t in candidate],
+        selected_sha256=norms.tensor_sha(selected),
+        selected_elements=int(expected_mask.sum()),
+        selected_rows=int(expected_mask.any(-1).sum()),
+        missed_original_failures=int((failures & ~expected_mask).sum()),
+        changed_elements=int(
+            (candidate[2].view(torch.int16) != baseline[2].view(torch.int16)).sum()
+        ),
+        original_oracle=norms.compare(baseline[2], reference),
+        corrected_oracle=norms.compare(candidate[2], reference),
+        mismatches=norms.mismatch_examples(candidate[2], reference),
+        detector_exact=True,
+        non_target_and_unselected_exact=True,
+    )
+
+
+def execute_case(case, launchers, weights, historical):
+    combo, correction = launchers
+    inputs = [
+        norms.packed_inputs(case["rows"], case["seed"] + 100 * phase, case["magnitude"])
+        for phase in range(2)
+    ]
+    require(
+        [norms.tensor_sha(t) for t in inputs] == historical["inputs"],
+        "historical inputs differ",
+    )
+    baseline = norms.run_launches({"combo": combo}, *inputs, weights)
+    candidate = guarded_candidate(combo, correction, *inputs, weights)
+    phases = []
+    for phase, (data, base, (values, selected)) in enumerate(
+        zip(inputs, baseline, candidate)
+    ):
+        require(
+            [norms.tensor_sha(t) for t in base]
+            == historical["outputs"]["combo"][phase],
+            "historical original output differs",
+        )
+        reference = norms.layernorm_oracle(data[:, 2048:2176], weights[2], weights[3])
+        phases.append(phase_metrics(base, values, selected, reference, weights[3]))
+    return dict(
+        **case,
+        input_sha256=historical["inputs"],
+        phases=phases,
+        replay_guards_mutation_passed=True,
+    )
+
+
+def audit_record(record, case, historical):
+    require({k: record[k] for k in case} == case, "case order differs")
+    require(record["input_sha256"] == historical["inputs"], "input hashes differ")
+    require(
+        record["replay_guards_mutation_passed"] is True and len(record["phases"]) == 2,
+        "missing replay/phases",
+    )
+    for phase, item in enumerate(record["phases"]):
+        require(
+            item["baseline_sha256"] == historical["outputs"]["combo"][phase],
+            "original output hashes differ",
+        )
+        require(
+            item["candidate_sha256"][:2] == item["baseline_sha256"][:2],
+            "Q/KV hashes differ",
+        )
+        require(
+            item["detector_exact"] is True
+            and item["non_target_and_unselected_exact"] is True,
+            "preservation checks missing",
+        )
+        require(
+            item["missed_original_failures"] == 0, "detector missed original failure"
+        )
+        require(
+            0 <= item["selected_rows"] <= case["rows"]
+            and 0
+            <= item["changed_elements"]
+            <= item["selected_elements"]
+            <= case["rows"] * 128,
+            "invalid selected/changed counts",
+        )
+        require(
+            item["corrected_oracle"]["elements"] == case["rows"] * 128
+            and item["corrected_oracle"]["max_bf16_ulp"] <= 1,
+            "corrected one-ULP oracle failed",
+        )
+
+
+def timing_case(rows, launchers, weights):
+    import torch
+
+    from benchmarks.kernels.glm53_indexer_correction import IndexerOnlyCorrection
+
+    combo, correction = launchers
+    data = norms.packed_inputs(rows, TIMING["seed"], TIMING["magnitude"])
+    x = data.cuda()
+    wg = [w.cuda() for w in weights]
+    outputs = [
+        torch.empty((rows, stride), dtype=torch.bfloat16, device="cuda")[:, :width]
+        for width, (_, stride) in norms.LAYOUTS.items()
+    ]
+    selected = torch.empty((rows, 128), dtype=torch.uint8, device="cuda")
+    adapted = IndexerOnlyCorrection(combo, correction[(rows, 1, 1)], selected)
+    args = (x, *wg, *outputs, rows, rows, rows)
+    graphs = {}
+    # Fixed control then correction, three paired readings, no configuration search.
+    for name, launch in (("control", combo), ("correction", adapted)):
+        for _ in range(TIMING["warmup"]):
+            launch(*args, stream=torch.cuda.current_stream().cuda_stream)
+        graph = torch.cuda.CUDAGraph()
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.graph(graph, stream=stream):
+            for _ in range(TIMING["graph_calls"]):
+                launch(*args, stream=stream.cuda_stream)
+        torch.cuda.current_stream().wait_stream(stream)
+        graphs[name] = graph
+        for _ in range(TIMING["warmup"]):
+            graph.replay()
+    result = {name: [] for name in graphs}
+    for _ in range(TIMING["repeats"]):
+        for name, graph in graphs.items():
+            start, end = (
+                torch.cuda.Event(enable_timing=True),
+                torch.cuda.Event(enable_timing=True),
+            )
+            start.record()
+            graph.replay()
+            end.record()
+            end.synchronize()
+            result[name].append(start.elapsed_time(end) * 1000 / TIMING["graph_calls"])
+    return dict(
+        rows=rows, microseconds_per_bundle=result, includes_selection_writes=True
+    )
+
+
+def run(manifest_path, output):
+    require(not output.exists(), "attempt exists; no retry")
+    manifest = json.loads(manifest_path.read_text())
+    verify(manifest)
+    require(
+        os.environ.get("CUDA_VISIBLE_DEVICES") == "0,1,2,3",
+        "rank-matched GPUs required",
+    )
+    require(not common.gpu_query(), "another GPU workload active")
+    output.mkdir(parents=True)
+    os.environ.update(
+        TRITON_CACHE_DIR=str(output.resolve() / "triton"),
+        TORCHINDUCTOR_CACHE_DIR=str(output.resolve() / "inductor"),
+        TRITON_CACHE_AUTOTUNING="0",
+    )
+    summary = dict(
+        status="running",
+        records=[],
+        binaries=[],
+        timings=[],
+        manifest_sha256=sha(manifest_path),
+        gpu_config=common.gpu_config(),
+    )
+    common.save_new(
+        output / "attempt.json",
+        dict(pid=os.getpid(), manifest_sha256=sha(manifest_path)),
+    )
+    try:
+        import torch
+
+        torch.set_num_threads(1)
+        summary.update(torch=torch.__version__, cuda=torch.version.cuda)
+        require(
+            torch.cuda.device_count() == 4
+            and all(torch.cuda.get_device_capability(r) == (12, 0) for r in range(4)),
+            "four SM120 GPUs required",
+        )
+        weights = norms.load_weights()
+        require(
+            {k: norms.tensor_sha(w) for k, w in zip(norms.WEIGHTS, weights)}
+            == manifest["weight_sha256"],
+            "real weights differ",
+        )
+        historical = norms.load_checked(
+            Path(manifest["historical_summary"]), manifest["historical_summary_sha256"]
+        )
+        launchers = compile_launchers(manifest, output, summary)
+        for index, case in enumerate(manifest["cases"]):
+            summary["active_case"] = dict(index=index, **case)
+            with torch.cuda.device(case["rank"]):
+                record = execute_case(
+                    case, launchers[case["rank"]], weights, historical["checks"][index]
+                )
+            path = output / f"case-{index:03d}.json"
+            common.save_new(path, record)
+            summary["records"].append(dict(path=path.name, sha256=sha(path)))
+            audit_record(record, case, historical["checks"][index])
+            if (index + 1) % 10 == 0:
+                print(f"Indexer correction: {index + 1}/120 cases", flush=True)
+        with torch.cuda.device(TIMING["rank"]):
+            for rows in TIMING_ROWS:
+                summary["timings"].append(
+                    timing_case(rows, launchers[TIMING["rank"]], weights)
+                )
+        verify(manifest)
+        summary["status"] = "complete"
+    except BaseException as error:
+        summary.update(status="failed", error=repr(error))
+        raise
+    finally:
+        common.save_new(output / "summary.json", summary)
+
+
+def audit(manifest_path, output):
+    manifest = json.loads(manifest_path.read_text())
+    verify(manifest)
+    summary = json.loads((output / "summary.json").read_text())
+    require(summary["manifest_sha256"] == sha(manifest_path), "manifest changed")
+    require(
+        not list((output / "triton").rglob("*.autotune.json")), "unexpected autotuning"
+    )
+    require(
+        not common.gpu_query() and common.gpu_config() == summary["gpu_config"],
+        "GPU release/config changed",
+    )
+    historical = norms.load_checked(
+        Path(manifest["historical_summary"]), manifest["historical_summary_sha256"]
+    )
+    for rank, binary in enumerate(summary["binaries"]):
+        expected = manifest["records"][rank]
+        require(
+            binary["rank"] == rank
+            and binary["original_selected"] == expected["selected"],
+            "binary rank/choice changed",
+        )
+        require(
+            binary["original_cubin_sha256"] == expected["cubin_sha256"]
+            and binary["original_source_sha256"] == expected["source_sha256"],
+            "original binary/source differs",
+        )
+        files = {
+            binary["original_source"]: binary["original_source_sha256"],
+            binary["original_cubin"]: binary["original_cubin_sha256"],
+            **binary["correction_artifacts"],
+        }
+        for name, digest in files.items():
+            require(sha(output / name) == digest, "probe artifact changed")
+        require(
+            binary["correction_metadata"] == manifest["options"],
+            "correction compiler policy differs",
+        )
+    failures, records = [], []
+    for index, item in enumerate(summary["records"]):
+        require(item["path"] == f"case-{index:03d}.json", "case path/order changed")
+        record = norms.load_checked(output / item["path"], item["sha256"])
+        try:
+            audit_record(record, manifest["cases"][index], historical["checks"][index])
+        except ValueError as error:
+            failures.append(dict(index=index, error=str(error)))
+        records.append(record)
+    complete = (
+        summary["status"] == "complete"
+        and len(records) == 120
+        and len(summary["binaries"]) == 4
+        and not failures
+    )
+    require(
+        summary["status"] != "complete" or complete,
+        "completed probe lacks qualification",
+    )
+    if complete:
+        require(
+            [r["rows"] for r in summary["timings"]] == list(TIMING_ROWS),
+            "timing matrix incomplete",
+        )
+    result = dict(
+        status="complete" if complete else "terminal-failure",
+        cases=len(records),
+        failures=failures,
+        manifest_sha256=sha(manifest_path),
+        summary_sha256=sha(output / "summary.json"),
+        sources_verified=len(manifest["sources"]),
+        original_files_verified=len(manifest["original_files"]),
+        selected_elements=sum(
+            p["selected_elements"] for r in records for p in r["phases"]
+        ),
+        selected_rows=sum(p["selected_rows"] for r in records for p in r["phases"]),
+        changed_elements=sum(
+            p["changed_elements"] for r in records for p in r["phases"]
+        ),
+        corrected_oracle_max_ulp=max(
+            (
+                p["corrected_oracle"]["max_bf16_ulp"]
+                for r in records
+                for p in r["phases"]
+            ),
+            default=None,
+        ),
+        historical_indexer_oracle_pass=False,
+        production_qualified=False,
+        timings=summary["timings"],
+        gpu_processes_after="",
+        scope=__doc__,
+    )
+    common.save_new(output / "analysis.json", result)
+    print(json.dumps(result, indent=2))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("prepare", "run", "audit"))
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    if args.action == "prepare":
+        prepare(args.manifest)
+    else:
+        require(args.output is not None, "output required")
+        (run if args.action == "run" else audit)(args.manifest, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/check_glm53_indexer_correction_loader.py
+++ b/benchmarks/kernels/check_glm53_indexer_correction_loader.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+"""One-attempt actual AOT load plus bound-leaf numerics; no model forward."""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from benchmarks.kernels import check_glm53_geometry_loader as common
+from benchmarks.kernels.audit_glm53_indexer_correction_graphs import (
+    inventory,  # noqa: F401
+)
+from benchmarks.kernels.check_glm53_attention_norms import require, verify
+from benchmarks.kernels.glm53_indexer_bound_leaves import qualify_bindings  # noqa: F401
+from benchmarks.kernels.glm53_indexer_correction_loader import (
+    SCHEMA,
+    IndexerCorrectionLoader,
+)
+from benchmarks.kernels.prepare_glm53_indexer_correction_loader import (
+    CONTRACTS_SHA,
+    ORDER,
+    QUALIFICATION_SHA,
+    SELECTION_CAPACITY,
+)
+from slimserve.rmsnorm_diagnostic import NAMESPACE, sha
+
+MODULE = "benchmarks.kernels.check_glm53_indexer_correction_loader"
+AUDITOR_MODULE = "benchmarks.kernels.audit_glm53_indexer_correction_loader"
+UNIT_PREFIX = "glm53-indexer-aot-v1"
+LOADER = IndexerCorrectionLoader
+LEAF_WEIGHT_COUNT = 4
+
+
+def read_manifest(path):
+    path = path.resolve()
+    data = common.read_json(path)
+    prep = common.read_json(path.parent.parent / "preparation.json")
+    require(
+        data["schema"] == SCHEMA
+        and data["namespace"] == NAMESPACE
+        and data["qualification_sha256"] == QUALIFICATION_SHA
+        and data["contracts_sha256"] == CONTRACTS_SHA
+        and data["selection_capacity"] == SELECTION_CAPACITY
+        and prep["status"] == "prepared"
+        and prep["sources"] == data["sources"]
+        and [(r["mode"], r["rank"]) for r in prep["runs"]] == list(ORDER),
+        "wrong prepared correction series",
+    )
+    for row, (mode, rank) in zip(prep["runs"], ORDER):
+        expected = path.parent.parent / f"{mode}-rank{rank}/manifest.json"
+        require(
+            row["manifest"] == str(expected)
+            and row["manifest_sha256"] == sha(expected),
+            "prepared manifest changed",
+        )
+    require(
+        (data["mode"], data["rank"]) in ORDER
+        and path.parent.name == f"{data['mode']}-rank{data['rank']}"
+        and data["cache_root"] == str(path.parent / "cache")
+        and data["private_namespace"]
+        == str(path.parent / "cache/torch_compile_cache/torch_aot_compile" / NAMESPACE)
+        and data["receipts"] == str(path.parent / "receipts"),
+        "wrong rank/mode/cache paths",
+    )
+    require(
+        set(data["targets"]) == {str(r) for r in range(4)}
+        and all(
+            len(data["targets"][str(r)]) == 1
+            and len(data["targets"][str(r)][0]["static_graph_uses"]) == 2
+            and len(data["expected_graphs"][str(r)])
+            == len(data["artifact_roots"][str(r)])
+            == 7
+            and sum(len(a["submodules"]) for a in data["artifact_roots"][str(r)]) == 46
+            for r in range(4)
+        ),
+        "incomplete target/AOT matrix",
+    )
+    require(
+        data["private_sources"]
+        == {
+            t["correction"]["relative"]: t["correction"]["source_sha256"]
+            for ts in data["targets"].values()
+            for t in ts
+        },
+        "private correction source inventory differs",
+    )
+    from benchmarks.kernels.check_glm53_attention_overwrite import matrix
+
+    require(
+        [r["case"] for r in data["qualified_leaf_cases"]] == matrix(),
+        "qualified leaf order changed",
+    )
+    require(
+        data["git_commit"]
+        == subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "source commit changed",
+    )
+    verify(data)
+    return data, prep
+
+
+def prior_receipts(path, manifest, preparation):
+    return common.prior_receipts(path, manifest, preparation, order=ORDER)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("run", "launch"))
+    parser.add_argument("--manifest", type=Path, required=True)
+    args = parser.parse_args()
+    (common.run if args.action == "run" else common.launch)(
+        args.manifest, workflow=sys.modules[__name__]
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/check_glm53_indexer_order.py
+++ b/benchmarks/kernels/check_glm53_indexer_order.py
@@ -3,17 +3,13 @@
 """Bounded installed top-k repeatability probe; synthetic inputs, no timing claim."""
 
 import argparse
-import hashlib
 import json
 import subprocess
 from pathlib import Path
 
 import torch
 
-
-def sha(path):
-    with path.open("rb") as stream:
-        return hashlib.file_digest(stream, "sha256").hexdigest()
+from benchmarks.kernels.replay_glm53_indexer import sha
 
 
 def selection_validity(logits, indices, k=512):

--- a/benchmarks/kernels/check_glm53_indexer_order.py
+++ b/benchmarks/kernels/check_glm53_indexer_order.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded installed top-k repeatability probe; synthetic inputs, no timing claim."""
+
+import argparse
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+import torch
+
+
+def sha(path):
+    with path.open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def selection_validity(logits, indices, k=512):
+    """Independent CPU membership/score check; tie indices need not be canonical."""
+    logits, indices = logits.cpu(), indices.cpu().long()
+    n = logits.shape[1]
+    count = min(n, k)
+    valid = bool(((indices[:, :count] >= 0) & (indices[:, :count] < n)).all())
+    valid &= bool((indices[:, count:] == -1).all())
+    chosen = indices[:, :count].sort(dim=1).values
+    valid &= bool((chosen[:, 1:] != chosen[:, :-1]).all())
+    if not valid:
+        return False
+    values = logits.gather(1, chosen).sort(dim=1, descending=True).values
+    best = logits.sort(dim=1, descending=True).values[:, :count]
+    return torch.equal(values, best)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"], text=True
+    ).strip()
+    if active:
+        parser.error(f"GPU compute processes already active: {active}")
+    args.output.mkdir(parents=True, exist_ok=False)
+    from vllm import _custom_ops as ops
+
+    torch.set_num_threads(1)
+    root = Path(__file__).resolve().parents[2]
+    native = root / "vllm/_C_stable_libtorch.abi3.so"
+    result = {
+        "status": "running",
+        "diagnostic_only": True,
+        "git_commit": subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True
+        ).strip(),
+        "source_sha256": sha(Path(__file__)),
+        "native_sha256": sha(native),
+        "torch": torch.__version__,
+        "gpu": torch.cuda.get_device_name(),
+        "protocol": "6 sizes x3 families;10 eager and10 graph calls each,8 rows/top512",
+        "cases": [],
+    }
+
+    def save():
+        (args.output / "summary.json").write_text(json.dumps(result, indent=2) + "\n")
+
+    save()
+    for columns in (160, 512, 513, 1904, 2048, 8192):
+        generator = torch.Generator().manual_seed(752 + columns)
+        unique = (
+            torch.stack(
+                [torch.randperm(columns, generator=generator) for _ in range(8)]
+            ).float()
+            / columns
+        )
+        tied = torch.zeros_like(unique)
+        tied[:, :31] = torch.arange(1, 32).float()
+        random = torch.randn(8, columns, generator=generator)
+        inputs = {"unique": unique, "tied": tied, "random": random}
+        logits = unique.cuda()
+        starts = torch.zeros(8, dtype=torch.int32, device="cuda")
+        ends = torch.full((8,), columns, dtype=torch.int32, device="cuda")
+        output = torch.empty(8, 512, dtype=torch.int32, device="cuda")
+
+        def call(
+            logits=logits, starts=starts, ends=ends, output=output, columns=columns
+        ):
+            ops.top_k_per_row_prefill(logits, starts, ends, output, 8, columns, 1, 512)
+
+        call()
+        graph = torch.cuda.CUDAGraph()
+        stream = torch.cuda.Stream(device=logits.device)
+        stream.wait_stream(torch.cuda.current_stream(logits.device))
+        with torch.cuda.graph(graph, stream=stream):
+            call()
+        for family, host in inputs.items():
+            logits.copy_(host)
+            observations = {"eager": [], "graph": []}
+            for mode in observations:
+                for _ in range(10):
+                    output.fill_(-777)
+                    if mode == "eager":
+                        call()
+                    else:
+                        graph.replay()
+                    observations[mode].append(output.cpu())
+            row = {"columns": columns, "family": family, "modes": {}}
+            for mode, outputs in observations.items():
+                ref = outputs[0]
+                ref_set = ref.sort(dim=1).values
+                row["modes"][mode] = {
+                    "all_selections_valid": all(
+                        selection_validity(host, x) for x in outputs
+                    ),
+                    "changed_positions_vs_first": [
+                        int((x != ref).sum()) for x in outputs
+                    ],
+                    "changed_set_positions_vs_first": [
+                        int((x.sort(dim=1).values != ref_set).sum()) for x in outputs
+                    ],
+                }
+            artifact = args.output / f"selection-{columns}-{family}.pt"
+            torch.save(
+                {
+                    "logits": host,
+                    "row_starts": starts.cpu(),
+                    "row_ends": ends.cpu(),
+                    "outputs": {k: torch.stack(v) for k, v in observations.items()},
+                },
+                artifact,
+            )
+            row["artifact"] = {"path": str(artifact), "sha256": sha(artifact)}
+            result["cases"].append(row)
+            save()
+            print(json.dumps(row), flush=True)
+        del graph, call
+    assert sha(native) == result["native_sha256"]
+    assert sha(Path(__file__)) == result["source_sha256"]
+    result["status"] = "complete"
+    result["all_selections_valid"] = all(
+        m["all_selections_valid"] for r in result["cases"] for m in r["modes"].values()
+    )
+    save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/compare_cuda_sass.py
+++ b/benchmarks/kernels/compare_cuda_sass.py
@@ -65,7 +65,7 @@ def signatures(path):
 
 def compare(before, candidate):
     common = sorted(before.keys() & candidate.keys())
-    changed = [name for name in common if before[name] - candidate[name]]
+    changed = [name for name in common if before[name] != candidate[name]]
     removed = sorted(before.keys() - candidate.keys())
     added = sorted(
         name for name in candidate if candidate[name] - before.get(name, Counter())

--- a/benchmarks/kernels/compare_cuda_sass.py
+++ b/benchmarks/kernels/compare_cuda_sass.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compare saved cuobjdump SASS, including BOTH encoded 64-bit instruction words.
+
+Raw disassembly must come from the named frozen binaries. Keep all duplicate
+function copies per architecture. Reject missing scheduling words rather than
+silently comparing only the mnemonic/first word. No GPU work or disassembly is
+launched here; the full original raw files are preserved and hashed.
+"""
+
+import argparse
+import hashlib
+import json
+import re
+from collections import Counter
+from pathlib import Path
+
+from benchmarks.kernels.replay_glm53_indexer import sha
+
+INSTRUCTION = re.compile(r"\s*/\*([0-9a-f]+)\*/\s*.*?;")
+CONTROL = re.compile(r"\s*/\*\s*0x[0-9a-f]{16}\s*\*/\s*$")
+ENCODING = re.compile(r"/\*\s*0x[0-9a-f]{16}\s*\*/\s*$")
+
+
+def function_bodies(lines):
+    """Yield (architecture + symbol, ordered PC->full encoded instruction)."""
+    arch, name, body, pending = None, None, {}, None
+    for line in lines:
+        if pending is not None:
+            assert CONTROL.fullmatch(line), f"missing control word after {hex(pending)}"
+            body[pending] += "\n" + line.strip()
+            pending = None
+            continue
+        if re.search(r"arch = sm_", line):
+            arch = line.strip()
+        if "Function :" in line:
+            if name is not None:
+                assert body, name
+                yield name, body
+            assert arch is not None
+            name = arch + " " + line.split("Function :", 1)[1].strip()
+            body = {}
+        instruction = INSTRUCTION.match(line)
+        if instruction:
+            assert name is not None and ENCODING.search(line)
+            pc = int(instruction[1], 16)
+            assert pc not in body
+            body[pc] = line.strip()
+            pending = pc
+    assert pending is None, "truncated instruction scheduling word"
+    assert name is not None and body
+    yield name, body
+
+
+def body_sha(body):
+    return hashlib.sha256("\n".join(body.values()).encode()).hexdigest()
+
+
+def signatures(path):
+    result = {}
+    with path.open() as stream:
+        for name, body in function_bodies(stream):
+            result.setdefault(name, Counter())[body_sha(body)] += 1
+    return result
+
+
+def compare(before, candidate):
+    common = sorted(before.keys() & candidate.keys())
+    changed = [name for name in common if before[name] - candidate[name]]
+    removed = sorted(before.keys() - candidate.keys())
+    added = sorted(
+        name for name in candidate if candidate[name] - before.get(name, Counter())
+    )
+    identical = sum(sum((before[name] & candidate[name]).values()) for name in common)
+    return dict(
+        before_functions=sum(sum(values.values()) for values in before.values()),
+        candidate_functions=sum(sum(values.values()) for values in candidate.values()),
+        identical_common_functions=identical,
+        changed_common_functions=changed,
+        removed_functions=removed,
+        added_functions=added,
+        bodies={
+            name: dict(
+                before_instances=dict(before.get(name, {})),
+                candidate_instances=dict(candidate.get(name, {})),
+            )
+            for name in sorted(before.keys() | candidate.keys())
+        },
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--before-binary", required=True, type=Path)
+    parser.add_argument("--candidate-binary", required=True, type=Path)
+    parser.add_argument("--before-sass", required=True, type=Path)
+    parser.add_argument("--candidate-sass", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    result = compare(signatures(args.before_sass), signatures(args.candidate_sass))
+    result.update(
+        comparison="all PCs and BOTH encoding words; duplicate copies retained",
+        before_binary=dict(
+            path=str(args.before_binary), sha256=sha(args.before_binary)
+        ),
+        candidate_binary=dict(
+            path=str(args.candidate_binary), sha256=sha(args.candidate_binary)
+        ),
+        before_sass=dict(path=str(args.before_sass), sha256=sha(args.before_sass)),
+        candidate_sass=dict(
+            path=str(args.candidate_sass), sha256=sha(args.candidate_sass)
+        ),
+        source_sha256=sha(Path(__file__)),
+    )
+    with args.output.open("x") as stream:
+        stream.write(json.dumps(result, indent=2) + "\n")
+    print(json.dumps({k: v for k, v in result.items() if k != "bodies"}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/glm53_indexer_bound_leaves.py
+++ b/benchmarks/kernels/glm53_indexer_bound_leaves.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Numerical checks through actual AOT-held launchers, not model forwards."""
+
+from pathlib import Path
+
+from benchmarks.kernels import check_glm53_attention_norms as norms
+from benchmarks.kernels.check_glm53_rmsnorm_geometry import write_new
+
+PHASE_ORDER = [0, 0, 1, 1, 0]
+
+
+def expected_bindings(graphs):
+    return sorted(
+        (
+            {k: r[k] for k in ("graph", "symbol", "source")}
+            for r in graphs["bindings"]
+            if r["target"]
+        ),
+        key=lambda r: (r["graph"], r["symbol"], r["source"]),
+    )
+
+
+def expected_cases(manifest):
+    return [
+        r
+        for r in manifest["qualified_leaf_cases"]
+        if r["case"]["rank"] == manifest["rank"]
+    ]
+
+
+def audit_leaf(record, binding, entry, mode):
+    norms.require(mode in ("control", "correction"), "invalid leaf mode")
+    norms.require(
+        record["status"] == "complete"
+        and record["binding"] == binding
+        and record["qualified_case"] == entry,
+        "leaf binding/case identity differs",
+    )
+    qualified = norms.load_checked(Path(entry["path"]), entry["sha256"])
+    norms.require(
+        record["input_sha256"] == qualified["input_sha256"]
+        and record["replay_guards_pass"] is True,
+        "leaf input/replay guards differ",
+    )
+    norms.require(
+        [o["phase"] for o in record["observations"]] == PHASE_ORDER,
+        "missing leaf observations",
+    )
+    for observation in record["observations"]:
+        reference = qualified["phases"][observation["phase"]]
+        key = "candidate_sha256" if mode == "correction" else "baseline_sha256"
+        norms.require(
+            observation["outputs"] == reference[key],
+            "bound leaf output differs from qualified binary",
+        )
+        if mode == "correction":
+            norms.require(
+                observation["selection_sha256"] == reference["selected_sha256"]
+                and observation["arena_guards_pass"] is True,
+                "bound selection or arena guards differ",
+            )
+        else:
+            norms.require(
+                "selection_sha256" not in observation,
+                "control unexpectedly writes selection",
+            )
+
+
+def qualify_bindings(modules, manifest, graphs, output):
+    import torch
+
+    private = Path(manifest["private_namespace"])
+    module_map = {str(Path(m.__file__).relative_to(private)): m for m in modules}
+    weights = norms.load_weights()
+    norms.require(
+        {k: norms.tensor_sha(w) for k, w in zip(norms.WEIGHTS, weights)}
+        == manifest["weight_sha256"],
+        "leaf checkpoint weights changed",
+    )
+    bindings, cases = expected_bindings(graphs), expected_cases(manifest)
+    norms.require(
+        len(bindings) == 2 and len(cases) == 30, "two bindings/thirty cases required"
+    )
+    results = []
+    for binding in bindings:
+        tuner = vars(module_map[binding["graph"]])[binding["symbol"]]
+        launch = vars(tuner)["run"]
+        adapter = (
+            getattr(launch, "__self__", None)
+            if manifest["mode"] == "correction"
+            else None
+        )
+        for entry in cases:
+            case = entry["case"]
+            record = dict(
+                status="running", binding=binding, qualified_case=entry, observations=[]
+            )
+            path = output / f"leaf-{len(results):03d}.json"
+            try:
+                data = [
+                    norms.packed_inputs(
+                        case["rows"], case["seed"] + 100 * p, case["magnitude"]
+                    )
+                    for p in range(2)
+                ]
+                record["input_sha256"] = [norms.tensor_sha(x) for x in data]
+                if adapter is not None:
+                    adapter.verify()
+                    adapter.storage.fill_(171)
+
+                def observe(
+                    phase, values, *, adapter=adapter, case=case, record=record
+                ):
+                    item = dict(
+                        phase=phase, outputs=[norms.tensor_sha(t) for t in values]
+                    )
+                    if adapter is not None:
+                        adapter.verify()
+                        storage = adapter.storage.cpu()
+                        rows = case["rows"]
+                        norms.require(
+                            torch.all(storage[0] == 171).item()
+                            and torch.all(storage[rows + 1 :] == 171).item(),
+                            "leaf arena guard or unused rows mutated",
+                        )
+                        item.update(
+                            selection_sha256=norms.tensor_sha(storage[1 : rows + 1]),
+                            arena_guards_pass=True,
+                        )
+                    record["observations"].append(item)
+
+                norms.run_launches(
+                    {"combo": launch}, *data, weights, observe_phase=observe
+                )
+                norms.require(
+                    vars(tuner)["run"] is launch,
+                    "live target dispatch changed during leaves",
+                )
+                record.update(status="complete", replay_guards_pass=True)
+                audit_leaf(record, binding, entry, manifest["mode"])
+            except BaseException as error:
+                record.update(status="failed", error=repr(error))
+                raise
+            finally:
+                write_new(path, record)
+            results.append(dict(path=path.name, sha256=norms.sha(path)))
+            if len(results) % 10 == 0:
+                print(f"Bound leaves: {len(results)}/60", flush=True)
+    report = dict(
+        status="complete", bindings=bindings, cases=len(results), records=results
+    )
+    write_new(output / "bound-leaves.json", report)
+    return dict(cases=len(results), sha256=norms.sha(output / "bound-leaves.json"))

--- a/benchmarks/kernels/glm53_indexer_correction.py
+++ b/benchmarks/kernels/glm53_indexer_correction.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Isolated indexer cancellation correction; not installed into serving."""
+
+import triton
+import triton.language as tl
+from triton.language.extra.cuda import libdevice
+
+EXPONENT = -12
+OPTIONS = dict(num_warps=1, num_stages=1, enable_fp_fusion=False)
+
+
+def check_layout(packed, gamma, bias, output, selected, rows):
+    import torch
+
+    tensors = (packed, gamma, bias, output, selected)
+    if not all(isinstance(t, torch.Tensor) for t in tensors):
+        raise ValueError("tensor arguments required")
+    if any(t.device != packed.device for t in tensors):
+        raise ValueError("one device required")
+    if (
+        any(t.dtype != torch.bfloat16 for t in tensors[:-1])
+        or selected.dtype != torch.uint8
+    ):
+        raise ValueError("BF16 values and uint8 selection required")
+    expected = (
+        ((rows, 2336), (2336, 1)),
+        ((128,), (1,)),
+        ((128,), (1,)),
+        ((rows, 128), (256, 1)),
+        ((rows, 128), (128, 1)),
+    )
+    if any(
+        (tuple(t.shape), t.stride()) != layout for t, layout in zip(tensors, expected)
+    ):
+        raise ValueError("packed/indexer/selection layout differs")
+
+
+@triton.jit
+def correct_indexer(Packed, Gamma, Bias, Output, Selected, N):
+    row = tl.program_id(0)
+    col = tl.arange(0, 128)
+    valid = row < N
+    y = tl.load(Output + row * 256 + col, valid, other=0).to(tl.float32)
+    b = tl.load(Bias + col).to(tl.float32)
+    scale = tl.abs(y - b) + tl.abs(b)
+    selected = valid & (scale > 0) & (tl.abs(y) <= 0.000244140625 * scale)
+    # Explicit diagnostic coverage; its bandwidth is included in probe timing.
+    tl.store(Selected + row * 128 + col, selected.to(tl.uint8), valid)
+    if tl.sum(selected.to(tl.int32), 0) > 0:
+        x = tl.load(Packed + row * 2336 + 2048 + col, valid, other=0).to(tl.float64)
+        mean = tl.sum(x, 0) / 128.0
+        centered = x - mean
+        variance = tl.sum(centered * centered, 0) / 128.0
+        inverse = 1.0 / libdevice.sqrt(variance + tl.full((), 1e-6, tl.float64))
+        gamma = tl.load(Gamma + col).to(tl.float64)
+        value = (centered * inverse) * gamma + b.to(tl.float64)
+        # Keep FP64 through affine; only the final result converts to BF16.
+        tl.store(Output + row * 256 + col, value.to(tl.bfloat16), selected)
+
+
+class IndexerOnlyCorrection:
+    """Original combo ABI plus a precompiled correction on the same stream."""
+
+    def __init__(self, combo, correction, selected):
+        if not callable(combo) or not callable(correction):
+            raise ValueError("two precompiled launchers required")
+        self.combo, self.correction, self.selected = combo, correction, selected
+        self.combo_calls = self.correction_calls = 0
+
+    def __call__(self, *args, stream):
+        if len(args) != 11:
+            raise ValueError("original combo ABI requires eleven arguments")
+        rows = args[8]
+        if type(rows) is not int or rows <= 0 or args[9:] != (rows, rows):
+            raise ValueError("matching positive row counts required")
+        check_layout(args[0], args[3], args[4], args[7], self.selected, rows)
+        result = self.combo(*args, stream=stream)
+        self.combo_calls += 1
+        self.correction(
+            args[0], args[3], args[4], args[7], self.selected, rows, stream=stream
+        )
+        self.correction_calls += 1
+        return result

--- a/benchmarks/kernels/glm53_indexer_correction_loader.py
+++ b/benchmarks/kernels/glm53_indexer_correction_loader.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in indexer correction loader policy; no production installation.
+
+Reuse observed static CUDA loads and the extra-launch graph lifecycle. Compile
+the unchanged qualified JIT, then adapt its already-compiled bytes to Torch's
+static launcher; do not generate another kernel or inject a saved cubin.
+"""
+
+import base64
+import hashlib
+from pathlib import Path
+
+from benchmarks.analyze_glm53_quality_pair import require
+from benchmarks.kernels.glm53_indexer_correction import (
+    OPTIONS,
+    IndexerOnlyCorrection,
+)
+from benchmarks.kernels.glm53_kv_loader import (
+    KVIntervention,
+    KVLoader,
+    check_source,
+    load_preserving_provenance,
+)
+from slimserve.rmsnorm_diagnostic import sha
+
+SCHEMA = "glm53-indexer-correction-loader-v1"
+SIGNATURE = dict(
+    Packed="*bf16", Gamma="*bf16", Bias="*bf16", Output="*bf16", Selected="*u8", N="i32"
+)
+
+
+def to_static(compiled, record, rank, binary_root):
+    """Exact in-memory/disk image checks before any driver load."""
+    import triton
+    from torch._inductor.runtime.static_triton_launcher import (
+        StaticallyLaunchedCudaKernel,
+    )
+    from torch._inductor.runtime.triton_heuristics import StaticTritonCompileResult
+
+    key = base64.b32encode(bytes.fromhex(compiled.hash)).decode().rstrip("=")
+    path = Path(binary_root) / key / (record["kernel"] + ".cubin")
+    require(
+        compiled.src.fn.__name__ == record["kernel"] == "correct_indexer"
+        and compiled.src.fn.arg_names == list(SIGNATURE)
+        and compiled.src.signature == SIGNATURE
+        and not compiled.src.constants
+        and key == record["selected"]["hash"]
+        and record["selected"]["config"] == {"num_warps": 1, "num_stages": 1}
+        and {k: getattr(compiled.metadata, k) for k in OPTIONS} == OPTIONS,
+        "correction JIT/signature/config/key differs",
+    )
+    image = compiled.asm["cubin"]
+    require(
+        isinstance(image, bytes)
+        and path.resolve() == path
+        and hashlib.sha256(image).hexdigest() == sha(path) == record["cubin_sha256"],
+        "correction compiled image differs from qualification",
+    )
+    # Same conversion performed by StaticTritonCompileResult.can_statically_launch,
+    # but no permissive fallback to another launcher and no recompile.
+    compiled._cubin_path = str(path)
+    static = StaticallyLaunchedCudaKernel(compiled)
+    require(
+        static.arg_tys == "OOOOOi" and not static.full_constexprs,
+        "correction static ABI differs",
+    )
+    return StaticTritonCompileResult(
+        static,
+        triton.Config({}, num_warps=1, num_stages=1),
+        dict(device=rank, device_type="cuda", constants={}, signature=SIGNATURE),
+        dict(grid_type="FixedGrid", fixed_grid=["N", 1, 1]),
+    )
+
+
+class BoundIndexerCorrection:
+    """Per-binding fixed scratch storage; no allocation or compilation in run.
+
+    Only views and the qualified adapter are created on the host during graph
+    capture. Each target binding owns its arena; CUDA graph replay uses its stable
+    addresses. Serving must validate capacity against its scheduler before install.
+    """
+
+    def __init__(self, combo, correction, storage, capacity):
+        self.combo, self.correction = combo, correction
+        self.storage, self.capacity = storage, capacity
+        self.address = storage.data_ptr()
+        self.device = storage.device
+        self.verify()
+
+    def verify(self):
+        import torch
+
+        require(
+            type(self.capacity) is int
+            and 0 < self.capacity <= 65536
+            and isinstance(self.storage, torch.Tensor)
+            and self.storage.dtype == torch.uint8
+            and self.storage.device == self.device
+            and tuple(self.storage.shape) == (self.capacity + 2, 128)
+            and self.storage.stride() == (128, 1)
+            and self.storage.data_ptr() == self.address,
+            "indexer selection arena rebound or malformed",
+        )
+        require(
+            callable(self.combo) and callable(self.correction),
+            "bound launchers required",
+        )
+
+    def run(self, *args, stream):
+        require(len(args) == 11, "original combo ABI requires eleven arguments")
+        rows = args[8]
+        require(
+            type(rows) is int
+            and 0 < rows <= self.capacity
+            and args[9:] == (rows, rows),
+            "correction rows exceed fixed arena or disagree",
+        )
+        self.verify()
+        selected = self.storage[1 : rows + 1]
+        return IndexerOnlyCorrection(self.combo, self.correction, selected)(
+            *args, stream=stream
+        )
+
+
+def check_adapter(adapter, combo, correction, capacity):
+    require(
+        type(adapter) is BoundIndexerCorrection
+        and adapter.combo is combo
+        and adapter.correction is correction
+        and adapter.capacity == capacity
+        and "run" not in vars(adapter)
+        and "verify" not in vars(adapter),
+        "indexer correction adapter dispatch changed",
+    )
+    adapter.verify()
+
+
+class IndexerCorrectionIntervention(KVIntervention):
+    schema = SCHEMA
+    candidate_mode = "correction"
+    extra_key = "correction"
+    event_prefix = "indexer_correction"
+
+    def make_adapter(self, launcher, pair):
+        import torch
+
+        capacity = self.manifest["selection_capacity"]
+        require(
+            type(capacity) is int and 0 < capacity <= 65536,
+            "bounded selection capacity required",
+        )
+        storage = torch.full(
+            (capacity + 2, 128), 171, dtype=torch.uint8, device=f"cuda:{self.rank}"
+        )
+        adapter = BoundIndexerCorrection(launcher, pair[1], storage, capacity)
+        return adapter, adapter.run
+
+    def verify_adapter(self, binding):
+        adapter = binding["adapter"]
+        require(
+            getattr(binding["run"], "__self__", None) is adapter
+            and getattr(binding["run"], "__func__", None) is BoundIndexerCorrection.run,
+            "indexer correction run bypassed",
+        )
+        check_adapter(
+            adapter,
+            binding["launcher"],
+            binding["appended"][1],
+            self.manifest["selection_capacity"],
+        )
+
+    def graph_inventory(self, modules):
+        from benchmarks.kernels.audit_glm53_indexer_correction_graphs import inventory
+
+        return inventory(modules, self.manifest, self.rank, self.mode, self.observer)
+
+
+class IndexerCorrectionLoader(KVLoader):
+    hook_marker = "_glm53_indexer_correction_loader"
+    controller_class = IndexerCorrectionIntervention
+    source_file = __file__
+
+    def compile_replacement(self, record):
+        import torch
+        import triton
+        from triton.compiler import ASTSource
+
+        self.check_cache()
+        check_source(record, self.private)
+        jit = self.templates.get(record["relative"])
+        if jit is None:
+            jit = load_preserving_provenance(
+                self.private / record["relative"],
+                Path(record["source"]),
+                record["kernel"],
+                f"glm53_indexer_{sha(self.manifest_path)}_rank{self.rank}",
+                debug_source=Path(record["debug_source"]),
+            )
+            self.templates[record["relative"]] = jit
+        root = self.cache / "triton" / str(self.rank)
+        with torch.cuda.device(self.rank), triton.knobs.cache.scope():
+            triton.knobs.cache.dir = str(root)
+            compiled = triton.compile(
+                ASTSource(jit, signature=SIGNATURE), options=OPTIONS
+            )
+            result = to_static(compiled, record, self.rank, root)
+        self.check_cache()
+        require(
+            self.observer.digest(result) == record["cubin_sha256"],
+            "static conversion changed image",
+        )
+        return result

--- a/benchmarks/kernels/glm53_indexer_correction_serving.py
+++ b/benchmarks/kernels/glm53_indexer_correction_serving.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qualified correction plus diagnostic-only scheduler/stream envelope checks.
+
+No change to the AOT-qualified leaf dispatch. Both control and correction have
+the same host checks; timings are diagnostics, not production baselines.
+"""
+
+import threading
+from functools import wraps
+
+from benchmarks.kernels.audit_glm53_indexer_correction_graphs import inventory
+from benchmarks.kernels.check_glm53_attention_norms import require
+from benchmarks.kernels.glm53_geometry_serving import ServingGeometry
+from benchmarks.kernels.glm53_indexer_correction_loader import IndexerCorrectionLoader
+
+
+def check_envelope(record, capacity):
+    require(
+        type(capacity) is int
+        and capacity == 8192
+        and type(record["max_num_tokens"]) is int
+        and 0 < record["max_num_tokens"] <= capacity
+        and record["scheduler_max_tokens"] == record["max_num_tokens"]
+        and all(
+            type(n) is int and 0 < n <= record["max_num_tokens"]
+            for n in record["capture_sizes"]
+        )
+        and record["data_parallel_size"] == record["decode_context_parallel_size"] == 1
+        and record["use_ubatching"] is False
+        and record["sequence_parallel"] is False,
+        "indexer correction requires bounded serialized TP4 scheduler/capture",
+    )
+
+
+def runtime_envelope(runner, capacity):
+    record = dict(
+        max_num_tokens=runner.max_num_tokens,
+        scheduler_max_tokens=runner.scheduler_config.max_num_batched_tokens,
+        capture_sizes=list(runner.cudagraph_batch_sizes),
+        data_parallel_size=runner.parallel_config.data_parallel_size,
+        decode_context_parallel_size=runner.parallel_config.decode_context_parallel_size,
+        use_ubatching=runner.parallel_config.use_ubatching,
+        sequence_parallel=runner.compilation_config.pass_config.enable_sp,
+    )
+    check_envelope(record, capacity)
+    return record
+
+
+class ServingIndexerCorrection(ServingGeometry):
+    def __init__(self, rank, manifest, path):
+        super().__init__(
+            rank,
+            manifest,
+            path,
+            loader_type=IndexerCorrectionLoader,
+            graph_inventory=inventory,
+            root_only=True,
+        )
+        self.streams["runtime-envelope"] = (
+            self.folder / "runtime-envelope.jsonl"
+        ).open("x")
+        self.runner = None
+        self.owner_thread = self.last_stream = self.live_stream = None
+        self.observed = set()
+
+    def snapshot(self, phase):
+        import torch
+
+        envelope = runtime_envelope(self.runner, self.manifest["selection_capacity"])
+        require(
+            envelope == self.summary["runtime_envelope"], "runtime envelope changed"
+        )
+        report = super().snapshot(phase)
+        guards = []
+        for binding in self.loader.controller.owners.values():
+            if "adapter" not in binding:
+                continue
+            adapter = binding["adapter"]
+            adapter.verify()
+            storage = adapter.storage
+            require(
+                bool(torch.all(storage[0] == 171))
+                and bool(torch.all(storage[-1] == 171)),
+                "serving selection arena guard overwritten",
+            )
+            guards.append(dict(address=adapter.address, bytes=storage.numel()))
+        require(
+            len(guards) == (2 if self.mode == "correction" else 0),
+            "arena coverage differs",
+        )
+        self.summary.setdefault("arena_snapshots", {})[phase] = guards
+        self.save()
+        return report
+
+    def observe_padding(self, tokens, result):
+        import torch
+
+        padded, ubatch, dp_tokens = result[1].num_tokens, result[2], result[3]
+        require(
+            type(tokens) is int
+            and type(padded) is int
+            and 0
+            < tokens
+            <= padded
+            <= self.summary["runtime_envelope"]["max_num_tokens"]
+            and not ubatch
+            and dp_tokens is None,
+            "actual padded batch exceeds arena or enables parallel microbatches",
+        )
+        thread = threading.get_ident()
+        require(
+            self.owner_thread in (None, thread),
+            "concurrent worker thread is unqualified",
+        )
+        self.owner_thread = thread
+        stream = int(torch.cuda.current_stream().cuda_stream)
+        phase = "live" if self.summary["status"] == "capture-qualified" else "startup"
+        if phase == "live":
+            require(self.live_stream in (None, stream), "live forward stream changed")
+            self.live_stream = stream
+        barrier = self.last_stream is not None and self.last_stream != stream
+        if barrier:
+            require(
+                not torch.cuda.is_current_stream_capturing(),
+                "stream transition inside capture",
+            )
+            # Startup/profile/capture may use different streams. Establish ordering
+            # explicitly at transitions only; steady-state batches do not synchronize.
+            torch.cuda.synchronize()
+        self.last_stream = stream
+        key = (phase, tokens, padded, stream)
+        if key not in self.observed or barrier:
+            self.observed.add(key)
+            self.emit(
+                "runtime-envelope",
+                dict(
+                    phase=phase,
+                    tokens=tokens,
+                    padded=padded,
+                    stream=stream,
+                    thread=thread,
+                    transition_barrier=barrier,
+                ),
+            )
+
+    def install(self, runner):
+        self.runner = runner
+        self.summary["runtime_envelope"] = runtime_envelope(
+            runner, self.manifest["selection_capacity"]
+        )
+        self.save()
+        original = runner._determine_batch_execution_and_padding
+
+        @wraps(original)
+        def padding(*args, **kwargs):
+            try:
+                result = original(*args, **kwargs)
+                self.observe_padding(args[0] if args else kwargs["num_tokens"], result)
+                return result
+            except BaseException as error:
+                self.fail("runtime-envelope", error)
+                raise
+
+        super().install(runner)
+        runner._determine_batch_execution_and_padding = padding
+
+        def restore():
+            require(
+                runner._determine_batch_execution_and_padding is padding,
+                "foreign padding hook change",
+            )
+            runner._determine_batch_execution_and_padding = original
+
+        self.stack.callback(restore)
+
+
+def check_runtime_records(manifest, summary, records):
+    """Independent CPU audit of configuration, guards and observed padded batches."""
+    envelope = summary["runtime_envelope"]
+    check_envelope(envelope, manifest["selection_capacity"])
+    phases = ("before-forward", "capture-before", "capture-after")
+    arenas = summary["arena_snapshots"]
+    require(set(arenas) == set(phases), "missing arena snapshot")
+    reference = arenas[phases[0]]
+    require(
+        all(arenas[p] == reference for p in phases)
+        and len(reference) == (2 if manifest["mode"] == "correction" else 0)
+        and len({r["address"] for r in reference}) == len(reference)
+        and all(
+            type(r["address"]) is int
+            and r["address"] > 0
+            and r["bytes"] == (manifest["selection_capacity"] + 2) * 128
+            for r in reference
+        ),
+        "arena lifetime/address/size changed",
+    )
+    require(
+        records
+        and {r["phase"] for r in records} == {"startup", "live"}
+        and len({r["thread"] for r in records}) == 1
+        and len({r["stream"] for r in records if r["phase"] == "live"}) == 1,
+        "runtime thread/stream coverage incomplete",
+    )
+    last_stream, live = None, False
+    for row in records:
+        require(
+            type(row["tokens"]) is int
+            and type(row["padded"]) is int
+            and 0 < row["tokens"] <= row["padded"] <= envelope["max_num_tokens"],
+            "observed padding outside arena",
+        )
+        require(not live or row["phase"] == "live", "startup after live execution")
+        live = row["phase"] == "live"
+        require(
+            row["transition_barrier"]
+            is (last_stream is not None and last_stream != row["stream"]),
+            "missing/unexpected stream transition barrier",
+        )
+        last_stream = row["stream"]
+    return dict(
+        observed_batches=len(records),
+        max_padded=max(r["padded"] for r in records),
+        single_live_stream=True,
+        arena_bindings=len(reference),
+    )

--- a/benchmarks/kernels/glm53_stable_align_probe.cu
+++ b/benchmarks/kernels/glm53_stable_align_probe.cu
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Isolated probe; does not register a torch op or replace a serving kernel.
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include "glm_moe_stable_align.cuh"
+
+using torch::Tensor;
+
+void run_into(Tensor ids, Tensor sorted, Tensor experts, Tensor padded,
+              Tensor offsets, int64_t block, bool parallel_count, bool aggregate,
+              bool parallel_scatter) {
+    TORCH_CHECK(aggregate || parallel_count, "direct count requires 1024 threads");
+    TORCH_CHECK(!parallel_scatter || (parallel_count && !aggregate),
+                "parallel scatter requires direct count");
+    TORCH_CHECK(ids.is_cuda() && ids.scalar_type() == torch::kInt32 &&
+                ids.is_contiguous() && ids.dim() == 2 && ids.size(0) >= 17 &&
+                ids.size(0) <= 8192 && ids.size(1) == 8,
+                "expected contiguous CUDA int32 [17..8192,8] IDs");
+    TORCH_CHECK(block == 8 || block == 16 || block == 32 || block == 48 || block == 64,
+                "unsupported block size");
+    const int numel = ids.numel();
+    const int capacity = std::min(numel * int(block), numel + 288 * (int(block) - 1));
+    const int blocks = (capacity + block - 1) / block;
+    const std::vector<std::pair<Tensor, int64_t>> outputs = {
+        {sorted, capacity}, {experts, blocks}, {padded, 1}, {offsets, 289}};
+    for (const auto& [tensor, size] : outputs) {
+        TORCH_CHECK(tensor.device() == ids.device() && tensor.scalar_type() == torch::kInt32 &&
+                    tensor.is_contiguous() && tensor.dim() == 1 && tensor.size(0) == size,
+                    "incorrect same-device contiguous int32 output geometry");
+    }
+    const c10::cuda::CUDAGuard guard(ids.device());
+    const auto* prop = at::cuda::getCurrentDeviceProperties();
+    TORCH_CHECK(prop->major == 12 && prop->minor == 0, "SM120 probe only");
+    const auto stream = at::cuda::getCurrentCUDAStream();
+    auto counter = !aggregate ? tms::glm_stable_align::count_prefix<1024, false>
+        : parallel_count ? tms::glm_stable_align::count_prefix<1024, true>
+                         : tms::glm_stable_align::count_prefix<256, true>;
+    counter<<<2, parallel_count ? 1024 : 256, 0, stream>>>(
+        ids.data_ptr<int>(), sorted.data_ptr<int>(), experts.data_ptr<int>(),
+        padded.data_ptr<int>(), offsets.data_ptr<int>(), numel, block, capacity, blocks);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    auto scatter = parallel_scatter ? tms::glm_stable_align::scatter_bitmap<512>
+                                    : tms::glm_stable_align::scatter_bitmap<256>;
+    scatter<<<288, parallel_scatter ? 512 : 256, 0, stream>>>(
+        ids.data_ptr<int>(), sorted.data_ptr<int>(), offsets.data_ptr<int>(), numel);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+std::vector<Tensor> run(Tensor ids, int64_t block, bool parallel_count, bool aggregate,
+                       bool parallel_scatter) {
+    TORCH_CHECK(ids.dim() == 2 && ids.size(0) >= 17 && ids.size(0) <= 8192 &&
+                ids.size(1) == 8, "expected [17..8192,8] IDs");
+    TORCH_CHECK(block == 8 || block == 16 || block == 32 || block == 48 || block == 64,
+                "unsupported block size");
+    const int numel = ids.numel();
+    const int capacity = std::min(numel * int(block), numel + 288 * (int(block) - 1));
+    auto options = ids.options().dtype(torch::kInt32);
+    auto sorted = torch::empty({capacity}, options);
+    auto experts = torch::empty({(capacity + block - 1) / block}, options);
+    auto padded = torch::empty({1}, options);
+    auto offsets = torch::empty({289}, options);
+    run_into(ids, sorted, experts, padded, offsets, block, parallel_count, aggregate,
+             parallel_scatter);
+    return {sorted, experts, padded};
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("run", &run, pybind11::arg("ids"), pybind11::arg("block"),
+          pybind11::arg("parallel_count") = false, pybind11::arg("aggregate") = true,
+          pybind11::arg("parallel_scatter") = false);
+    m.def("run_into", &run_into, pybind11::arg("ids"), pybind11::arg("sorted"),
+          pybind11::arg("experts"), pybind11::arg("padded"), pybind11::arg("offsets"),
+          pybind11::arg("block"), pybind11::arg("parallel_count") = false,
+          pybind11::arg("aggregate") = true, pybind11::arg("parallel_scatter") = false);
+}

--- a/benchmarks/kernels/glm53_stable_align_probe.py
+++ b/benchmarks/kernels/glm53_stable_align_probe.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Isolated SM120 stable large-M alignment candidate, not used by serving."""
+
+import os
+from pathlib import Path
+
+from benchmarks.kernels.benchmark_mhc_output_parallel import build as build_probe
+
+
+def build():
+    directory = os.environ.get("SLIMSERVE_GLM53_STABLE_ALIGN_PROBE")
+    if not directory:
+        raise RuntimeError(
+            "set SLIMSERVE_GLM53_STABLE_ALIGN_PROBE to an isolated build directory"
+        )
+    return build_probe(Path(directory), name="glm53_stable_align_probe")

--- a/benchmarks/kernels/glm53_stable_route_probe.cu
+++ b/benchmarks/kernels/glm53_stable_route_probe.cu
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Isolated probe: neither registers nor replaces the serving router.
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include "glm_moe_routing.cuh"
+
+using torch::Tensor;
+
+std::vector<Tensor> run(Tensor logits, Tensor bias, int64_t scoring,
+                       bool renormalize, double scaling, int64_t block_size,
+                       bool stable) {
+    TORCH_CHECK(logits.is_cuda() && logits.scalar_type() == torch::kFloat32 &&
+                logits.is_contiguous() && logits.dim() == 2 &&
+                logits.size(0) >= 1 && logits.size(0) <= 16 &&
+                logits.size(1) == 288, "expected contiguous CUDA FP32 [1..16,288]");
+    TORCH_CHECK(bias.device() == logits.device() && bias.is_contiguous() &&
+                bias.scalar_type() == torch::kFloat32 && bias.dim() == 1 &&
+                bias.size(0) == 288, "expected same-device contiguous FP32 bias[288]");
+    TORCH_CHECK(scoring == 0 || scoring == 1, "expected sigmoid or sqrt-softplus");
+    TORCH_CHECK(block_size == 8 || block_size == 16 || block_size == 32 ||
+                block_size == 48 || block_size == 64, "unsupported block size");
+    const c10::cuda::CUDAGuard guard(logits.device());
+    const int M = logits.size(0), numel = M * 8;
+    const int capacity = std::min(numel * int(block_size),
+                                  numel + 288 * (int(block_size) - 1));
+    const int blocks = (capacity + block_size - 1) / block_size;
+    auto i32 = logits.options().dtype(torch::kInt32);
+    auto weights = torch::empty({M, 8}, logits.options());
+    auto ids = torch::empty({M, 8}, i32);
+    auto sorted = torch::empty({capacity}, i32);
+    auto experts = torch::empty({blocks}, i32);
+    auto padded = torch::empty({1}, i32);
+    auto kernel = stable ? tms::glm_route::route_align_kernel<288, 8, true>
+                         : tms::glm_route::route_align_kernel<288, 8, false>;
+    kernel<<<1, tms::glm_route::THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+        logits.data_ptr<float>(), bias.data_ptr<float>(), weights.data_ptr<float>(),
+        ids.data_ptr<int32_t>(), sorted.data_ptr<int32_t>(), experts.data_ptr<int32_t>(),
+        padded.data_ptr<int32_t>(), M, scoring, scaling, renormalize, block_size,
+        capacity, blocks);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return {weights, ids, sorted, experts, padded};
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) { m.def("run", &run); }

--- a/benchmarks/kernels/glm53_stable_route_probe.py
+++ b/benchmarks/kernels/glm53_stable_route_probe.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Isolated SM120 compilation of both small-M route/alignment policies."""
+
+import os
+from pathlib import Path
+
+from benchmarks.kernels.benchmark_mhc_output_parallel import build as build_probe
+
+
+def build():
+    directory = os.environ.get("SLIMSERVE_GLM53_STABLE_ROUTE_PROBE")
+    if not directory:
+        raise RuntimeError(
+            "set SLIMSERVE_GLM53_STABLE_ROUTE_PROBE to an isolated build directory"
+        )
+    return build_probe(Path(directory), name="glm53_stable_route_probe")

--- a/benchmarks/kernels/prepare_glm53_indexer_correction_loader.py
+++ b/benchmarks/kernels/prepare_glm53_indexer_correction_loader.py
@@ -1,0 +1,336 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU inspection of qualified indexer sources and actual AOT root mapping.
+
+This produces a base report, not runnable per-arm manifests or a GPU protocol.
+"""
+
+import argparse
+import base64
+import copy
+import importlib
+import shutil
+import subprocess
+from pathlib import Path
+
+from benchmarks.kernels.check_glm53_attention_norms import load_checked, require, verify
+from benchmarks.kernels.check_glm53_rmsnorm_geometry import write_new
+from benchmarks.kernels.glm53_artifact_roots import discover, read_store
+from benchmarks.kernels.glm53_indexer_correction_loader import SCHEMA
+from benchmarks.kernels.prepare_glm53_geometry_loader import (
+    current_sources,
+    graph_inventory,
+    loader_source_files,
+)
+from benchmarks.kernels.prepare_glm53_kv_loader import CONTRACTS_SHA, MAPPING_SHA
+from slimserve.rmsnorm_diagnostic import NAMESPACE, sha
+
+ROOT = Path(__file__).resolve().parents[2]
+RESULTS = ROOT / "perf/results/2026-09-10"
+QUALIFICATION_SHA = "c6ac3d0399af92be467ef47831f512c4edee60ff08fe0772afb399c59a18cc65"
+SELECTION_CAPACITY = 8192  # Explicit diagnostic envelope; serving must check it.
+ORDER = tuple((mode, rank) for mode in ("control", "correction") for rank in range(4))
+
+
+def build_base():
+    folder = RESULTS / "indexer-correction-v1"
+    analysis_path = folder / "analysis.json"
+    analysis = load_checked(analysis_path, QUALIFICATION_SHA)
+    require(
+        analysis["status"] == "complete"
+        and analysis["cases"] == 120
+        and not analysis["failures"]
+        and analysis["corrected_oracle_max_ulp"] <= 1
+        and analysis["production_qualified"] is False,
+        "completed isolated correction qualification required",
+    )
+    manifest_path = RESULTS / "runtime-control/indexer-correction-manifest-v1.json"
+    old = load_checked(manifest_path, analysis["manifest_sha256"])
+    summary_path = folder / "summary.json"
+    summary = load_checked(summary_path, analysis["summary_sha256"])
+    require(
+        summary["status"] == "complete"
+        and len(summary["binaries"]) == 4
+        and summary["manifest_sha256"] == sha(manifest_path),
+        "qualified summary differs",
+    )
+    contracts_path = RESULTS / "runtime-control/attention-contracts.json"
+    contracts = load_checked(contracts_path, CONTRACTS_SHA)
+    mapping_path = RESULTS / "runtime-control/norm-graph-role-pairs.json"
+    mapping = load_checked(mapping_path, MAPPING_SHA)
+    original = Path(old["original_namespace"])
+    require(original.name == NAMESPACE, "wrong original namespace")
+    kernel = ROOT / "benchmarks/kernels/glm53_indexer_correction.py"
+    require(
+        sha(kernel) == old["sources"][str(kernel)],
+        "qualified correction kernel changed",
+    )
+    receipts = {
+        str(p): sha(p)
+        for p in (
+            analysis_path,
+            manifest_path,
+            summary_path,
+            contracts_path,
+            mapping_path,
+            kernel,
+        )
+    }
+    for path, digest in contracts["receipts"].items():
+        require(sha(path) == digest, "attention contract receipt changed")
+        receipts[path] = digest
+    leaf_cases = []
+    require(
+        len(summary["records"]) == len(old["cases"]) == 120,
+        "complete leaf matrix required",
+    )
+    for index, (item, case) in enumerate(zip(summary["records"], old["cases"])):
+        require(item["path"] == f"case-{index:03d}.json", "qualified case path differs")
+        path = folder / item["path"]
+        leaf = load_checked(path, item["sha256"])
+        require({k: leaf[k] for k in case} == case, "qualified case order differs")
+        receipts[str(path)] = item["sha256"]
+        leaf_cases.append(dict(path=str(path), sha256=item["sha256"], case=case))
+    targets = {}
+    for rank in range(4):
+        (source,) = [r for r in old["records"] if r["rank"] == rank]
+        binary = summary["binaries"][rank]
+        require(
+            binary["rank"] == rank
+            and binary["original_selected"] == source["selected"]
+            and binary["original_source_sha256"] == source["source_sha256"]
+            and binary["original_cubin_sha256"] == source["cubin_sha256"],
+            "original source/binary join differs",
+        )
+        relative = str(Path(source["source"]).relative_to(original))
+        require(
+            old["original_files"][relative] == source["source_sha256"],
+            "target absent from original inventory",
+        )
+        for field in ("source", "debug_source", "ptx"):
+            require(
+                sha(source[field]) == source[field + "_sha256"],
+                "original provenance changed",
+            )
+            receipts[source[field]] = source[field + "_sha256"]
+        cubins = []
+        for name, digest in binary["correction_artifacts"].items():
+            path = folder / name
+            require(
+                path.resolve() == path
+                and path.is_relative_to(folder)
+                and sha(path) == digest,
+                "qualified correction artifact drift",
+            )
+            receipts[str(path)] = digest
+            if path.suffix == ".cubin":
+                cubins.append(digest)
+        require(
+            len(cubins) == 1 and binary["correction_metadata"] == old["options"],
+            "correction image/config join differs",
+        )
+        uses = []
+        for pair in contracts["pairs"]:
+            if pair["rank"] != rank:
+                continue
+            mapped = pair["combo"]
+            require(
+                mapped["source"] == source["source"]
+                and mapped["source_sha256"] == source["source_sha256"]
+                and mapped["symbol"] == source["info"]["kernel"]
+                and mapped["config"] == source["selected"]["config"],
+                "target graph map differs",
+            )
+            uses.append(dict(graph=pair["old_graph"], symbol=mapped["symbol"]))
+        require(
+            len(uses) == 2 and len({r["graph"] for r in uses}) == 2,
+            "two real target graph uses required",
+        )
+        target = {
+            k: source[k]
+            for k in (
+                "source",
+                "source_sha256",
+                "debug_source",
+                "debug_source_sha256",
+                "selected",
+                "cubin_sha256",
+            )
+        }
+        target.update(
+            relative=relative,
+            kernel=source["info"]["kernel"],
+            static_graph_uses=uses,
+            correction=dict(
+                source=str(kernel),
+                source_sha256=sha(kernel),
+                relative="correction_sources/glm53_indexer_correction.py",
+                debug_source=str(kernel),
+                debug_source_sha256=sha(kernel),
+                kernel="correct_indexer",
+                selected=dict(
+                    hash=base64.b32encode(bytes.fromhex(binary["correction_hash"]))
+                    .decode()
+                    .rstrip("="),
+                    config=dict(num_warps=1, num_stages=1),
+                ),
+                cubin_sha256=cubins[0],
+            ),
+        )
+        targets[str(rank)] = [target]
+    modules = (
+        "glm53_indexer_correction_loader",
+        "audit_glm53_indexer_correction_graphs",
+        "glm53_kv_loader",
+        "glm53_loader_hooks",
+        "glm53_binary_observer",
+        "glm53_artifact_roots",
+        "audit_glm53_geometry_graphs",
+        "glm53_indexer_bound_leaves",
+        "check_glm53_indexer_correction_loader",
+        "audit_glm53_indexer_correction_loader",
+        "check_glm53_geometry_loader",
+        "audit_glm53_kv_loader",
+        "audit_glm53_geometry_loader",
+    )
+    additions = [
+        Path(__file__),
+        *loader_source_files(),
+        *[
+            Path(importlib.import_module("benchmarks.kernels." + n).__file__)
+            for n in modules
+        ],
+        Path(
+            importlib.import_module(
+                "torch._inductor.runtime.static_triton_launcher"
+            ).__file__
+        ),
+    ]
+    previous = copy.deepcopy(old["sources"])
+    additions.append(ROOT / "perf/glm53-indexer-loader-protocol.md")
+    released = {}
+    for name in (
+        "perf/glm53-indexer-correction-protocol.md",
+        "perf/glm53-attention-isolation.md",
+    ):
+        path = str(ROOT / name)
+        before = previous.pop(path, None)
+        if before is not None:
+            additions.append(Path(path))
+            if sha(path) != before:
+                released[path] = dict(previous=before, current=sha(path))
+    sources, refreshed = current_sources(previous, additions)
+    sources.update(receipts)
+    base = dict(
+        schema=SCHEMA,
+        namespace=NAMESPACE,
+        qualification_sha256=QUALIFICATION_SHA,
+        contracts_sha256=CONTRACTS_SHA,
+        original_namespace=str(original),
+        original_files=old["original_files"],
+        targets=targets,
+        expected_graphs=graph_inventory(mapping, original),
+        expected_gpu_config=summary["gpu_config"],
+        selection_capacity=SELECTION_CAPACITY,
+        qualified_leaf_cases=leaf_cases,
+        weight_sha256=old["weight_sha256"],
+        sources=sources,
+        released_helper_changes={**released, **refreshed},
+        git_commit=subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True
+        ).strip(),
+    )
+    roots = {}
+    for rank in range(4):
+        store, _ = read_store(original / f"rank_{rank}_0/model")
+        require(
+            store.num_artifacts() == 7 and store.num_entries() == 46,
+            "AOT matrix changed",
+        )
+        roots[str(rank)] = discover(store, original, base["expected_graphs"][str(rank)])
+    base["artifact_roots"] = roots
+    verify(base)
+    return base
+
+
+def prepare_series(output):
+    require(not output.exists(), "preserve prior series")
+    require(
+        not subprocess.check_output(
+            ["git", "status", "--porcelain"], text=True
+        ).strip(),
+        "commit implementation/protocol before preparation",
+    )
+    base = build_base()
+    output, original = output.resolve(), Path(base["original_namespace"])
+    require(
+        not output.is_relative_to(original) and not original.is_relative_to(output),
+        "overlapping caches",
+    )
+    require(not any(p.is_symlink() for p in original.rglob("*")), "original aliases")
+    output.mkdir(parents=True)
+    extras = {
+        t["correction"]["relative"]: t["correction"]
+        for ts in base["targets"].values()
+        for t in ts
+    }
+    runs = []
+    for mode, rank in ORDER:
+        folder = output / f"{mode}-rank{rank}"
+        cache = folder / "cache"
+        private = cache / "torch_compile_cache/torch_aot_compile" / NAMESPACE
+        shutil.copytree(original, private)
+        require(
+            all(sha(private / p) == h for p, h in base["original_files"].items()),
+            "private copy differs",
+        )
+        for relative, source in extras.items():
+            target = private / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            require(not target.exists(), "extra source collision")
+            shutil.copyfile(source["source"], target)
+            require(sha(target) == source["source_sha256"], "extra copy differs")
+        manifest = dict(
+            base,
+            rank=rank,
+            mode=mode,
+            cache_root=str(cache),
+            private_namespace=str(private),
+            private_sources={p: r["source_sha256"] for p, r in extras.items()},
+            receipts=str(folder / "receipts"),
+        )
+        path = folder / "manifest.json"
+        write_new(path, manifest)
+        runs.append(
+            dict(mode=mode, rank=rank, manifest=str(path), manifest_sha256=sha(path))
+        )
+    verify(base)
+    write_new(
+        output / "preparation.json",
+        dict(
+            status="prepared",
+            runs=runs,
+            sources=base["sources"],
+            qualification_sha256=QUALIFICATION_SHA,
+        ),
+    )
+    print(f"Prepared {len(runs)} ordered AOT/leaf runs", flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--prepare-series", action="store_true")
+    args = parser.parse_args()
+    require(not args.output.exists(), "preserve prior report")
+    if args.prepare_series:
+        prepare_series(args.output)
+        return
+    base = build_base()
+    write_new(args.output, base)
+    print(
+        f"Inspected 4 sources, 8 AOT target bindings; {len(base['sources'])} receipts"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/prepare_glm53_indexer_correction_serving.py
+++ b/benchmarks/kernels/prepare_glm53_indexer_correction_serving.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Join completed AOT/leaf receipts into one control/correction/return series."""
+
+import argparse
+import sys
+from pathlib import Path
+
+from benchmarks.kernels import prepare_glm53_kv_serving as common
+from benchmarks.kernels.check_glm53_attention_norms import require
+from benchmarks.kernels.check_glm53_indexer_correction_loader import ORDER as ORDER
+from benchmarks.kernels.prepare_glm53_geometry_serving import integration_sources
+from slimserve.indexer_correction_diagnostic import (
+    AOT_PAIR_SHA as AOT_PAIR_SHA,
+)
+from slimserve.indexer_correction_diagnostic import (
+    CASES as CASES,
+)
+from slimserve.indexer_correction_diagnostic import (
+    SERVING_SCHEMA as SERVING_SCHEMA,
+)
+
+ROOT = common.ROOT
+PAIR = ROOT / "perf/results/2026-09-10/indexer-aot-v1/pair-analysis.json"
+EXTRA_KEY = "correction"
+COMMON_FIELDS = (
+    *common.COMMON_FIELDS,
+    "selection_capacity",
+    "weight_sha256",
+    "qualified_leaf_cases",
+)
+# No qualified kernel/loader/graph inspector bytes may change. Only this closed
+# stage's notebook changed among the AOT source freeze; serving files are new.
+INTEGRATION_SITES = {ROOT / "perf/glm53-indexer-loader-protocol.md"}
+
+
+def check_completed_report(report, row, manifest):
+    require(
+        row["leaf_cases"] == report["leaf_cases"] == 60
+        and report["leaf_phase_observations"] == 300
+        and manifest["selection_capacity"] == 8192
+        and len(manifest["qualified_leaf_cases"]) == 120,
+        "completed bound-leaf/arena qualification required",
+    )
+
+
+def completed_evidence(path):
+    return common.completed_evidence(path, workflow=sys.modules[__name__])
+
+
+def serving_sources(previous):
+    from slimserve.campaign_sources import PATHS
+
+    return integration_sources(
+        previous,
+        [
+            Path(__file__),
+            Path(common.__file__),
+            *(ROOT / p for p in PATHS),
+            *(
+                ROOT / f"benchmarks/kernels/{name}.py"
+                for name in (
+                    "prepare_glm53_geometry_serving",
+                    "glm53_geometry_workload",
+                    "audit_glm53_geometry_serving",
+                    "run_glm53_geometry_serving",
+                    "glm53_indexer_correction_serving",
+                )
+            ),
+            ROOT / "benchmarks/analyze_glm53_deterministic_serving.py",
+            ROOT / "slimserve/registry.py",
+            ROOT / "slimserve/hardware.py",
+            ROOT / "slimserve/profiles.json",
+            ROOT / "vllm/compilation/cuda_graph.py",
+            ROOT / "vllm/distributed/parallel_state.py",
+            ROOT / "vllm/utils/torch_utils.py",
+            ROOT / "perf/glm53-indexer-serving-protocol.md",
+            *sorted(INTEGRATION_SITES),
+        ],
+        allowed_changes=INTEGRATION_SITES,
+    )
+
+
+def prepare(path, output, *, inspect_only=False):
+    return common.prepare(
+        path, output, inspect_only=inspect_only, workflow=sys.modules[__name__]
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--qualification", type=Path, default=PAIR)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--inspect-only", action="store_true")
+    args = parser.parse_args()
+    prepare(args.qualification.resolve(), args.output, inspect_only=args.inspect_only)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/replay_glm53_indexer.py
+++ b/benchmarks/kernels/replay_glm53_indexer.py
@@ -18,8 +18,11 @@ import torch
 
 
 def sha(path):
+    digest = hashlib.sha256()
     with path.open("rb") as stream:
-        return hashlib.file_digest(stream, "sha256").hexdigest()
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
 
 
 def tensor_sha(value):

--- a/benchmarks/kernels/replay_glm53_indexer.py
+++ b/benchmarks/kernels/replay_glm53_indexer.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Replay captured first-layer GLM indexer inputs; no timing/quality claim.
+
+Fixed protocol: each original GPU, one warmup + five eager + five graph calls,
+alternating NaN/123 in undefined tails. Save EVERY output. The captured input
+has no ambiguous cutoff ties, so selected sets must equal the validated capture;
+raw output order is allowed to vary. Never substitute a new serving start.
+"""
+
+import argparse
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+import torch
+
+
+def sha(path):
+    with path.open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def tensor_sha(value):
+    return hashlib.sha256(
+        memoryview(value.contiguous().reshape(-1).view(torch.uint8).numpy())
+    ).hexdigest()
+
+
+def verified_selection(logits, starts, ends, indices, k=512):
+    """Independent CPU score-set, bounds, uniqueness and cutoff-tie checks."""
+    rows, columns = logits.shape
+    assert columns >= k and logits.dtype == torch.float32
+    assert starts.shape == ends.shape == (rows,)
+    assert starts.dtype == ends.dtype == indices.dtype == torch.int32
+    assert indices.shape == (rows, k)
+    assert bool((starts == 0).all())
+    assert bool(((ends >= 0) & (ends <= columns)).all())
+    visible = torch.arange(columns)[None, :] < ends[:, None]
+    assert bool(torch.isfinite(logits[visible]).all())
+    assert bool((logits[~visible] == 0).all())
+    valid = torch.arange(k)[None, :] < ends.clamp(max=k)[:, None]
+    assert torch.equal(indices >= 0, valid)
+    assert bool((indices[~valid] == -1).all())
+    assert bool(((indices < ends[:, None]) | ~valid).all())
+    ordered = indices.sort(dim=1).values
+    assert bool(((ordered[:, 1:] != ordered[:, :-1]) | (ordered[:, 1:] == -1)).all())
+    values = logits.gather(1, indices.clamp_min(0).long()).masked_fill(
+        ~valid, -torch.inf
+    )
+    best = logits.masked_fill(~visible, -torch.inf).topk(k, dim=1).values
+    assert torch.equal(values.sort(dim=1, descending=True).values, best)
+    cutoff = best[:, -1]
+    greater = ((logits > cutoff[:, None]) & visible).sum(dim=1)
+    equal = ((logits == cutoff[:, None]) & visible).sum(dim=1)
+    ambiguous = (ends > k) & (equal > k - greater)
+    return ordered, int(ambiguous.sum())
+
+
+def replay_device(captured, expected, device, operation):
+    rows, columns = captured["logits"].shape
+    records, outputs = [], []
+    with torch.cuda.device(device):
+        logits, starts, ends = (
+            captured[k].to(device) for k in ("logits", "starts", "ends")
+        )
+        indices = torch.empty_like(captured["indices"], device=device)
+        undefined = torch.arange(columns, device=device)[None, :] >= ends[:, None]
+
+        def call():
+            operation(logits, starts, ends, indices, rows, columns, 1, 512)
+
+        def observed_call(mode, repeat, callback):
+            poison = float("nan") if repeat % 2 == 0 else 123.0
+            logits.masked_fill_(undefined, poison)
+            before = logits.view(torch.uint8).clone()
+            indices.fill_(-777)
+            callback()
+            assert torch.equal(before, logits.view(torch.uint8)), (
+                "native modified logits"
+            )
+            actual = indices.cpu()
+            assert torch.equal(actual.sort(dim=1).values, expected), (
+                "selected set changed"
+            )
+            changed = actual != captured["indices"]
+            records.append(
+                {
+                    "mode": mode,
+                    "repeat": repeat,
+                    "undefined_tail_poison": "NaN" if repeat % 2 == 0 else "123",
+                    "selected_set_equals_validated_capture": True,
+                    "changed_order_positions_vs_capture": int(changed.sum()),
+                    "changed_order_rows_vs_capture": int(changed.any(dim=1).sum()),
+                    "sha256": tensor_sha(actual),
+                }
+            )
+            outputs.append(actual)
+
+        observed_call("warmup", 0, call)
+        graph = torch.cuda.CUDAGraph()
+        stream = torch.cuda.Stream(device=device)
+        stream.wait_stream(torch.cuda.current_stream(device))
+        with torch.cuda.graph(graph, stream=stream):
+            call()
+        torch.cuda.current_stream(device).wait_stream(stream)
+        for mode, callback in (("eager", call), ("graph", graph.replay)):
+            for repeat in range(5):
+                observed_call(mode, repeat, callback)
+        torch.cuda.synchronize(device)
+        del graph, stream
+    return records, outputs
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"], text=True
+    ).strip()
+    if active:
+        parser.error(f"GPU compute processes already active: {active}")
+    from slimserve.index_journal import enabled
+    from vllm import _custom_ops as ops
+
+    assert not enabled(), "replay must run without the serving observer"
+    assert torch.cuda.device_count() == 4
+    assert all(torch.cuda.get_device_capability(i) == (12, 0) for i in range(4))
+    torch.set_num_threads(1)
+    root = Path(__file__).resolve().parents[2]
+    run = args.run.resolve()
+    receipt = json.loads((run / "summary.json").read_text())
+    assert receipt["status"] == "complete" and receipt["diagnostic_only"]
+    native = "vllm/_C_stable_libtorch.abi3.so"
+    assert sha(root / native) == receipt["runtime"]["native_sha256"][native]
+    paths = list((run / "trace").glob("index-*.jsonl"))
+    assert len(paths) == 4
+    journals = {}
+    for path in paths:
+        events = [json.loads(line) for line in path.read_text().splitlines()]
+        forward = next(e for e in events if e["kind"] == "forward_begin")
+        device = int(forward["device"].split(":")[-1])
+        assert device not in journals
+        assert forward["tokens"] == 7616 and forward["computed_tokens"] == 0
+        journals[device] = path, events
+    assert set(journals) == set(range(4))
+    args.output.mkdir(parents=True, exist_ok=False)
+    result = {
+        "status": "running",
+        "diagnostic_only": True,
+        "protocol": (
+            "each original GPU: 1 warmup +5 eager +5 graph; poison NaN/123 tails"
+        ),
+        "git_commit": subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True
+        ).strip(),
+        "git_status": subprocess.check_output(["git", "status", "--short"], text=True),
+        "implementation_sha256": {
+            name: sha(root / name)
+            for name in (
+                "benchmarks/kernels/replay_glm53_indexer.py",
+                "vllm/_custom_ops.py",
+                "slimserve/index_journal.py",
+            )
+        },
+        "native_sha256": sha(root / native),
+        "torch": torch.__version__,
+        "source_receipt": {
+            "path": str(run / "summary.json"),
+            "sha256": sha(run / "summary.json"),
+        },
+        "devices": [],
+    }
+
+    def save():
+        (args.output / "summary.json").write_text(json.dumps(result, indent=2) + "\n")
+
+    save()
+    for device in range(4):
+        path, events = journals[device]
+        assert len([e for e in events if e["kind"] == "request_complete"]) == 3
+        captured, inputs = {}, []
+        for stage in ("logits", "starts", "ends", "indices"):
+            matches = [
+                e
+                for e in events
+                if e["kind"] == "tensor"
+                and e["chunk"] == 1
+                and e["stage"] == f"layer-03.call-0.{stage}"
+            ]
+            assert [m["match"] for m in matches] == [1, 2, 3]
+            if stage != "indices":
+                assert len({m["sha256"] for m in matches}) == 1
+            item = matches[0]
+            archive = Path(item["archive"]["path"])
+            assert sha(archive) == item["archive"]["sha256"]
+            value = torch.load(archive, weights_only=True, map_location="cpu")
+            assert tensor_sha(value) == item["sha256"]
+            captured[stage] = value
+            inputs.append(
+                {"stage": stage, "path": str(archive), "sha256": sha(archive)}
+            )
+        expected, ambiguous = verified_selection(**captured)
+        assert ambiguous == 0, "protocol requires unambiguous captured score sets"
+        rows, columns = captured["logits"].shape
+        assert (rows, columns) == (7616, 1904)
+        records, outputs = replay_device(
+            captured, expected, device, ops.top_k_per_row_prefill
+        )
+        output = args.output / f"gpu-{device}-all11-outputs.pt"
+        with output.open("xb") as stream:
+            torch.save(torch.stack(outputs), stream)
+        result["devices"].append(
+            {
+                "device": device,
+                "gpu": torch.cuda.get_device_name(device),
+                "journal_sha256": sha(path),
+                "inputs": inputs,
+                "observations": records,
+                "output_archive": {
+                    "path": str(output),
+                    "sha256": sha(output),
+                    "bytes": output.stat().st_size,
+                },
+            }
+        )
+        save()
+        print(
+            json.dumps(
+                {
+                    "device": device,
+                    "verified_calls": len(records),
+                    "distinct_output_orders": len({r["sha256"] for r in records}),
+                }
+            ),
+            flush=True,
+        )
+    result["status"] = "complete"
+    assert sha(root / native) == result["native_sha256"]
+    save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/replay_glm53_indexer_ties.py
+++ b/benchmarks/kernels/replay_glm53_indexer_ties.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fixed native-control/canonical-tie replay of actual layer23 captures.
+
+Each original GPU: each selector gets one warmup, five eager and five graph
+calls. Both use canonical output order. Preserve ALL88 output matrices. This
+is a correctness/repeatability diagnostic, not a benchmark or quality claim.
+"""
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.replay_glm53_indexer import sha, tensor_sha, verified_selection
+
+
+def canonical_selection(logits, starts, ends, k=512):
+    """Independent CPU score-descending, ID-ascending oracle; zeros compare equal."""
+    assert logits.device.type == "cpu" and logits.dtype == torch.float32
+    assert starts.dtype == ends.dtype == torch.int32
+    rows, columns = logits.shape
+    assert starts.shape == ends.shape == (rows,)
+    assert (starts == 0).all() and ((ends >= 0) & (ends <= columns)).all()
+    result = torch.full((rows, k), -1, dtype=torch.int32)
+    for row, end in enumerate(ends.tolist()):
+        assert torch.isfinite(logits[row, :end]).all()
+        selected = logits[row, :end].argsort(descending=True, stable=True)[:k]
+        result[row, : len(selected)] = selected.sort().values.int()
+    return result
+
+
+def replay_device(captured, expected, device, label, operation, canonicalize):
+    observations, outputs = [], []
+    with torch.cuda.device(device):
+        logits, starts, ends = (
+            captured[k].to(device) for k in ("logits", "starts", "ends")
+        )
+        indices = torch.empty_like(captured["indices"], device=device)
+        undefined = torch.arange(1904, device=device)[None, :] >= ends[:, None]
+
+        def call():
+            operation(logits, starts, ends, indices, 7616, 1904, 1, 512)
+            canonicalize(indices)
+
+        def observe(mode, repeat, callback):
+            logits.masked_fill_(undefined, float("nan") if repeat % 2 == 0 else 123.0)
+            before = logits.view(torch.uint8).clone()
+            indices.fill_(-777)
+            callback()
+            assert torch.equal(before, logits.view(torch.uint8))
+            actual = indices.cpu()
+            _, actual_ties = verified_selection(
+                captured["logits"], captured["starts"], captured["ends"], actual
+            )
+            assert actual_ties == 1
+            ordered = actual.where(actual >= 0, 2147483647)
+            assert torch.equal(ordered, ordered.sort(dim=1).values)
+            changed = (actual != expected).any(dim=1).nonzero().flatten().tolist()
+            assert changed in ([], [6329])
+            if label == "canonical-ties":
+                assert not changed
+            observations.append(
+                dict(
+                    selector=label,
+                    mode=mode,
+                    repeat=repeat,
+                    undefined_poison="NaN" if repeat % 2 == 0 else "123",
+                    all_score_sets_valid=True,
+                    canonical_oracle_equal=not changed,
+                    changed_rows_vs_canonical=changed,
+                    sha256=tensor_sha(actual),
+                )
+            )
+            outputs.append(actual)
+
+        observe("warmup", 0, call)
+        stream = torch.cuda.Stream(device=device)
+        stream.wait_stream(torch.cuda.current_stream(device))
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=stream):
+            call()
+        torch.cuda.current_stream(device).wait_stream(stream)
+        for mode, callback in (("eager", call), ("graph", graph.replay)):
+            for repeat in range(5):
+                observe(mode, repeat, callback)
+        torch.cuda.synchronize(device)
+        del graph, stream
+    return observations, outputs
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run", required=True, type=Path)
+    parser.add_argument("--reference-native", required=True, type=Path)
+    parser.add_argument("--native-comparison", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"], text=True
+    ).strip()
+    assert not active, f"GPU compute processes already active: {active}"
+    from slimserve.canonical_indexer import canonicalize, enabled
+    from vllm import _custom_ops as ops
+
+    assert not enabled(), "replay must not inherit serving diagnostic flags"
+    assert torch.cuda.device_count() == 4
+    assert all(torch.cuda.get_device_capability(i) == (12, 0) for i in range(4))
+    torch.set_num_threads(1)
+    root = Path(__file__).resolve().parents[2]
+    run = args.run.resolve()
+    receipt = json.loads((run / "summary.json").read_text())
+    assert receipt["status"] == "complete" and receipt["diagnostic_only"]
+    assert receipt["git_commit"] == "4cead10f6fcb12a199f1b65c47f28929cbf271e2"
+    native = "vllm/_C_stable_libtorch.abi3.so"
+    assert sha(args.reference_native) == receipt["runtime"]["native_sha256"][native]
+    proof = json.loads(args.native_comparison.read_text())
+    assert proof["before_binary"]["sha256"] == sha(args.reference_native)
+    assert proof["candidate_binary"]["sha256"] == sha(root / native)
+    assert not proof["changed_common_functions"] and not proof["removed_functions"]
+    assert proof["identical_common_functions"] == proof["before_functions"]
+    journals = {}
+    for path in (run / "trace").glob("index-*.jsonl"):
+        events = [json.loads(line) for line in path.read_text().splitlines()]
+        assert events[0]["capture_layer"] == 23
+        assert events[0]["selection_order"] == "canonical-pool-id"
+        forward = next(e for e in events if e["kind"] == "forward_begin")
+        device = int(forward["device"].split(":")[-1])
+        assert device not in journals
+        assert len([e for e in events if e["kind"] == "request_complete"]) == 3
+        journals[device] = path, events
+    assert set(journals) == set(range(4))
+    args.output.mkdir(parents=True, exist_ok=False)
+    result = dict(
+        status="running",
+        diagnostic_only=True,
+        protocol=(
+            "each original GPU, each selector:1 warmup+5 eager+5 graph; "
+            "canonical output order"
+        ),
+        git_commit=subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True
+        ).strip(),
+        git_status=subprocess.check_output(["git", "status", "--short"], text=True),
+        implementation_sha256={
+            name: sha(root / name)
+            for name in (
+                "benchmarks/kernels/replay_glm53_indexer_ties.py",
+                "benchmarks/kernels/replay_glm53_indexer.py",
+                "slimserve/canonical_indexer.py",
+                "slimserve/canonical_indexer_kernel.py",
+                "vllm/_custom_ops.py",
+                "csrc/libtorch_stable/sampler.cu",
+            )
+        },
+        native_sha256=sha(root / native),
+        reference_native_sha256=sha(args.reference_native),
+        native_comparison=dict(
+            path=str(args.native_comparison), sha256=sha(args.native_comparison)
+        ),
+        source_receipt=dict(
+            path=str(run / "summary.json"), sha256=sha(run / "summary.json")
+        ),
+        torch=torch.__version__,
+        devices=[],
+    )
+
+    def save():
+        (args.output / "summary.json").write_text(json.dumps(result, indent=2) + "\n")
+
+    save()
+    for device in range(4):
+        path, events = journals[device]
+        captured, files = {}, []
+        for stage in ("logits", "starts", "ends", "indices"):
+            items = [
+                e
+                for e in events
+                if e["kind"] == "tensor"
+                and e["chunk"] == 1
+                and e["stage"] == f"layer-23.call-0.{stage}"
+            ]
+            assert [e["match"] for e in items] == [1, 2, 3]
+            if stage != "indices":
+                assert len({e["sha256"] for e in items}) == 1
+            item = items[0]
+            archive = Path(item["archive"]["path"])
+            assert sha(archive) == item["archive"]["sha256"]
+            assert archive.stat().st_size == item["archive"]["bytes"]
+            value = torch.load(archive, weights_only=True, map_location="cpu")
+            assert tensor_sha(value) == item["sha256"]
+            captured[stage] = value
+            files.append(dict(stage=stage, path=str(archive), sha256=sha(archive)))
+        _, ties = verified_selection(**captured)
+        assert ties == 1 and captured["logits"].shape == (7616, 1904)
+        expected = canonical_selection(
+            *(captured[k] for k in ("logits", "starts", "ends"))
+        )
+        assert 994 in expected[6329] and 1398 not in expected[6329]
+        observations, outputs = [], []
+        for label, operation in (
+            ("native", ops.top_k_per_row_prefill),
+            ("canonical-ties", ops.glm53_top_k_per_row_prefill),
+        ):
+            recorded, matrices = replay_device(
+                captured, expected, device, label, operation, canonicalize
+            )
+            observations.extend(recorded)
+            outputs.extend(matrices)
+        archive = args.output / f"gpu-{device}-all22-outputs.pt"
+        with archive.open("xb") as stream:
+            torch.save(torch.stack(outputs), stream)
+        counts = {
+            label: len({r["sha256"] for r in observations if r["selector"] == label})
+            for label in ("native", "canonical-ties")
+        }
+        result["devices"].append(
+            dict(
+                device=device,
+                journal=str(path),
+                journal_sha256=sha(path),
+                inputs=files,
+                canonical_oracle_sha256=tensor_sha(expected),
+                observations=observations,
+                distinct_output_sets=counts,
+                output_archive=dict(
+                    path=str(archive), sha256=sha(archive), bytes=archive.stat().st_size
+                ),
+            )
+        )
+        save()
+        print(
+            json.dumps(
+                dict(
+                    device=device,
+                    verified_calls=len(observations),
+                    distinct_output_sets=counts,
+                )
+            ),
+            flush=True,
+        )
+    assert sha(root / native) == result["native_sha256"]
+    for name, digest in result["implementation_sha256"].items():
+        assert sha(root / name) == digest
+    result["status"] = "complete"
+    save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/replay_glm53_indexer_ties.py
+++ b/benchmarks/kernels/replay_glm53_indexer_ties.py
@@ -32,16 +32,17 @@ def canonical_selection(logits, starts, ends, k=512):
 
 
 def replay_device(captured, expected, device, label, operation, canonicalize):
+    rows, columns = captured["logits"].shape
     observations, outputs = [], []
     with torch.cuda.device(device):
         logits, starts, ends = (
             captured[k].to(device) for k in ("logits", "starts", "ends")
         )
         indices = torch.empty_like(captured["indices"], device=device)
-        undefined = torch.arange(1904, device=device)[None, :] >= ends[:, None]
+        undefined = torch.arange(columns, device=device)[None, :] >= ends[:, None]
 
         def call():
-            operation(logits, starts, ends, indices, 7616, 1904, 1, 512)
+            operation(logits, starts, ends, indices, rows, columns, 1, 512)
             canonicalize(indices)
 
         def observe(mode, repeat, callback):

--- a/perf/glm53-indexer-correction-protocol.md
+++ b/perf/glm53-indexer-correction-protocol.md
@@ -1,0 +1,135 @@
+# GLM53 indexer selective correction: isolated GPU protocol
+
+Status: completed isolated diagnostic on `f5ad4f884`; model qualification pending.
+Fixed recipe v1, TP4 RTX PRO 6000 SM120;
+production attention, quant, defaults and model-quality floors stay unchanged.
+This extra-launch diagnostic is not a speed optimization or serving integration.
+
+Baseline: four source/config/binary-exact original attention bundles from the
+completed rank-private probe. Their indexer LayerNorm128 one-BF16-ULP gate
+failed (max5); the split kernel is not used here. The independent historical
+failure remains recorded even if a new correction passes.
+
+Hypothesis: actual BF16 output/bias identifies cancellation-prone elements;
+FP64 recomputation can repair them without changing any unselected or sibling
+values. The CPU screen in `glm53-attention-isolation.md` caught all retained
+failures. Fixed trigger2^-12, chosen before GPU work; no threshold/config search.
+
+## Candidate and boundaries
+
+`benchmarks/kernels/glm53_indexer_correction.py` is opt-in probe code only:
+
+- Original combo first, correction second, same stream.
+- Output/bias detector in FP32, exact CPU-screen predicate. One warp per row;
+  128 columns; num_stages1; compiler FP fusion disabled.
+- Read input columns2048:2176 of `[rows,2336]`; recompute row mean, centered
+  variance, inverse standard deviation, normalization and affine in FP64.
+  Epsilon remains1e-6. Convert only the completed affine result to BF16.
+- Store only flagged elements in the first128 columns of `[rows,256]`.
+  Q1536, KV512, indexer gate, every unflagged value and input/weight/row/stride
+  guards must remain unchanged. A guarded uint8 selection output records the
+  actual detector decision; its overhead is included in diagnostic timing.
+
+## Prescribed experiment
+
+One CPU preparation, **one GPU process**, one terminal CPU audit. GPU0..3 run
+sequentially, each using its own fresh rank-private cache. Exactly120 cases:
+four ranks × rows(1,3,16,640,7616) × seeds(530901,530902) × magnitudes(.125,1,8).
+Each case has the original and seed+100 phase, eager repetition and graph
+replay with changed/restored input. Reproduce every original input/output hash.
+No model weights beyond the four small layer11 BF16 norm tensors are loaded.
+
+Correctness: exact GPU/CPU detector agreement; zero missed original failures;
+corrected indexer <=1 BF16 ULP against the unchanged FP64 oracle; all non-target,
+unflagged, input/weight/output/selection guards and graph checks pass. The final
+model-quality gate is separate and NOT exercised by this probe.
+
+Only after all120 cases pass, time rank0 rows(1,16,640,7616), seed530901,
+magnitude1.0. Control then correction, three paired repetitions; ten eager
+warmups and ten graph warmups per arm. Each timed graph contains32 calls.
+CUDA events report microseconds per original bundle or bundle+correction,
+including selection writes. No TPS, model performance or uninstrumented kernel
+claim follows from these timings. No tuning, retries, replacement starts,
+excluded cases or serving-cache writes. Stop and audit the first failed case.
+
+## Resources and freeze
+
+CPU preparation/tests/audit: user scope8GiB, swap0, CUDA hidden. GPU probe:
+user scope16GiB, swap0, CUDA_VISIBLE_DEVICES=0,1,2,3; one Torch/OMP CPU thread.
+Check no active compute workloads before starting. Record and compare GPU
+identity/driver/power settings at entry and after process exit. No native build
+or competing GPU work. Freeze code/protocol/compiler/receipts from preparation
+through terminal audit; preserve all raw data and original5172-file inventory.
+
+Commit the CPU-tested implementation before running these commands:
+
+```bash
+systemd-run --user --scope --unit=glm53-indexer-correction-prepare-v1 -p MemoryMax=8G -p MemorySwapMax=0 env CUDA_VISIBLE_DEVICES= PYTHONDONTWRITEBYTECODE=1 OMP_NUM_THREADS=1 .venv/bin/python -m benchmarks.kernels.check_glm53_indexer_correction prepare --manifest perf/results/2026-09-10/runtime-control/indexer-correction-manifest-v1.json
+systemd-run --user --scope --unit=glm53-indexer-correction-gpu-v1 -p MemoryMax=16G -p MemorySwapMax=0 env CUDA_VISIBLE_DEVICES=0,1,2,3 PYTHONDONTWRITEBYTECODE=1 OMP_NUM_THREADS=1 .venv/bin/python -m benchmarks.kernels.check_glm53_indexer_correction run --manifest perf/results/2026-09-10/runtime-control/indexer-correction-manifest-v1.json --output perf/results/2026-09-10/indexer-correction-v1
+systemd-run --user --scope --unit=glm53-indexer-correction-audit-v1 -p MemoryMax=8G -p MemorySwapMax=0 env CUDA_VISIBLE_DEVICES= PYTHONDONTWRITEBYTECODE=1 OMP_NUM_THREADS=1 .venv/bin/python -m benchmarks.kernels.check_glm53_indexer_correction audit --manifest perf/results/2026-09-10/runtime-control/indexer-correction-manifest-v1.json --output perf/results/2026-09-10/indexer-correction-v1
+```
+
+Preparation consumes pinned completed historical audits, not obsolete freeze
+validators. It creates a new source freeze for this experiment. Audit failure
+does not authorize another start: retain the failure and revise the hypothesis
+or implementation under a new explicit protocol before any subsequent GPU run.
+
+## Completed result (2026-09-10)
+
+Exactly one preparation, one GPU process and one terminal audit completed on
+`f5ad4f884`; no retry, replacement, omitted case, model launch or native build.
+CPU gate:95 pass/5.13s (initial5.15s). Both XML reports are retained under
+`runtime-control/indexer-correction-cpu-{v1,final}.xml` for2026-09-10.
+
+All120 cases/two phases pass. Corrected LayerNorm128 max1 BF16 ULP meets the
+unchanged oracle. GPU selection flags exactly match the independent CPU
+output/bias predicate; zero original failures are missed. Original input and
+three-output hashes reproduce. Q/KV, every unselected indexer value, input/
+weight/output/packed-gate/selection guards, eager repeat and changed/restored
+graph replay are exact. All four rank numerical records agree after removing
+only the rank field.
+
+Totals across ranks:5,720 selected elements,5,692 selected rows,484 changed
+elements. The deduplicated matrix has1,430 selected elements (0.011249% of
+12,711,936),1,423 selected rows (1.432858% of99,312),121 changed elements.
+Unlike the earlier CPU proxy, these counts come from actual GPU output flags.
+They describe this synthetic matrix and real layer11 weights, not all model
+layers/activations. The historical original failure remains recorded separately.
+
+All four new cubins have identical bytes, SHA
+`bd00effc35c7c0619ce74d3819aa3322cc110e423ce157ce855994f30188453e`.
+Saved PTX contains FP64 reduction, centering, variance and affine operations;
+full TTIR/PTX/cubin artifacts are retained per rank. Actual configuration is
+one warp, one stage, FP fusion disabled. All four original bundles reproduce
+their rank-specific archived binary identities.
+
+Only after numerical success, the prescribed timing matrix completed. Values
+are microseconds per bundle; median[min,max] across three paired repetitions:
+
+| Rows | Original bundle | Original + correction | Median added cost |
+| ---: | ---: | ---: | ---: |
+| 1 | 1.282 [1.280,1.293] | 1.978 [1.960,1.996] | 0.696 |
+| 16 | 1.472 [1.457,1.507] | 2.218 [2.215,2.258] | 0.746 |
+| 640 | 2.300 [2.240,2.306] | 5.553 [5.490,5.567] | 3.253 |
+| 7616 | 13.387 [13.183,13.446] | 17.831 [17.785,18.133] | 4.444 |
+
+These timings include selection writes and are NOT serving TPS or a speed win.
+Retain as an isolated correctness candidate for opt-in loader/model qualification,
+not a production default. An actual AOT-loader/forward/capture qualification and
+full control/correction/return model-quality comparison remain necessary. Do not
+remove selection writes without separately qualifying the changed binary.
+
+Terminal audit verifies236 frozen sources/receipts, all5,172 original files,
+all recorded binaries/cases, GPU release and unchanged UUID/driver/600W settings.
+Freeze ended after audit; later notebook updates do not alter that completed
+record. Subsequent work must consume this pinned completion, not rerun expired
+source-frozen validators.
+
+Raw directory: `perf/results/2026-09-10/indexer-correction-v1/`.
+
+- `analysis.json`: c6ac3d0399af92be467ef47831f512c4edee60ff08fe0772afb399c59a18cc65
+- `summary.json`: c8bae9e6b1c2c67398995aa213a2834a15ebd8a6a05fce3e6da848e5c1ddc855
+- Manifest `runtime-control/indexer-correction-manifest-v1.json`:
+  f6aeac30247935d93c97943c06da2b4a586efd915c768d3150dfbf7940315dbb
+
+No serving/profile/quant/native change or stable TPS baseline promotion follows.

--- a/perf/glm53-indexer-loader-protocol.md
+++ b/perf/glm53-indexer-loader-protocol.md
@@ -134,6 +134,21 @@ CUDA_VISIBLE_DEVICES=0,1,2,3 for rank-matched processes; each operates on its
 prescribed rank. GPU identities/driver/power settings must match the isolated
 qualification before and after each process. Confirm released contexts.
 
+Disk-cost review (2026-09-11): the retained completed `indexer-aot-v1` series
+occupies2,955,108,352 allocated bytes (2.752GiB), with2,832,429,791 apparent
+bytes including all eight private caches, manifests and qualification receipts.
+The control-rank0 private namespace occupies367,742,976 allocated bytes.
+Measured with `du -s -B1` and `du -s --apparent-size -B1`; this is the completed
+series footprint, not peak preparation space or a universal model-cache bound.
+Eight independent copies are intentional: per-arm loading may update caches,
+and sharing writable artifacts would compromise the isolation contract.
+
+Preparation deliberately refuses any existing output, including a partial
+failed series. Preserve that directory as failure evidence and retry only with
+a new explicit `--output` path after fixing the cause; do not delete evidence
+or resume a partially frozen namespace. This retained diagnostic is not a
+production serving cache, and no new AOT/serving campaign is prescribed here.
+
 ```bash
 systemd-run --user --scope --unit=glm53-indexer-aot-prepare-v1 -p MemoryMax=8G -p MemorySwapMax=0 env CUDA_VISIBLE_DEVICES= PYTHONDONTWRITEBYTECODE=1 OMP_NUM_THREADS=1 .venv/bin/python -m benchmarks.kernels.prepare_glm53_indexer_correction_loader --prepare-series --output perf/results/2026-09-10/indexer-aot-v1
 systemd-run --user --scope --unit=glm53-indexer-aot-controller-v1 -p MemoryMax=8G -p MemorySwapMax=0 env CUDA_VISIBLE_DEVICES=0,1,2,3 PYTHONDONTWRITEBYTECODE=1 OMP_NUM_THREADS=1 bash -c 'set -e; for mode in control correction; do for rank in 0 1 2 3; do .venv/bin/python -m benchmarks.kernels.check_glm53_indexer_correction_loader launch --manifest perf/results/2026-09-10/indexer-aot-v1/$mode-rank$rank/manifest.json; done; done'

--- a/perf/glm53-indexer-loader-protocol.md
+++ b/perf/glm53-indexer-loader-protocol.md
@@ -1,0 +1,170 @@
+# GLM53 indexer correction loader qualification
+
+Status: prescribed AOT/leaf series and final pair audit complete on `cf95040f3`.
+Serving integration remains pending.
+The fixed recipe/profile and original production attention remain unchanged.
+
+## Qualified starting point
+
+The isolated correction on `f5ad4f884` passed120 all-rank cases/two phases,
+unchanged max1BF16ULP oracle, detector agreement, non-target preservation and
+graph/guard checks. Its extra-launch timing is diagnostic, not a speed win.
+Completed result: `indexer-correction-v1/analysis.json` under2026-09-10, SHA
+c6ac3d0399af92be467ef47831f512c4edee60ff08fe0772afb399c59a18cc65.
+The original historical oracle failure and pending model-quality gate remain
+separate. See `glm53-indexer-correction-protocol.md` for the full GPU record.
+
+The kernel source is unchanged, SHA
+24ccefc2f8afcd74105a4715dc7bd930cf788fd5192d35c54098c98cd00173b7;
+all four qualified cubins have SHA
+bd00effc35c7c0619ce74d3819aa3322cc110e423ce157ce855994f30188453e.
+
+## Loader foundation
+
+- `glm53_indexer_correction_loader.py`: a separate schema, correction mode and
+  hook/event names atop the shared extra-launch lifecycle. KV remains the
+  default adapter policy, with its existing dispatch behavior preserved.
+- Compile the unchanged JIT with its original signature/options; compare key,
+  in-memory bytes and exact private-cache file against qualification. Convert
+  that compiled object to Torch's actual static CUDA launcher. No new kernel
+  generation, binary substitution or permissive launcher fallback.
+- Static ABI is five tensor pointers followed by int32 N; grid(N,1,1). The
+  existing binary observer records the actual driver input before loading and
+  retains live object/handle provenance afterward.
+- Each graph target binding gets fixed `[8194,128]` uint8 storage, including two
+  guard rows (1,048,832 bytes). A host view supplies the first N working rows to
+  the unchanged qualified adapter. No CUDA allocation/compile in dispatch.
+  This is an explicit8192-row diagnostic envelope, not an asserted scheduler
+  limit: future serving installation must check actual padded batch limits.
+- The graph inspector follows live `tuner.run` to the correction adapter and
+  its actual static runner; it does not infer appended identity from the
+  original combo's compile results. Arena address/geometry/device drift is
+  rejected. Original compile-result/launcher metadata remains truthful.
+
+The arena assumes serialized execution of a binding, as in the intended vLLM
+forward stream. Arbitrary concurrent cross-stream calls are not qualified.
+Serving/capture validation must establish the real lifecycle; a CPU test is not
+proof of CUDA graph or concurrent-workload safety.
+
+## CPU evidence
+
+358 tests pass/20.50s;14 upstream Torch deprecation warnings. Initial131 pass/
+7.72s retained. Coverage includes the real Torch static constructor/generated
+N-grid launcher with simulated native driver, strict source/config/image/ABI
+admission, fixed-arena view offsets/bounds/rebinding, future/graph binding,
+handle drift, wrong-device rejection and existing KV/geometry loader/serving
+regressions. CUDA driver and allocation are simulated where needed; no GPU or
+model launch occurred. Ruff/diff checks pass.
+
+`prepare_glm53_indexer_correction_loader.py` currently writes an **inspection
+base**, not runnable per-arm manifests. It joins the completed GPU receipt to
+all eight archived target uses, seven actual serialized AOT roots/46 entries
+per rank,269 source/evidence hashes and the5,172-file original inventory. It
+rejects qualified-kernel or archived graph drift. Completed audits are consumed
+without rerunning their expired source freezes.
+
+CPU8GiB/swap0, one OMP thread, CUDA hidden:
+
+```bash
+systemd-run --user --scope --unit=glm53-indexer-loader-inspection-v1 -p MemoryMax=8G -p MemorySwapMax=0 env CUDA_VISIBLE_DEVICES= PYTHONDONTWRITEBYTECODE=1 OMP_NUM_THREADS=1 .venv/bin/python -m benchmarks.kernels.prepare_glm53_indexer_correction_loader --output perf/results/2026-09-10/runtime-control/indexer-loader-inspection-v1.json
+systemd-run --user --scope --unit=glm53-indexer-loader-cpu-final -p MemoryMax=8G -p MemorySwapMax=0 env CUDA_VISIBLE_DEVICES= PYTHONDONTWRITEBYTECODE=1 OMP_NUM_THREADS=1 .venv/bin/python -m pytest -q tests/slimserve/test_indexer_correction_loader.py tests/slimserve/test_indexer_correction.py tests/slimserve/test_indexer_precision_analysis.py tests/slimserve/test_kv_loader.py tests/slimserve/test_kv_loader_audit.py tests/slimserve/test_kv_serving.py tests/slimserve/test_kv_serving_preparation.py tests/slimserve/test_binary_observer.py tests/slimserve/test_geometry_loader.py tests/slimserve/test_geometry_loader_audit.py tests/slimserve/test_geometry_serving.py tests/slimserve/test_geometry_serving_runner.py --junitxml=perf/results/2026-09-10/runtime-control/indexer-loader-cpu-final.xml
+```
+
+Raw under `perf/results/2026-09-10/runtime-control/`:
+
+- `indexer-loader-inspection-v1.json`:89f90eb95530b179f4150a5c2dbd37b87f5839f5e3ce62f4c5d169ee79fc240b
+- `indexer-loader-cpu-{v1,final}.xml`
+
+## Required next work before model execution
+
+Add runnable per-arm manifests, controller and independent offline auditor using
+the shared AOT lifecycle. Preserve actual-root inventory and full non-target
+binding comparisons. The new dispatch has not run on GPU: exercise each actual
+graph-held target with the original synthetic matrix, both phases, original and
+qualified corrected output hashes, arena/input/output guards and replay checks.
+Loading modules alone cannot qualify the static-launcher ABI or workspace.
+
+Prescribe the all-rank control/correction order, fixed matrix and failure policy
+before GPU work; use fresh private caches, CPU8GiB/GPU16GiB and swap0, one GPU
+workload at a time. Freeze sources from preparation through terminal audit.
+Only after that gate should this policy join the before-forward/capture serving
+lifecycle and a separately prescribed model control/correction/return series.
+No GPU/model process is prescribed by this foundation checkpoint.
+
+## Runnable AOT/leaf qualification v1
+
+This section supersedes the foundation's no-GPU next-step note above. Commit the
+complete implementation and this protocol before preparation. One preparation,
+eight sequential GPU processes, one audit per process, one final pair audit:
+control ranks0,1,2,3 then correction ranks0,1,2,3. One fresh private namespace per
+process. Stop on the first load/leaf/audit/release failure; no replacement starts.
+
+Each rank loads all seven actual serialized AOT roots/46 entries. Independent
+graph inventory expects25 bound launchers, two target bindings, and exact
+non-target equality against that rank's control. Binary observation covers the
+original and appended images; original metadata is not relabeled as correction.
+
+After target seal, exercise **each of the two actual graph-held target runs**,
+not an independently compiled substitute. Each binding runs30 cases: rows
+(1,3,16,640,7616), seeds(530901,530902), magnitudes(.125,1,8). Both seed and
+seed+100 inputs reproduce the completed isolated probe's input hashes. Five
+observations (original, repeat, changed graph replay, changed eager, restored
+graph replay) must reproduce its original or corrected output hashes by arm.
+Correction flags must reproduce the prior GPU flag hashes at every observation.
+Initialize each fixed arena to171 before a case; guard row0 and all unused rows
+after the live slice must stay171. Input/weight/output/stride/gate guards and
+eager/replay equality use the existing norm probe's checks.
+
+This totals480 bound-leaf cases,960 unique input phases across the eight runs,
+and2,400 repeated/replayed observations. Only four small real layer11 norm
+tensors are read; the summary/auditor explicitly require four, not zero. There
+is no outer-model deserialization, model forward, serving request, timer or TPS.
+The original oracle failure stays historical; corrected hashes inherit the
+previous one-ULP qualification only on that exact matrix.
+
+Global binary sealing occurs after leaf validation. Re-inventory actual graphs
+afterward; nothing may be rebound. Audit the complete leaf sequence and all raw
+receipt hashes independently; controller attestations alone are insufficient.
+Fresh source freeze spans preparation through the final successful pair audit
+(or retained terminal failure audit). Keep the qualified correction kernel and
+loader policy unchanged. No concurrent GPU work, serving, native build or tuning.
+
+Resources: CPU preparation/controller/audit8GiB; GPU process16GiB, swap0 for all.
+CUDA_VISIBLE_DEVICES=0,1,2,3 for rank-matched processes; each operates on its
+prescribed rank. GPU identities/driver/power settings must match the isolated
+qualification before and after each process. Confirm released contexts.
+
+```bash
+systemd-run --user --scope --unit=glm53-indexer-aot-prepare-v1 -p MemoryMax=8G -p MemorySwapMax=0 env CUDA_VISIBLE_DEVICES= PYTHONDONTWRITEBYTECODE=1 OMP_NUM_THREADS=1 .venv/bin/python -m benchmarks.kernels.prepare_glm53_indexer_correction_loader --prepare-series --output perf/results/2026-09-10/indexer-aot-v1
+systemd-run --user --scope --unit=glm53-indexer-aot-controller-v1 -p MemoryMax=8G -p MemorySwapMax=0 env CUDA_VISIBLE_DEVICES=0,1,2,3 PYTHONDONTWRITEBYTECODE=1 OMP_NUM_THREADS=1 bash -c 'set -e; for mode in control correction; do for rank in 0 1 2 3; do .venv/bin/python -m benchmarks.kernels.check_glm53_indexer_correction_loader launch --manifest perf/results/2026-09-10/indexer-aot-v1/$mode-rank$rank/manifest.json; done; done'
+systemd-run --user --scope --unit=glm53-indexer-aot-pair-v1 -p MemoryMax=8G -p MemorySwapMax=0 env CUDA_VISIBLE_DEVICES= PYTHONDONTWRITEBYTECODE=1 OMP_NUM_THREADS=1 .venv/bin/python -m benchmarks.kernels.audit_glm53_indexer_correction_loader compare perf/results/2026-09-10/indexer-aot-v1
+```
+
+An AOT/leaf pass still does not prove full-model quality, scheduler/padding
+coverage, arbitrary multi-stream reentrancy or serving graph-capture behavior.
+Those require the subsequent opt-in serving integration and separately prescribed
+control/correction/return workload. No production or stable-baseline promotion.
+
+## Completed v1 results
+
+All eight prescribed processes pass loading, leaf qualification, independent
+audit and GPU release.480 cases/960 unique phases/2,400 observations reproduce
+the completed isolated original/corrected output and selection hashes exactly.
+Every run has seven graphs/46 entries,25 bound launchers and two target bindings;
+each correction rank adds two static launchers. All92 non-target bindings exact.
+No forward, serving request, TPS or new timer was run.
+
+The final pair audit passes. Original5,172-file cache preserved; GPUs released,
+UUID/driver580.173.02/600W settings unchanged. One preparation and prescribed
+start per arm, no replacements, builds or concurrent GPU work. Source freeze
+ended after the successful pair audit, before notebook changes.
+
+Raw `perf/results/2026-09-10/indexer-aot-v1/pair-analysis.json`, SHA
+89fecf567bfe98ebcdb8ae6b948db7ad7387f4492877cba52c1f90ba65206061.
+Per-rank manifests, caches, launch/load/audit logs, driver/root inventories and
+individual leaf receipts remain under that directory. Consume these completed
+receipts in the next integration; do not rerun expired source-frozen validators.
+
+Decision: retain for opt-in serving integration. Scheduler/padding envelope,
+capture/serialized arena lifecycle and full-model quality remain separate gates.
+Historical original indexer oracle failure and stable TPS tables are unchanged.

--- a/perf/glm53-indexer-serving-protocol.md
+++ b/perf/glm53-indexer-serving-protocol.md
@@ -1,0 +1,194 @@
+# GLM53 selective indexer correction: model diagnostic
+
+Status: model series complete on `7b8f93afb`; all audits and final closure pass.
+Correction is quality-qualified on this workload, but has no speed win and stays
+opt-in. Source freeze has ended. Commands below are historical, not restart instructions.
+Production defaults, recipe and original arithmetic are unchanged.
+
+## Evidence and hypothesis
+
+Completed AOT/leaf series `cf95040f3`, pair SHA
+89fecf567bfe98ebcdb8ae6b948db7ad7387f4492877cba52c1f90ba65206061, verifies
+480 actual bound-leaf cases and2,400 eager/replay observations, non-target exactness,
+static image identity and arena guards. Consume those pinned completed receipts;
+do not rerun old frozen readers. The qualified correction kernel, loader, static
+ABI and selection writes remain byte-identical.
+
+Hypothesis: fixing the measured indexer LayerNorm cancellation may preserve or
+improve model-quality scores. Local one-ULP accuracy alone is insufficient; the
+previous KV-only candidate passed local accuracy but regressed model quality.
+This extra-launch diagnostic is not proposed as a speed optimization.
+
+## Serving lifecycle and scope
+
+Use the shared real-profile before-forward/capture lifecycle, actual graph roots,
+independent binary and non-target inventory, private caches and one-attempt
+controller. Distinct opt-in flag `SLIMSERVE_GLM53_INDEXER_CORRECTION` accepts only
+control/correction with its prepared manifest. No geometry/KV/legacy diagnostic
+mixing or alternative compiler policy. CLI/worker/campaign enforce the same flag.
+
+The actual scheduler maximum must equal the runner maximum and fit8192 rows;
+every configured capture size must fit. Reject DP/DCP>1, sequence parallelism or
+microbatching. Keep per-binding fixed1,048,832-byte arenas; verify addresses and
+end guards before forward, before capture and after capture. No leaf changes.
+
+Both arms additionally check the real batch-padding dispatcher before forward:
+positive integer input<=padded<=scheduler maximum, no DP token synchronization or
+microbatch output. Require a single host thread, and one steady-state live GPU
+stream. Startup/capture stream transitions explicitly synchronize once before
+continuing; an in-capture transition is rejected. Record newly observed batch
+shapes/streams and all transitions without per-token file writes. Existing vLLM
+capture/wrapper/parallel-stream implementations are frozen evidence. These checks
+are diagnostic instrumentation; there is no arbitrary cross-stream reentrancy
+claim and no production TPS promotion.
+
+## Required next gate
+
+CPU tests must cover default inertness, exact manifest/evidence admission,
+distinct policy/event dispatch, legacy KV/geometry regression, actual Torch
+AOT/capture plumbing with simulated driver, scratch bounds/lifetime, and runtime
+padding/thread/stream rejection. CPU8GiB/swap0, CUDA hidden, one OMP thread.
+The complete CPU gate must pass before the series below starts.
+
+## Prescribed model series v1
+
+Fixed `glm53-nvfp4-4` / `rtx6000`, recipe
+`glm53-redhatai-nvfp4-fp8-kda-tp4-v1`, TP4 Marlin, no EP/speculation, BF16
+activation/KV/lm_head, qualified original attention combo and native binaries.
+Native-order1/BF16fn1/TC0 match the completed diagnostic reference; native-order
+remains off in production. No power/clock/quant/compiler or quality-floor changes.
+
+Exactly one control, one correction, one return-control start, in that order;
+one fresh private namespace each. All5,172 original files plus the single shared
+qualified correction source are copied independently into each namespace. No
+saved replacement cubin is injected. The unchanged loader compiles/checks/adapts
+the qualified JIT as in the completed AOT series. All eight prior process/leaf
+audits, graph bindings and input/output/flag receipts are joined without rerunning
+expired validators. Only the closed loader notebook is released among prior
+frozen files; the serving integration/client/stream sources are newly frozen.
+
+Use the unchanged shared workload: exact1000 input/300 output, cold-prefix,
+c1/c8/c16 with three repeats each; three quality passes of4,096 scored text
+tokens plus all needle contrasts; text/image canaries; cold32K/128K prefill.
+Both controls must reproduce the pinned historical per-token vectors exactly.
+Every arm must repeat within-start exactly. The candidate's unchanged quality
+gate is evaluated and recorded, never waived or called passing if it fails.
+A repeatable candidate quality regression alone permits the prescribed return
+control to establish reversibility. Any other load/validity/audit/teardown failure
+stops the series; retain/audit partial evidence and do not retry/replace a start.
+All92 non-target AOT bindings must match, and return restores the full inventory.
+
+CPU preparation/controller/audit8GiB, serving150GiB, swap0 throughout. No builds,
+other GPU jobs, source/doc edits or commits from preparation through successful
+closure or audited terminal failure. The controller discovers the compatible
+registry profile, checks fixed hardware and GPU release, and enforces predecessors.
+The original historical oracle failure remains recorded even if correction passes
+its independent gate. No production/default or stable TPS promotion in this series.
+
+After CPU qualification and commit, from the repository root:
+
+```bash
+systemd-run --user --scope --unit=glm53-indexer-serving-v1-prepare -p MemoryMax=8G -p MemorySwapMax=0 env CUDA_VISIBLE_DEVICES= PYTHONDONTWRITEBYTECODE=1 OMP_NUM_THREADS=1 .venv/bin/python -m benchmarks.kernels.prepare_glm53_indexer_correction_serving --output perf/results/2026-09-10/indexer-serving-v1
+
+systemd-run --user --scope --unit=glm53-indexer-serving-v1-controller -p MemoryMax=8G -p MemorySwapMax=0 env CUDA_VISIBLE_DEVICES= PYTHONDONTWRITEBYTECODE=1 OMP_NUM_THREADS=1 bash -c 'for indexer_serving_case in control correction return-control; do .venv/bin/python -m benchmarks.kernels.run_glm53_geometry_serving launch "perf/results/2026-09-10/indexer-serving-v1/${indexer_serving_case}/manifest.json" || exit "$?"; done'
+
+systemd-run --user --scope --unit=glm53-indexer-serving-v1-close -p MemoryMax=8G -p MemorySwapMax=0 env CUDA_VISIBLE_DEVICES= PYTHONDONTWRITEBYTECODE=1 OMP_NUM_THREADS=1 .venv/bin/python -m benchmarks.kernels.run_glm53_geometry_serving close perf/results/2026-09-10/indexer-serving-v1
+```
+
+The historical geometry filename is the shared controller, not the selected
+intervention. Correction's manifest selects its flag, policy, graph/arena auditor,
+case order and closure result keys. Run closure after success or first failure,
+without launching unused cases. Preserve logs, failed attempts and private caches.
+
+CPU preparation may inspect completed evidence without making a serving cache:
+
+```bash
+systemd-run --user --scope --unit=glm53-indexer-serving-inspection-v1 -p MemoryMax=8G -p MemorySwapMax=0 env CUDA_VISIBLE_DEVICES= PYTHONDONTWRITEBYTECODE=1 OMP_NUM_THREADS=1 .venv/bin/python -m benchmarks.kernels.prepare_glm53_indexer_correction_serving --inspect-only --output perf/results/2026-09-10/runtime-control/indexer-serving-inspection-v1.json
+```
+
+That inspection completed, joining1,032 source/evidence receipts and5,172 original
+files. SHA06d82d9ba34a5e44a574d30bc6d7e6b128e4277770feac89442ced5c59792afb.
+It predates final formatting/tests/protocol edits; preparation freezes the committed
+bytes, not those earlier integration hashes. No GPU/cache/start was consumed.
+
+## Completed CPU gate
+
+Final554 tests pass/53.12s,14 upstream Torch deprecation warnings. Ruff and diff
+checks pass. Includes actual Torch AOT/capture plumbing with simulated driver and
+CPU-backed simulated CUDA arenas, independent runtime/graph audit, admission,
+fresh shared-source copying, manifest roundtrip, quality-failure closure and
+legacy loader/serving/campaign regressions. GPU/serving qualification is pending.
+
+Raw under `perf/results/2026-09-10/runtime-control/`:
+`indexer-serving-initial-cpu.xml`120 pass/14.63s;
+`indexer-serving-new-cpu-v1.xml`82 pass/two fixture-copy failures (Torch's copy
+restoration expected metadata absent from the minimal simulated tuner), corrected
+by constructing a second explicit fixture owner;
+`indexer-serving-new-cpu-v2.xml`108 pass/6.83s;
+`indexer-serving-cpu-final-v2.xml`547 pass/two test-isolation failures (a new test
+mutated a nested shared registry dictionary), corrected with a deep-copied plan;
+`indexer-serving-cpu-final-v3.xml`554 pass/53.12s after additional correction
+closure tests. The first final command named nonexistent CLI/ordering test files
+and stopped before collection; no code/model/case attempt was consumed.
+
+## Completed serving result
+
+Exactly the three prescribed starts, all serving/audit exits0 and final closure
+complete. All27 exact1000/300 timing rounds (225 measured requests), nine quality
+passes, text/image canaries and cold32K/128K checks complete. Every4,096 text score
+and168 needle-token score matches the historical original in all nine passes,
+not only aggregate means. Every unchanged window quality gate passes. Correction
+does not reproduce failed no-combo; no quality improvement is claimed from equality.
+
+All four ranks verify seven real AOT roots/46 entries,25 original launchers and
+two target bindings before forward and around capture. The candidate adds two
+qualified static launchers/rank. All92 non-target bindings compare exactly across
+starts, and return restores the full original binding inventory. This is AOT-root
+coverage, not a comparison of every later non-root runtime kernel.
+
+Runtime envelope is8192 rows; actual captures1,2,4,8,16,24,32,40,48,56,64. Each
+candidate rank records28 distinct observed shape/stream entries, maximum padded
+8192, one worker thread/live stream, and two distinct fixed1,048,832-byte arenas
+with stable addresses/intact end guards through capture. Startup stream changes
+have explicit barriers. No live selection/change-count instrumentation was added:
+score equality does not establish how many real activation values were corrected.
+Arbitrary cross-stream calls and contexts beyond the tested workload remain unqualified.
+
+Diagnostic E2E tok/s, median [min,max] of three repeats:
+
+| Arm | c1 | c8 | c16 |
+| --- | ---: | ---: | ---: |
+| Control | 157.160 [156.957,157.434] | 579.913 [577.775,581.489] | 781.671 [779.696,782.615] |
+| Correction | 156.457 [156.379,156.711] | 578.474 [578.000,578.546] | 777.935 [777.046,780.660] |
+| Return-control | 156.954 [156.858,157.182] | 579.502 [578.781,580.501] | 781.081 [779.999,781.528] |
+
+Cold prefill scheduled-to-first-token ms, median [min,max], no cached tokens:
+
+| Arm | 32K | 128K |
+| --- | ---: | ---: |
+| Control | 2581.139 [2579.520,2583.602] | 10882.224 [10847.315,10915.347] |
+| Correction | 2587.435 [2585.409,2588.407] | 10913.296 [10872.642,10945.535] |
+| Return-control | 2587.629 [2584.422,2589.924] | 10919.193 [10878.127,10951.509] |
+
+Startup168.110/164.111/162.090s; GPU release0.470/0.046/0.727s in order. Each arm
+retains eight recoverable allocator OOM warnings for4,718,592,000-byte temporary
+requests during scoring; requests complete, but the allocator path is not clean.
+The size matches a2MiB-rounded [7616,154880] FP32 buffer. Full prompt logits and
+FP32 log_softmax in GPUModelRunner/Sampler are candidates, not stack-proven cause.
+Teardown receipts retain1/0/3 transient zombies; resource-tracker warnings remain
+(control/return: one shared-memory object; candidate: four semaphores/six shared
+memory objects). No unhandled serving failure, retry, replacement or cache deletion.
+
+Closure verifies1,032 frozen source/evidence receipts,5,172 original files,
+preserved per-arm artifacts, GPU release and unchanged UUID/driver580.173.02/600W.
+Fresh GPU query confirms no compute processes. Freeze ended before notebook edits.
+Raw `perf/results/2026-09-10/indexer-serving-v1/closure.json`, SHA
+0d1302e05d6f2350d1bcf60be4d04691f489d6c3040f1bbca37fd890d139fa8b.
+
+Decision: retain as quality-qualified opt-in diagnostic; do not enable it by
+default. It pays a small extra-launch cost without improving these scores. No
+stable speed baseline, quant/native/default change or original-oracle relabeling.
+Resume measured performance work; before a fused correction variant, establish
+actual launch/selection coverage on real activations. Investigate the shared
+scoring allocation warnings without changing score semantics. No new GPU run is
+prescribed by this completed result; consume completed receipts after source edits.

--- a/tests/kernels/test_glm53_canonical_indexer.py
+++ b/tests/kernels/test_glm53_canonical_indexer.py
@@ -62,6 +62,8 @@ def test_changed_eager_graph_inputs_padding_and_storage_bounds(rows, offset):
 
 @pytest.mark.parametrize("device", [0, 1, 2, 3])
 def test_all44_real_replay_outputs_canonicalize_without_changing_membership(device):
+    if torch.cuda.device_count() < 4:
+        pytest.skip("requires four CUDA devices")
     root = Path(__file__).resolve().parents[2]
     path = root / "perf/results/2026-09-09/indexer-saved-input-replay/summary.json"
     if not path.exists():

--- a/tests/kernels/test_glm53_canonical_indexer.py
+++ b/tests/kernels/test_glm53_canonical_indexer.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Order-only diagnostic: independent CPU oracle, changed graphs, real captures."""
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+import torch
+
+from slimserve.canonical_indexer import canonicalize
+
+pytestmark = pytest.mark.skipif(
+    not (torch.cuda.is_available() and torch.cuda.get_device_capability() == (12, 0)),
+    reason="requires SM120",
+)
+
+
+def reference(indices):
+    # CPU sort puts -1 first. Rotate each row's negative prefix to the end;
+    # independent of the Triton INT_MAX-key implementation.
+    ordered = indices.sort(dim=1).values
+    padding = (indices == -1).sum(dim=1)
+    offsets = (torch.arange(512)[None, :] + padding[:, None]) % 512
+    return ordered.gather(1, offsets)
+
+
+def fixture(rows, seed):
+    g = torch.Generator().manual_seed(seed)
+    # Duplicates are intentionally included: ordering must preserve the whole
+    # multiset, not silently deduplicate or reselect. Real native IDs are unique.
+    values = torch.randint(0, 262144, (rows, 512), dtype=torch.int32, generator=g)
+    count = (torch.arange(rows) * 31 + seed) % 513
+    count[0] = 0 if seed % 2 else 512
+    values[torch.arange(512)[None, :] >= count[:, None]] = -1
+    return values[:, torch.randperm(512, generator=g)]
+
+
+@pytest.mark.parametrize("rows", [1, 2, 16, 17, 64, 65, 128, 640, 7616, 8192])
+@pytest.mark.parametrize("offset", [0, 1])
+def test_changed_eager_graph_inputs_padding_and_storage_bounds(rows, offset):
+    storage = torch.full((rows * 512 + 5,), -777, device="cuda", dtype=torch.int32)
+    indices = storage[offset : offset + rows * 512].view(rows, 512)
+    indices.copy_(fixture(rows, 391))
+    canonicalize(indices)
+    graph = torch.cuda.CUDAGraph()
+    stream = torch.cuda.Stream(device=indices.device)
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.graph(graph, stream=stream):
+        canonicalize(indices)
+    torch.cuda.current_stream().wait_stream(stream)
+    for seed in (392, 393, 394):
+        value = fixture(rows, seed)
+        want = reference(value)
+        for callback in (lambda: canonicalize(indices), graph.replay):
+            indices.copy_(value)
+            callback()
+            assert torch.equal(indices.cpu(), want)
+            assert (storage[:offset] == -777).all()
+            assert (storage[offset + rows * 512 :] == -777).all()
+
+
+@pytest.mark.parametrize("device", [0, 1, 2, 3])
+def test_all44_real_replay_outputs_canonicalize_without_changing_membership(device):
+    root = Path(__file__).resolve().parents[2]
+    path = root / "perf/results/2026-09-09/indexer-saved-input-replay/summary.json"
+    if not path.exists():
+        pytest.skip("requires locally retained full-chunk selector replay")
+    doc = json.loads(path.read_text())
+    assert doc["status"] == "complete"
+    entry = next(d for d in doc["devices"] if d["device"] == device)
+    archive = Path(entry["output_archive"]["path"])
+    with archive.open("rb") as stream:
+        assert (
+            hashlib.file_digest(stream, "sha256").hexdigest()
+            == entry["output_archive"]["sha256"]
+        )
+    values = torch.load(archive, weights_only=True, map_location="cpu", mmap=True)
+    assert values.shape == (11, 7616, 512)
+    want = reference(values[0])
+    with torch.cuda.device(device):
+        indices = values[0].to(device)
+        canonicalize(indices)
+        graph = torch.cuda.CUDAGraph()
+        stream = torch.cuda.Stream(device=device)
+        stream.wait_stream(torch.cuda.current_stream(device))
+        with torch.cuda.graph(graph, stream=stream):
+            canonicalize(indices)
+        torch.cuda.current_stream(device).wait_stream(stream)
+        for index, value in enumerate(values):
+            assert torch.equal(reference(value), want)
+            indices.copy_(value)
+            canonicalize(indices) if index % 2 == 0 else graph.replay()
+            assert torch.equal(indices.cpu(), want)

--- a/tests/kernels/test_glm53_canonical_moe.py
+++ b/tests/kernels/test_glm53_canonical_moe.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ordering-only intervention against independent CPU alignment construction."""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from slimserve.canonical_moe import canonicalize, geometry
+from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
+    moe_align_block_size,
+)
+from vllm.model_executor.layers.fused_moe.router.glm_route_align import (
+    marlin_block_size_m,
+)
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+def expected_alignment(ids, block_size):
+    flat = ids.cpu().numpy().reshape(-1)
+    capacity, max_blocks, _ = geometry(len(ids), 8, 288, block_size)
+    sorted_ids = np.full(capacity, len(flat), dtype=np.int32)
+    expert_ids = np.full(max_blocks, -1, dtype=np.int32)
+    cursor = 0
+    for expert in range(288):
+        assignments = np.flatnonzero(flat == expert)
+        padded = (len(assignments) + block_size - 1) // block_size * block_size
+        sorted_ids[cursor : cursor + len(assignments)] = assignments
+        expert_ids[cursor // block_size : (cursor + padded) // block_size] = expert
+        cursor += padded
+    return tuple(
+        torch.from_numpy(x)
+        for x in (sorted_ids, expert_ids, np.array([cursor], dtype=np.int32))
+    )
+
+
+@pytest.mark.parametrize(
+    "tokens", [1, 2, 8, 16, 17, 31, 64, 65, 129, 640, 1024, 7616, 8192]
+)
+def test_exact_alignment_eager_and_changed_input_graph(tokens):
+    block = marlin_block_size_m(tokens, 8, 288)
+    k = torch.arange(8)
+    inputs = [
+        ((torch.arange(tokens)[:, None] * 37 + k) % 288).int(),
+        k.expand(tokens, 8).contiguous().int(),
+        ((torch.arange(tokens)[:, None] * 17 + k * 31 + 73) % 288).int(),
+    ]
+    ids = inputs[0].cuda()
+
+    def call():
+        result = moe_align_block_size(ids, block, 288)
+        canonicalize(*result, tokens=tokens, block_size=block)
+        return result
+
+    def check(result, inp):
+        for got, expected in zip(result, expected_alignment(inp, block)):
+            assert torch.equal(got.cpu(), expected)
+        assert torch.equal(ids.cpu(), inp)
+
+    for inp in inputs:
+        ids.copy_(inp)
+        check(call(), inp)
+        check(call(), inp)
+    graph = torch.cuda.CUDAGraph()
+    stream = torch.cuda.Stream(device=ids.device)
+    stream.wait_stream(torch.cuda.current_stream(ids.device))
+    with torch.cuda.graph(graph, stream=stream):
+        output = call()
+    for inp in inputs + inputs[::-1]:
+        ids.copy_(inp)
+        graph.replay()
+        check(output, inp)
+
+
+def test_all_captured_layouts_canonicalize_identically():
+    trace = Path("perf/results/2026-09-09/mhc-quality-moe-trace-diagnostic/trace")
+    paths = sorted(trace.glob("model-*.jsonl"))
+    if not paths:
+        pytest.skip("requires bounded real-model MoE captures")
+    assert len(paths) == 4
+    canonical = None
+    for path in paths:
+        rows = [json.loads(line) for line in path.read_text().splitlines()]
+        files = {
+            (r["match"], r["stage"]): Path(r["path"])
+            for r in rows
+            if r["kind"] == "moe_snapshot"
+        }
+        for match in (1, 2, 3):
+
+            def load(stage, files=files, match=match):
+                return torch.load(
+                    files[match, "moe3." + stage], map_location="cpu", weights_only=True
+                )
+
+            ids = load("router.ids")
+            count = load("up.padded_count")
+            capacity, blocks, _ = geometry(640, 8, 288, 32)
+            sorted_ids = torch.full((capacity,), 5120, dtype=torch.int32)
+            sorted_ids[: int(count)] = load("up.sorted_ids")
+            experts = torch.full((blocks,), -1, dtype=torch.int32)
+            experts[: int(count) // 32] = load("up.expert_ids")
+            arrays = [t.cuda() for t in (sorted_ids, experts, count)]
+            canonicalize(*arrays, tokens=640, block_size=32)
+            actual = [t.cpu() for t in arrays]
+            for got, expected in zip(actual, expected_alignment(ids, 32)):
+                assert torch.equal(got, expected)
+            if canonical is None:
+                canonical = actual
+            assert all(torch.equal(a, b) for a, b in zip(actual, canonical))

--- a/tests/kernels/test_glm53_index_journal.py
+++ b/tests/kernels/test_glm53_index_journal.py
@@ -3,6 +3,7 @@
 
 import hashlib
 import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -246,12 +247,14 @@ def test_compiled_real_indexer_journal_and_runner_chunks(
     assert len([e for e in events if e["kind"] == "tensor"]) == 2 * (11 * 4 + 4)
     for item in (e for e in events if "archive" in e):
         assert item["stage"].startswith(f"layer-{capture_layer:02d}.call-0.")
-        path = (
+        path = Path(item["archive"]["path"])
+        expected = (
             config.parent
             / "trace"
             / f"index-{events[0]['pid']}"
             / (item["archive"]["path"].split("/")[-1])
         )
+        assert path == expected
         assert (
             hashlib.sha256(path.read_bytes()).hexdigest() == item["archive"]["sha256"]
         )

--- a/tests/kernels/test_glm53_index_journal.py
+++ b/tests/kernels/test_glm53_index_journal.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Synthetic GPU observer qualification, not full-model repeatability evidence."""
+
+import hashlib
+import json
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from slimserve import index_journal as ij
+from slimserve.canonical_indexer import maybe_ordered_topk
+from vllm import _custom_ops as ops
+from vllm.model_executor.layers import glm5_next_indexer as gi
+from vllm.utils.torch_utils import direct_register_custom_op
+from vllm.v1.attention.backends.mla.indexer import (
+    DeepseekV32IndexerMetadata,
+    DeepseekV32IndexerPrefillMetadata,
+    build_prefill_chunk_metadata,
+)
+
+pytestmark = pytest.mark.skipif(
+    not (torch.cuda.is_available() and torch.cuda.get_device_capability() == (12, 0)),
+    reason="requires SM120",
+)
+
+
+@pytest.fixture
+def config(tmp_path, monkeypatch):
+    path = tmp_path / "config.json"
+    path.write_text(
+        json.dumps(
+            dict(
+                schema=1,
+                prompt_ids=list(range(8199)),
+                max_matches=3,
+                output_directory=str(tmp_path / "trace"),
+            )
+        )
+    )
+    monkeypatch.setenv("SLIMSERVE_GLM53_INDEX_JOURNAL", str(path))
+    monkeypatch.setenv("SLIMSERVE_GLM53_MODEL_JOURNAL", "1")
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_MOE", "1")
+    return path
+
+
+@pytest.mark.parametrize("family", ["unique", "tied", "random"])
+def test_native_observer_keeps_inputs_and_records_actual_output(config, family):
+    rows, columns = 8, 2049
+    g = torch.Generator(device="cuda").manual_seed(927)
+    logits = torch.randn(rows, columns, device="cuda", generator=g)
+    if family == "unique":
+        logits = torch.stack(
+            [torch.randperm(columns, device="cuda", generator=g) for _ in range(rows)]
+        ).float()
+    elif family == "tied":
+        logits.zero_()
+    starts = torch.zeros(rows, dtype=torch.int32, device="cuda")
+    ends = torch.tensor(
+        [0, 1, 160, 512, 513, 1904, 2048, 2049], dtype=torch.int32, device="cuda"
+    )
+    undefined = torch.arange(columns, device="cuda")[None, :] >= ends[:, None]
+    logits.masked_fill_(undefined, float("nan"))
+    original = logits.view(torch.uint8).clone()
+    indices = torch.full((rows, 512), -777, dtype=torch.int32, device="cuda")
+    wrapped = ij.instrument_topk(ops.top_k_per_row_prefill)
+    journal = ij.IndexJournal(config)
+    journal.begin("synthetic", 0, rows, logits.device)
+    journal.layer_rows = journal.layer_calls = 0
+    token, layer_token = ij.ACTIVE.set(journal), ij.LAYER.set(3)
+    try:
+        wrapped(logits, starts, ends, indices, rows, columns, 1, 512)
+    finally:
+        ij.LAYER.reset(layer_token)
+        ij.ACTIVE.reset(token)
+        journal.close()
+    assert torch.equal(logits.view(torch.uint8), original)
+    captured = torch.load(
+        journal.archive / "match-1-chunk-1-layer-03.call-0.indices.pt",
+        weights_only=True,
+    )
+    assert torch.equal(captured, indices.cpu())
+    masked = torch.load(
+        journal.archive / "match-1-chunk-1-layer-03.call-0.logits.pt", weights_only=True
+    )
+    assert (masked[undefined.cpu()] == 0).all()
+    for row, end in enumerate(ends.tolist()):
+        count = min(end, 512)
+        selected = captured[row, :count].long()
+        assert ((selected >= 0) & (selected < end)).all()
+        assert selected.unique().numel() == count
+        assert (captured[row, count:] == -1).all()
+        want = logits[row, :end].cpu().sort(descending=True).values[:count]
+        got = masked[row, selected].sort(descending=True).values
+        assert torch.equal(want, got)
+        if end <= 512:
+            assert torch.equal(selected, torch.arange(count))
+
+
+@pytest.mark.parametrize("tiles", [(8, 64), (2, 128)])
+@pytest.mark.parametrize(
+    "canonical,ties,fused",
+    [
+        (False, False, False),
+        (True, False, False),
+        (True, True, False),
+        (True, True, True),
+    ],
+)
+@pytest.mark.parametrize("capture_layer", [3, 23])
+def test_compiled_real_indexer_journal_and_runner_chunks(
+    config, monkeypatch, tiles, canonical, ties, fused, capture_layer
+):
+    """The registered real opaque op, real CUDA selector and synthetic paged KV.
+
+    Input/return buffers are unchanged by observing. Selection order above512
+    pools is already variable, so do not claim raw repeated-index parity there.
+    """
+    # Each scenario registers a fresh synthetic op in the same namespace.
+    # Do not accumulate guards for destroyed op instances across test cases.
+    torch._dynamo.reset()
+    monkeypatch.setattr(gi, "_ROW_TILE", tiles[0])
+    monkeypatch.setattr(gi, "_POOL_TILE", tiles[1])
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_INDEX_ORDER", str(int(canonical)))
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_INDEX_TIES", str(int(ties)))
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_INDEX_FUSED", str(int(fused)))
+    settings = json.loads(config.read_text())
+    settings["capture_layer"] = capture_layer
+    config.write_text(json.dumps(settings))
+    monkeypatch.setattr(
+        gi,
+        "top_k_per_row_prefill",
+        ij.instrument_topk(maybe_ordered_topk(ops.top_k_per_row_prefill)),
+    )
+    library = torch.library.Library("slimserve_index_journal_test", "FRAGMENT")
+    direct_register_custom_op(
+        op_name="pooled",
+        op_func=ij.instrument_pooled_indexer(gi.glm5_next_pooled_indexer),
+        fake_impl=gi.glm5_next_pooled_indexer_fake,
+        mutates_args=["kv_cache", "topk_indices_buffer", "decode_logits"],
+        target_lib=library,
+    )
+    g = torch.Generator(device="cuda").manual_seed(238)
+    q = torch.randn(8199, 32, 128, device="cuda", dtype=torch.bfloat16, generator=g)
+    packed = torch.randn(8199, 256, device="cuda", dtype=torch.bfloat16, generator=g)
+    weights = torch.randn(8199, 32, device="cuda", generator=g)
+    ape = torch.randn(4, 128, device="cuda", generator=g)
+    cache = torch.zeros(8, 1088, 256, device="cuda", dtype=torch.bfloat16)
+    out = torch.full((8199, 2080), -1, device="cuda", dtype=torch.int32)
+    decode_logits = torch.zeros(1, 2049, device="cuda")
+    embeds = torch.randn(8199, 4096, device="cuda", dtype=torch.bfloat16, generator=g)
+    prefixes = [f"model.layers.{i}.self_attn.indexer.k_cache" for i in ij.LAYERS]
+    context = SimpleNamespace(attn_metadata={})
+    monkeypatch.setattr(gi, "get_forward_context", lambda: context)
+
+    def forward(q, packed, weights, embeds, out):
+        for prefix in prefixes:
+            torch.ops.slimserve_index_journal_test.pooled(
+                q,
+                packed,
+                weights,
+                ape,
+                prefix,
+                cache,
+                out,
+                decode_logits,
+                2049,
+                512,
+                4,
+                128**-0.5,
+            )
+        return embeds
+
+    compiled = torch.compile(forward, fullgraph=True, backend="inductor")
+    state = SimpleNamespace(prompt_token_ids=list(range(8199)), num_computed_tokens=0)
+    runner = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_text_config=SimpleNamespace(hidden_size=4096, num_hidden_layers=45)
+        ),
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=4, pipeline_parallel_size=1
+        ),
+        speculative_config=None,
+        num_prompt_logprobs={"synthetic": 0},
+        requests={"synthetic": state},
+        input_batch=SimpleNamespace(num_reqs=1),
+    )
+    current_data = None
+
+    def model_forward(**kwargs):
+        return compiled(*current_data)
+
+    runner._model_forward = model_forward
+    ij.install_index_journal(runner)
+    for begin, rows in ((0, 8192), (8192, 7)):
+        state.num_computed_tokens = begin
+        end = begin + rows
+        sl_cpu = torch.tensor([end], dtype=torch.int32)
+        qsl_cpu = torch.tensor([0, rows], dtype=torch.int32)
+        sl = sl_cpu.cuda()
+        bt = torch.arange(8, device="cuda", dtype=torch.int32)[None, :]
+        chunk = build_prefill_chunk_metadata(
+            0, 1, qsl_cpu.cuda(), qsl_cpu, sl, sl, sl_cpu, bt, 1
+        )
+        md = DeepseekV32IndexerMetadata(
+            seq_lens=sl,
+            max_seq_len=end,
+            slot_mapping=torch.arange(begin, end, device="cuda"),
+            num_decodes=0,
+            num_decode_tokens=0,
+            num_prefills=1,
+            num_prefill_tokens=rows,
+            prefill=DeepseekV32IndexerPrefillMetadata(chunks=[chunk]),
+        )
+        context.attn_metadata = dict.fromkeys(prefixes, md)
+        data = (
+            q[begin:end],
+            packed[begin:end],
+            weights[begin:end],
+            embeds[begin:end],
+            out[begin:end],
+        )
+        expected = compiled(*data).clone()
+        expected_indices = data[-1].clone()
+        current_data = data
+        actual = runner._model_forward(
+            input_ids=torch.arange(begin, end, device="cuda"),
+            inputs_embeds=data[3],
+            positions=torch.arange(begin, end, device="cuda"),
+        )
+        assert torch.equal(actual.view(torch.uint8), expected.view(torch.uint8))
+        if canonical:
+            assert torch.equal(data[-1], expected_indices)
+        assert ij.ACTIVE.get() is None and ij.LAYER.get() is None
+    events = [
+        json.loads(line)
+        for line in next((config.parent / "trace").glob("index-*.jsonl"))
+        .read_text()
+        .splitlines()
+    ]
+    assert events[-1]["kind"] == "request_complete" and events[-1]["chunks"] == 2
+    assert events[0]["selection_order_implementation"] == (
+        "native-bitonic" if fused else "post-sort" if canonical else "native"
+    )
+    runner._slimserve_index_journal.close()
+    assert len([e for e in events if e["kind"] == "tensor"]) == 2 * (11 * 4 + 4)
+    for item in (e for e in events if "archive" in e):
+        assert item["stage"].startswith(f"layer-{capture_layer:02d}.call-0.")
+        path = (
+            config.parent
+            / "trace"
+            / f"index-{events[0]['pid']}"
+            / (item["archive"]["path"].split("/")[-1])
+        )
+        assert (
+            hashlib.sha256(path.read_bytes()).hexdigest() == item["archive"]["sha256"]
+        )

--- a/tests/kernels/test_glm53_indexer_ties.py
+++ b/tests/kernels/test_glm53_indexer_ties.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native cutoff policy against independent CPU score/index ordering."""
+
+import os
+import subprocess
+import sys
+
+import pytest
+import torch
+
+from slimserve.canonical_indexer import canonicalize
+from vllm import _custom_ops as ops
+
+pytestmark = pytest.mark.skipif(
+    not (torch.cuda.is_available() and torch.cuda.get_device_capability() == (12, 0)),
+    reason="requires SM120",
+)
+
+
+def oracle(logits, ends):
+    """Stable CPU sort starts in ascending pool-ID order; do not perturb scores."""
+    result = torch.full((len(ends), 512), -1, dtype=torch.int32)
+    for row, end in enumerate(ends.tolist()):
+        assert torch.isfinite(logits[row, :end]).all()
+        chosen = logits[row, :end].argsort(descending=True, stable=True)[:512]
+        result[row, : len(chosen)] = chosen.sort().values.int()
+    return result
+
+
+def matrix(rows, columns, family, phase):
+    g = torch.Generator().manual_seed(8231 + phase)
+    if family == "random":
+        values = torch.randn(rows, columns, generator=g)
+    elif family == "unique":
+        values = torch.stack(
+            [torch.randperm(columns, generator=g) for _ in range(rows)]
+        ).float()
+        values -= columns // 2
+    elif family == "ties":
+        # Small candidate ties, negative cutoffs, and exact ties larger than2048.
+        values = torch.randint(-2, 3, (rows, columns), generator=g).float() * 0.125
+    elif family == "adjacent":
+        base = torch.tensor(-8.358503341674805)
+        ulp = torch.nextafter(base, torch.tensor(torch.inf)) - base
+        values = base + torch.randint(-2, 3, (rows, columns), generator=g) * ulp
+    elif family == "zeros":
+        values = torch.zeros(rows, columns)
+        values[:, (phase % 2) :: 2] = -0.0
+    elif family == "cutoff":
+        values = torch.full((rows, columns), -8.358503341674805)
+        # >2048 equal-cutoff candidates plus strictly better/worse values when
+        # wide; ordered scanning must continue across chunks of nonmembers.
+        ids = torch.arange(columns)
+        values[:, (ids + phase) % 17 == 0] = -7.0
+        values[:, (ids + phase) % 7 == 0] = -9.0
+    else:
+        raise AssertionError(family)
+    choices = [
+        0,
+        1,
+        min(511, columns),
+        min(512, columns),
+        min(513, columns),
+        columns // 2,
+        max(0, columns - 1),
+        columns,
+    ]
+    ends = torch.tensor([choices[i % 8] for i in range(rows)], dtype=torch.int32)
+    return values, ends
+
+
+@pytest.fixture(params=["post-sort", "fused"])
+def selector(request):
+    return request.param
+
+
+def exercise(rows, columns, family, offset, selector, ragged=True):
+    # Guard both ends; storage offsets deliberately misalign vectorized input.
+    backing = torch.full((rows * columns + offset + 1,), 417.0, device="cuda")
+    logits = backing[offset : offset + rows * columns].view(rows, columns)
+    storage = torch.full(
+        (rows * 512 + offset + 1,), -987, dtype=torch.int32, device="cuda"
+    )
+    indices = storage[offset : offset + rows * 512].view(rows, 512)
+    starts = torch.zeros(rows, dtype=torch.int32, device="cuda")
+    ends = torch.zeros_like(starts)
+
+    def call():
+        operation = (
+            ops.glm53_top_k_per_row_ordered
+            if selector == "fused"
+            else ops.glm53_top_k_per_row_prefill
+        )
+        operation(logits, starts, ends, indices, rows, columns, 1, 512)
+        if selector == "post-sort":
+            canonicalize(indices)
+
+    logits.zero_()
+    call()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        call()
+    for phase in range(3):
+        values, visible = matrix(rows, columns, family, phase)
+        if not ragged:
+            visible.fill_(columns - phase)
+        expected = oracle(values, visible)
+        undefined = torch.arange(columns)[None, :] >= visible[:, None]
+        values[undefined] = float("nan") if phase % 2 == 0 else 123.0
+        logits.copy_(values)
+        ends.copy_(visible)
+        before = logits.view(torch.uint8).clone()
+        for callback in (call, graph.replay):
+            indices.fill_(-777)
+            callback()
+            assert torch.equal(indices.cpu(), expected)
+            assert torch.equal(before, logits.view(torch.uint8))
+            assert (starts == 0).all() and torch.equal(ends.cpu(), visible)
+            assert (storage[:offset] == -987).all() and storage[-1] == -987
+            assert (backing[:offset] == 417).all() and backing[-1] == 417
+    torch.cuda.synchronize()
+
+
+@pytest.mark.parametrize(
+    "columns", [160, 512, 513, 1904, 2048, 2049, 8193, 16384, 262144]
+)
+@pytest.mark.parametrize(
+    "family", ["random", "unique", "ties", "adjacent", "zeros", "cutoff"]
+)
+@pytest.mark.parametrize("offset", [0, 1])
+def test_native_tie_policy_changed_input_graphs(columns, family, offset, selector):
+    exercise(8, columns, family, offset, selector)
+
+
+@pytest.mark.parametrize("rows,columns", [(7616, 1904), (8192, 2049)])
+def test_full_chunk_geometry(rows, columns, selector):
+    exercise(rows, columns, "ties", 1, selector)
+
+
+@pytest.mark.parametrize("rows", [1, 2, 8, 16, 64])
+@pytest.mark.parametrize("columns", [1904, 262144])
+def test_small_rowcounts_all_visible(rows, columns, selector):
+    exercise(rows, columns, "cutoff", 1, selector, ragged=False)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() != 4, reason="requires all four GPUs")
+@pytest.mark.parametrize("device", [0, 1, 2, 3])
+def test_native_restores_foreign_current_device(device, selector):
+    values, visible = matrix(8, 1904, "adjacent", 1)
+    expected = oracle(values, visible)
+    logits, ends = values.to(device), visible.to(device)
+    starts = torch.zeros(8, dtype=torch.int32, device=device)
+    indices = torch.empty_like(expected, device=device)
+    operation = (
+        ops.glm53_top_k_per_row_ordered
+        if selector == "fused"
+        else ops.glm53_top_k_per_row_prefill
+    )
+    with torch.cuda.device((device + 1) % 4):
+        operation(logits, starts, ends, indices, 8, 1904, 1, 512)
+        assert torch.cuda.current_device() == (device + 1) % 4
+        if selector == "post-sort":
+            # Test the native guard independently of the Triton post-sort.
+            with torch.cuda.device(device):
+                canonicalize(indices)
+        assert torch.equal(indices.cpu(), expected)
+
+
+@pytest.mark.parametrize(
+    "bad", ["rows", "columns", "topk", "stride", "dtype", "output", "device"]
+)
+def test_native_host_guards(bad, selector):
+    logits = torch.zeros(2, 600, device="cuda")
+    starts = ends = torch.zeros(2, device="cuda", dtype=torch.int32)
+    indices = torch.empty(2, 512, device="cuda", dtype=torch.int32)
+    rows, stride0, stride1, topk = 2, 600, 1, 512
+    if bad == "rows":
+        rows = 0
+    elif bad == "columns":
+        logits = torch.zeros(2, 262145, device="cuda")
+        stride0 = 262145
+    elif bad == "topk":
+        topk = 256
+    elif bad == "stride":
+        stride1 = 2
+    elif bad == "dtype":
+        logits = logits.bfloat16()
+    elif bad == "output":
+        indices = indices[:, :511]
+    elif bad == "device":
+        indices = indices.cpu()
+    with pytest.raises(RuntimeError, match="GLM pool selector"):
+        operation = (
+            ops.glm53_top_k_per_row_ordered
+            if selector == "fused"
+            else ops.glm53_top_k_per_row_prefill
+        )
+        operation(logits, starts, ends, indices, rows, stride0, stride1, topk)
+
+
+@pytest.mark.parametrize("start,end", [(1, 600), (0, -1), (0, 601)])
+def test_invalid_device_ranges_fail_in_isolated_process(
+    start, end, record_property, selector
+):
+    # Device assertions invalidate a CUDA context: exercise them in a child,
+    # never in the context used by the positive correctness/graph tests.
+    name = "ordered" if selector == "fused" else "prefill"
+    code = f"""
+import torch
+from vllm import _custom_ops as ops
+logits = torch.zeros(1, 600, device='cuda')
+starts = torch.tensor([{start}], device='cuda', dtype=torch.int32)
+ends = torch.tensor([{end}], device='cuda', dtype=torch.int32)
+indices = torch.empty(1, 512, device='cuda', dtype=torch.int32)
+try:
+    ops.glm53_top_k_per_row_{name}(logits, starts, ends, indices, 1, 600, 1, 512)
+    torch.cuda.synchronize()
+except RuntimeError as error:
+    assert 'device-side assert' in str(error), str(error)
+else:
+    raise AssertionError('invalid device range was accepted')
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        env=dict(os.environ, CUDA_LAUNCH_BLOCKING="1"),
+        text=True,
+        capture_output=True,
+        timeout=60,
+    )
+    record_property("expected_device_assert_stderr", result.stderr)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "starts[row] == 0" in result.stderr

--- a/tests/kernels/test_glm53_native_ordering.py
+++ b/tests/kernels/test_glm53_native_ordering.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Real import-time native policy with no diagnostic flags or mock kernels."""
+
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from slimserve import canonical_indexer, glm53_ordering
+from tests.kernels.test_glm53_indexer_ties import matrix, oracle
+from tests.kernels.test_glm53_stable_route import check_result
+from vllm import _custom_ops as ops
+from vllm.model_executor.layers.fused_moe.experts import marlin_moe
+from vllm.model_executor.layers.fused_moe.router import glm_route_align as route
+from vllm.quixicore.ops import quixicore_ops as qc
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or os.getenv(glm53_ordering.FLAG) != "1",
+    reason="requires CUDA and explicit native-order policy at process start",
+)
+
+
+def test_real_import_policy_without_observers():
+    assert glm53_ordering.enabled()
+    assert all(os.getenv(k, "0") == "0" for k in glm53_ordering.LEGACY_FLAGS)
+    assert os.getenv("CUDA_LAUNCH_BLOCKING", "0") == "0"
+    for suffix in ("MODEL_JOURNAL", "MOE_JOURNAL", "SCORE_JOURNAL", "INDEX_JOURNAL"):
+        assert not os.getenv("SLIMSERVE_GLM53_" + suffix)
+    assert route._STABLE_ALIGNMENT_DIAGNOSTIC
+    assert marlin_moe._NATIVE_ORDER
+    assert marlin_moe._CANONICAL_MOE_DIAGNOSTIC
+    assert marlin_moe._STABLE_ALIGN_DIAGNOSTIC
+    assert "glm53_native_order_v1=1" in qc.graph_factors()
+
+
+@pytest.mark.parametrize("tokens", [1, 16])
+def test_real_router_publishes_stable_alignment(tokens):
+    logits = torch.zeros(tokens, 288, device="cuda")
+    bias = torch.zeros(288, device="cuda")
+    router = SimpleNamespace(
+        e_score_correction_bias=bias,
+        top_k=8,
+        num_expert_group=1,
+        topk_group=1,
+        scoring_func="sigmoid",
+        renormalize=True,
+        routed_scaling_factor=2.5,
+    )
+    assert route.eligible(router, logits, torch.int32)
+    capacity, blocks = route.alignment_geometry(tokens, 8, 288, 8)
+    for phase in range(3):
+        generator = torch.Generator().manual_seed(53900 + phase)
+        if phase:
+            logits.copy_(torch.randn(tokens, 288, generator=generator))
+        else:
+            logits.zero_()
+        weights, ids = route.route(router, logits)
+        alignment = route.consume(ids)
+        assert alignment is not None and alignment.canonical_assignment_order
+        assert route.consume(ids) is None
+        control = qc.glm_route_align(
+            logits, bias, 8, 0, True, 2.5, 8, capacity, blocks
+        )
+        check_result(
+            [weights, ids, alignment.sorted_token_ids, alignment.expert_ids,
+             alignment.num_tokens_post_padded],
+            control, tokens, 8,
+        )
+
+
+@pytest.mark.parametrize("columns", [513, 1904, 8193, 262144])
+@pytest.mark.parametrize("family", ["random", "adjacent", "cutoff"])
+def test_real_selector_wrapper_eager_and_changed_input_graph(columns, family):
+    # Pass the ordinary selector into the same factory used by the model.
+    function = canonical_indexer.maybe_ordered_topk(ops.top_k_per_row_prefill)
+    logits = torch.zeros(8, columns, device="cuda")
+    starts = torch.zeros(8, dtype=torch.int32, device="cuda")
+    ends = torch.zeros_like(starts)
+    ids = torch.empty(8, 512, dtype=torch.int32, device="cuda")
+
+    def call():
+        function(logits, starts, ends, ids, 8, columns, 1, 512)
+
+    call()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        call()
+    for phase in range(3):
+        values, visible = matrix(8, columns, family, phase)
+        expected = oracle(values, visible)
+        values[torch.arange(columns)[None, :] >= visible[:, None]] = float("nan")
+        logits.copy_(values)
+        ends.copy_(visible)
+        for invoke in (call, graph.replay):
+            ids.fill_(-777)
+            invoke()
+            assert torch.equal(ids.cpu(), expected)
+    torch.cuda.synchronize()

--- a/tests/kernels/test_glm53_stable_align.py
+++ b/tests/kernels/test_glm53_stable_align.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stable alignment candidate: independent CPU oracle, redzones and graphs."""
+
+import hashlib
+import json
+from functools import partial
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from benchmarks.kernels.glm53_stable_align_probe import build
+from slimserve.canonical_moe import canonicalize, geometry
+from tests.kernels.test_glm53_canonical_moe import expected_alignment
+from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
+    moe_align_block_size,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCES = [
+    Path(__file__),
+    ROOT / "benchmarks/kernels/glm53_stable_align_probe.py",
+    ROOT / "benchmarks/kernels/glm53_stable_align_probe.cu",
+    ROOT / "csrc/quixicore/serving/glm_moe_stable_align.cuh",
+    ROOT / "tests/kernels/test_glm53_canonical_moe.py",
+    ROOT / "slimserve/canonical_moe.py",
+    ROOT / "slimserve/canonical_moe_kernel.py",
+    ROOT / "vllm/model_executor/layers/fused_moe/moe_align_block_size.py",
+]
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+def sha(path):
+    with path.open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+@pytest.fixture(
+    scope="module",
+    params=[
+        pytest.param((256, True, False), id="256"),
+        pytest.param((1024, True, False), id="1024"),
+        pytest.param((1024, False, False), id="direct"),
+        pytest.param((1024, False, True), id="scatter512"),
+    ],
+)
+def probe(request):
+    module = build()
+    threads, aggregate, parallel_scatter = request.param
+    return SimpleNamespace(
+        __file__=module.__file__,
+        module=module,
+        count_threads=threads,
+        aggregate=aggregate,
+        scatter_threads=512 if parallel_scatter else 256,
+        run=partial(
+            module.run,
+            parallel_count=threads == 1024,
+            aggregate=aggregate,
+            parallel_scatter=parallel_scatter,
+        ),
+        run_into=partial(
+            module.run_into,
+            parallel_count=threads == 1024,
+            aggregate=aggregate,
+            parallel_scatter=parallel_scatter,
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def identities(probe, record_property):
+    files = SOURCES + [Path(probe.__file__)]
+    hashes = {str(p): sha(p) for p in files}
+    record_property("source_sha256", json.dumps(hashes, sort_keys=True))
+    record_property("count_threads", probe.count_threads)
+    record_property("aggregate", int(probe.aggregate))
+    record_property("scatter_threads", probe.scatter_threads)
+    yield
+    assert hashes == {str(p): sha(p) for p in files}
+
+
+def inputs(tokens):
+    generator = torch.Generator().manual_seed(2309 + tokens)
+    random = torch.rand(tokens, 288, generator=generator).topk(8, dim=1).indices.int()
+    skew = torch.arange(8).expand(tokens, 8).contiguous().int()
+    patterned = (
+        (torch.arange(tokens)[:, None] * 37 + torch.arange(8) * 31) % 288
+    ).int()
+    invalid = patterned.clone()
+    invalid[::3, 2] = -1
+    invalid[::5, 7] = 288
+    invalid[::7, 1] = 2**31 - 1
+    invalid[::11, 4] = -(2**31)
+    return [
+        random,
+        skew,
+        patterned,
+        invalid,
+        torch.full_like(skew, -1),
+        torch.full_like(skew, 13),
+        random.flip(0).contiguous(),
+    ]
+
+
+def protected(shape, offset, device):
+    size = int(np.prod(shape))
+    backing = torch.full(
+        (size + 64 + offset,), -1234567, dtype=torch.int32, device=device
+    )
+    view = backing[32 + offset : 32 + offset + size].view(shape)
+
+    def check():
+        assert (backing[: 32 + offset] == -1234567).all().item()
+        assert (backing[32 + offset + size :] == -1234567).all().item()
+
+    return view, check
+
+
+def expected_offsets(ids, block):
+    flat = ids.numpy().reshape(-1)
+    counts = np.bincount(flat[(flat >= 0) & (flat < 288)], minlength=288)
+    counts = (counts + block - 1) // block * block
+    return torch.from_numpy(np.concatenate(([0], counts.cumsum())).astype(np.int32))
+
+
+@pytest.mark.parametrize("tokens", [17, 31, 32, 33, 63, 64, 65, 129, 640, 7616, 8192])
+@pytest.mark.parametrize("block", [8, 16, 32, 48, 64])
+@pytest.mark.parametrize("offset", [0, 1])
+def test_stable_eager_changed_input_graph_and_redzones(probe, tokens, block, offset):
+    capacity, blocks, _ = geometry(tokens, 8, 288, block)
+    ids, check_ids = protected((tokens, 8), offset, "cuda")
+    allocations = [
+        protected(shape, offset, "cuda")
+        for shape in [(capacity,), (blocks,), (1,), (289,)]
+    ]
+    outputs = [x[0] for x in allocations]
+    phases = inputs(tokens)
+    expected = [
+        (*expected_alignment(p, block), expected_offsets(p, block)) for p in phases
+    ]
+
+    def call():
+        probe.run_into(ids, *outputs, block)
+
+    def check(index):
+        for got, ref in zip(outputs, expected[index]):
+            assert torch.equal(got.cpu(), ref)
+        assert torch.equal(ids.cpu(), phases[index])
+        check_ids()
+        for _, guard in allocations:
+            guard()
+
+    for index, inp in enumerate(phases):
+        ids.copy_(inp)
+        for output in outputs:
+            output.fill_(-999)
+        call()
+        check(index)
+        # Canonical post-sort assumes distinct top-k IDs per row. Duplicates
+        # deliberately exceed that separate diagnostic's bound; test our
+        # candidate against the independent CPU oracle for that phase only.
+        if index != 5:
+            native = moe_align_block_size(ids, block, 288)
+            canonicalize(*native, tokens=tokens, block_size=block)
+            assert all(torch.equal(a, b) for a, b in zip(native, outputs[:3]))
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        call()
+    torch.cuda.current_stream().wait_stream(stream)
+    for index in list(range(7)) + list(reversed(range(7))):
+        ids.copy_(phases[index])
+        for output in outputs:
+            output.fill_(919191)
+        graph.replay()
+        check(index)
+
+
+def test_all_actual_captured_routes(probe, record_property):
+    directory = ROOT / "perf/results/2026-09-09/stable-route-quality-diagnostic/trace"
+    paths = sorted(directory.glob("model-*.jsonl"))
+    assert len(paths) == 4, "the prescribed four-rank capture is required"
+    receipts = []
+    for path in paths:
+        rows = [json.loads(line) for line in path.read_text().splitlines()]
+        matches = [
+            r
+            for r in rows
+            if r["kind"] == "moe_snapshot" and r["stage"] == "moe3.router.ids"
+        ]
+        assert len(matches) == 3
+        for row in matches:
+            archive = Path(row["path"])
+            assert sha(archive) == row["file_sha256"]
+            ids = torch.load(archive, weights_only=True, map_location="cpu")
+            assert ids.shape == (640, 8)
+            got = probe.run(ids.cuda(), 32)
+            assert all(
+                torch.equal(a.cpu(), b)
+                for a, b in zip(got, expected_alignment(ids, 32))
+            )
+            receipts.append(dict(path=str(archive), sha256=sha(archive)))
+    record_property("actual_routes", json.dumps(receipts, sort_keys=True))
+
+
+@pytest.mark.parametrize("device", [0, 1, 2, 3])
+def test_foreign_current_device_and_nondefault_stream(probe, device):
+    if torch.cuda.device_count() != 4:
+        pytest.skip("requires the four-GPU qualification box")
+    ids_cpu = inputs(129)[0]
+    with torch.cuda.device(device):
+        ids = ids_cpu.cuda(device)
+        stream = torch.cuda.Stream(device=device)
+        stream.wait_stream(torch.cuda.current_stream(device))
+        with torch.cuda.stream(stream), torch.cuda.device((device + 1) % 4):
+            output = probe.run(ids, 48)
+            assert torch.cuda.current_device() == (device + 1) % 4
+        stream.synchronize()
+        assert all(
+            torch.equal(a.cpu(), b)
+            for a, b in zip(output, expected_alignment(ids_cpu, 48))
+        )
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "rows16",
+        "rows8193",
+        "topk7",
+        "float",
+        "cpu",
+        "strided",
+        "block0",
+        "block128",
+        "capacity",
+        "expert_shape",
+        "padded_dtype",
+        "offset_size",
+        "device",
+        "direct_without_parallel",
+        "scatter_without_direct",
+    ],
+)
+def test_invalid_contracts(probe, case):
+    ids = torch.zeros((17, 8), dtype=torch.int32, device="cuda")
+    capacity, blocks, _ = geometry(17, 8, 288, 8)
+    outputs = [
+        torch.empty(n, dtype=torch.int32, device="cuda")
+        for n in (capacity, blocks, 1, 289)
+    ]
+    block = 8
+    if case in ("rows16", "rows8193", "topk7"):
+        shape = {"rows16": (16, 8), "rows8193": (8193, 8), "topk7": (17, 7)}[case]
+        ids = torch.zeros(shape, dtype=torch.int32, device="cuda")
+    elif case == "float":
+        ids = ids.float()
+    elif case == "cpu":
+        ids = ids.cpu()
+    elif case == "strided":
+        ids = torch.zeros((17, 16), dtype=torch.int32, device="cuda")[:, ::2]
+    elif case.startswith("block"):
+        block = int(case[5:])
+    elif case == "capacity":
+        outputs[0] = outputs[0][:-1]
+    elif case == "expert_shape":
+        outputs[1] = outputs[1].view(1, -1)
+    elif case == "padded_dtype":
+        outputs[2] = outputs[2].float()
+    elif case == "offset_size":
+        outputs[3] = outputs[3][:-1]
+    elif case == "device":
+        outputs[0] = outputs[0].cpu()
+    elif case == "direct_without_parallel":
+        with pytest.raises(RuntimeError, match="requires 1024 threads"):
+            probe.module.run_into(ids, *outputs, block, False, False)
+        return
+    elif case == "scatter_without_direct":
+        with pytest.raises(RuntimeError, match="requires direct count"):
+            probe.module.run_into(ids, *outputs, block, True, True, True)
+        return
+    with pytest.raises(RuntimeError):
+        probe.run_into(ids, *outputs, block)

--- a/tests/kernels/test_glm53_stable_align_native.py
+++ b/tests/kernels/test_glm53_stable_align_native.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exact serving entry: CPU layout, frozen probe parity, graphs and redzones."""
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tests.kernels import test_glm53_stable_align as reference
+from vllm.model_executor.layers.fused_moe.router import glm_stable_align as custom
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+@pytest.fixture(scope="module")
+def probe():
+    import vllm._quixicore_C as native
+
+    # Load the qualified binary directly. Do not rebuild an archived control
+    # against the now-integrated header or silently change its source identity.
+    directory = Path(os.environ["SLIMSERVE_GLM53_STABLE_ALIGN_PROBE"])
+    path = directory / "glm53_stable_align_probe.so"
+    assert (
+        reference.sha(path)
+        == "9b1ed1328d49b0f723cb2b33f9f06d2b18e91c271296eac5e8057e9e16116d5c"
+    )
+    spec = importlib.util.spec_from_file_location("glm53_stable_align_probe", path)
+    frozen = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(frozen)
+
+    def run_into(ids, *args):
+        native.glm_stable_align(ids, *args)
+
+    def run(ids, block):
+        return custom.align(ids, block)
+
+    return SimpleNamespace(
+        __file__=native.__file__, frozen=frozen, run=run, run_into=run_into
+    )
+
+
+@pytest.fixture(autouse=True)
+def identities(probe, record_property):
+    files = reference.SOURCES + [
+        Path(__file__),
+        Path(probe.__file__),
+        Path(probe.frozen.__file__),
+        reference.ROOT / "csrc/quixicore/tm_cuda/tm_cuda_serving.cu",
+        reference.ROOT / "vllm/quixicore/ops.py",
+        Path(custom.__file__),
+    ]
+    hashes = {str(p): reference.sha(p) for p in files}
+    record_property("source_sha256", json.dumps(hashes, sort_keys=True))
+    yield
+    assert hashes == {str(p): reference.sha(p) for p in files}
+
+
+@pytest.mark.parametrize(
+    "tokens", [17, 18, 30, 31, 32, 33, 34, 63, 64, 65, 129, 640, 7616, 8192]
+)
+@pytest.mark.parametrize("block", [8, 16, 32, 48, 64])
+@pytest.mark.parametrize("offset", [0, 1])
+def test_native_graphs_redzones_and_probe(probe, tokens, block, offset):
+    reference.test_stable_eager_changed_input_graph_and_redzones(
+        probe, tokens, block, offset
+    )
+    for cpu in reference.inputs(tokens):
+        ids = cpu.cuda()
+        candidate = probe.run(ids, block)
+        small = tokens <= 32
+        control = probe.frozen.run(ids, block, not small, small, not small)
+        assert all(torch.equal(a, b) for a, b in zip(candidate, control))
+
+
+def test_native_actual_captured_routes(probe, record_property):
+    reference.test_all_actual_captured_routes(probe, record_property)
+
+
+@pytest.mark.parametrize("device", [0, 1, 2, 3])
+def test_native_device_and_stream(probe, device):
+    reference.test_foreign_current_device_and_nondefault_stream(probe, device)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "rows16",
+        "rows8193",
+        "topk7",
+        "float",
+        "cpu",
+        "strided",
+        "block0",
+        "block128",
+        "capacity",
+        "expert_shape",
+        "padded_dtype",
+        "offset_size",
+        "device",
+    ],
+)
+def test_native_invalid_contracts(probe, case):
+    reference.test_invalid_contracts(probe, case)
+
+
+@pytest.mark.parametrize("alias", ["ids-sorted", "sorted-experts", "padded-offsets"])
+def test_native_rejects_aliases(probe, alias):
+    capacity, blocks, _ = reference.geometry(17, 8, 288, 8)
+    backing = torch.zeros(capacity + 289, dtype=torch.int32, device="cuda")
+    ids = torch.zeros((17, 8), dtype=torch.int32, device="cuda")
+    outputs = [
+        torch.empty(n, dtype=torch.int32, device="cuda")
+        for n in (capacity, blocks, 1, 289)
+    ]
+    if alias == "ids-sorted":
+        ids, outputs[0] = backing[:136].view(17, 8), backing[:capacity]
+    elif alias == "sorted-experts":
+        outputs[0], outputs[1] = backing[:capacity], backing[:blocks]
+    else:
+        outputs[2], outputs[3] = backing[:1], backing[:289]
+    with pytest.raises(RuntimeError, match="single memory location"):
+        probe.run_into(ids, *outputs, 8)
+
+
+@pytest.mark.parametrize("tokens", [17, 32, 33, 640, 8192])
+@pytest.mark.parametrize("compiled", [False, True])
+def test_custom_op_changed_input_graph(probe, tokens, compiled):
+    call = custom.align
+    if compiled:
+        call = torch.compile(call, fullgraph=True, dynamic=False)
+    ids = reference.inputs(tokens)[0].cuda()
+    for _ in range(2):
+        call(ids, 32)
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        outputs = call(ids, 32)
+    torch.cuda.current_stream().wait_stream(stream)
+    for cpu in reference.inputs(tokens):
+        ids.copy_(cpu)
+        for output in outputs:
+            output.fill_(-999)
+        graph.replay()
+        assert all(
+            torch.equal(a.cpu(), b)
+            for a, b in zip(outputs, reference.expected_alignment(cpu, 32))
+        )

--- a/tests/kernels/test_glm53_stable_align_native.py
+++ b/tests/kernels/test_glm53_stable_align_native.py
@@ -22,7 +22,10 @@ def probe():
 
     # Load the qualified binary directly. Do not rebuild an archived control
     # against the now-integrated header or silently change its source identity.
-    directory = Path(os.environ["SLIMSERVE_GLM53_STABLE_ALIGN_PROBE"])
+    location = os.environ.get("SLIMSERVE_GLM53_STABLE_ALIGN_PROBE")
+    if not location:
+        pytest.skip("set SLIMSERVE_GLM53_STABLE_ALIGN_PROBE to the archived probe")
+    directory = Path(location)
     path = directory / "glm53_stable_align_probe.so"
     assert (
         reference.sha(path)

--- a/tests/kernels/test_glm53_stable_route.py
+++ b/tests/kernels/test_glm53_stable_route.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stable origin alignment; exact IDs/weight bits vs installed native router.
+
+Synthetic changed-input eager/graphs, not full-model or performance proof.
+"""
+
+import hashlib
+import itertools
+from pathlib import Path
+
+import pytest
+import torch
+
+from benchmarks.kernels.glm53_stable_route_probe import build
+from slimserve.canonical_moe import canonicalize
+from tests.kernels.test_glm53_canonical_moe import expected_alignment
+from vllm.model_executor.layers.fused_moe.router.glm_route_align import (
+    alignment_geometry,
+)
+from vllm.quixicore.ops import quixicore_ops as qc
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+@pytest.fixture(scope="module", params=("probe", "native"))
+def probe(request):
+    if request.param == "probe":
+        return build()
+    import vllm._quixicore_C as native
+
+    assert hasattr(native, "glm_route_align_stable"), "rebuild native stable router"
+
+    class NativeRouter:
+        __file__ = native.__file__
+
+        @staticmethod
+        def run(logits, bias, scoring, renormalize, scaling, block, stable):
+            capacity, blocks = alignment_geometry(len(logits), 8, 288, block)
+            call = native.glm_route_align_stable if stable else native.glm_route_align
+            return call(
+                logits, bias, 8, scoring, renormalize, scaling, block, capacity, blocks
+            )
+
+    return NativeRouter()
+
+
+@pytest.fixture(scope="module")
+def source_receipts(probe):
+    import vllm._quixicore_C as native
+
+    paths = [
+        Path(__file__),
+        Path(probe.__file__),
+        Path(native.__file__),
+        Path("csrc/quixicore/serving/glm_moe_routing.cuh"),
+        Path("csrc/quixicore/tm_cuda/tm_cuda_serving.cu"),
+        Path("vllm/quixicore/ops.py"),
+        Path("vllm/model_executor/layers/fused_moe/router/glm_route_align.py"),
+        Path("benchmarks/kernels/glm53_stable_route_probe.cu"),
+        Path("benchmarks/kernels/glm53_stable_route_probe.py"),
+        Path("benchmarks/kernels/benchmark_mhc_output_parallel.py"),
+        Path("tests/kernels/test_glm53_canonical_moe.py"),
+        Path("slimserve/canonical_moe.py"),
+        Path("slimserve/canonical_moe_kernel.py"),
+    ]
+
+    def hashes():
+        result = {}
+        for path in paths:
+            with path.open("rb") as stream:
+                result[str(path)] = hashlib.file_digest(stream, "sha256").hexdigest()
+        return result
+
+    initial = hashes()
+    yield initial
+    assert hashes() == initial, "source/native changed during qualification"
+
+
+@pytest.fixture(autouse=True)
+def record_sources(record_property, source_receipts):
+    for path, digest in source_receipts.items():
+        record_property(path, digest)
+
+
+def inputs(tokens, offset=0):
+    generator = torch.Generator().manual_seed(53100 + tokens)
+    base = torch.randn(tokens, 288, generator=generator) * 2
+    bias = torch.randn(288, generator=generator) * 0.5
+    tied = torch.zeros_like(base)
+    mixed = base.clone()
+    mixed[:, ::3] = float("nan")
+    mixed[:, 1::7] = float("inf")
+    mixed[:, 2::11] = float("-inf")
+    biased = bias.clone()
+    biased[::7] = float("nan")
+    biased[1::11] = float("inf")
+    biased[2::13] = float("-inf")
+    cases = [
+        (base, bias),
+        (tied, torch.zeros_like(bias)),
+        (base[:1].expand_as(base).clone(), bias),  # maximal expert skew
+        (torch.full_like(base, float("nan")), bias),
+        (torch.full_like(base, float("inf")), bias),
+        (torch.full_like(base, float("-inf")), bias),
+        (mixed, biased),
+        (-base, -bias),
+    ]
+    # Adjacent red zones and nonzero contiguous storage offsets; all raw input
+    # bytes, including NaN payloads, must remain unchanged.
+    backing = [
+        torch.full((tokens * 288 + offset + 1,), 123.0, device="cuda"),
+        torch.full((288 + offset + 1,), 123.0, device="cuda"),
+    ]
+    views = [backing[0][offset:-1].view(tokens, 288), backing[1][offset:-1]]
+    return cases, backing, views
+
+
+def assert_bits(left, right):
+    assert left.dtype == right.dtype and left.shape == right.shape
+    assert torch.equal(
+        left.contiguous().view(torch.uint8).cpu(),
+        right.contiguous().view(torch.uint8).cpu(),
+    )
+
+
+def check_result(result, native, tokens, block):
+    for a, b in zip(result[:2], native[:2]):
+        assert_bits(a, b)
+    for actual, expected in zip(result[2:], expected_alignment(native[1], block)):
+        assert_bits(actual, expected)
+    ids = result[1].cpu()
+    assert ((ids >= 0) & (ids < 288)).all()
+    assert (ids.sort(-1).values.diff(dim=-1) > 0).all()
+    assert_bits(result[3], native[3])
+    assert_bits(result[4], native[4])
+
+
+@pytest.mark.parametrize("tokens", range(1, 17))
+@pytest.mark.parametrize(
+    "scoring,renormalize", tuple(itertools.product((0, 1), (False, True)))
+)
+@pytest.mark.parametrize("block", (8, 16, 32, 48, 64))
+def test_changed_inputs(probe, tokens, scoring, renormalize, block):
+    cases, backing, (logits, bias) = inputs(tokens, offset=tokens % 2)
+    capacity, blocks = alignment_geometry(tokens, 8, 288, block)
+    scaling = 2.5 if renormalize else 0.75
+
+    def control():
+        return qc.glm_route_align(
+            logits, bias, 8, scoring, renormalize, scaling, block, capacity, blocks
+        )
+
+    def set_inputs(case):
+        logits.copy_(case[0])
+        bias.copy_(case[1])
+        return [t.clone() for t in backing]
+
+    # Control probe must preserve installed native router arithmetic. Candidate
+    # must additionally match the independent CPU layout and diagnostic sort.
+    for case in cases:
+        before = set_inputs(case)
+        native = control()
+        raw = probe.run(logits, bias, scoring, renormalize, scaling, block, False)
+        for a, b in zip(raw[:2] + raw[3:], native[:2] + native[3:]):
+            assert_bits(a, b)
+        stable = probe.run(logits, bias, scoring, renormalize, scaling, block, True)
+        check_result(stable, native, tokens, block)
+        canonicalize(*native[2:], tokens=tokens, block_size=block)
+        for a, b in zip(stable[2:], native[2:]):
+            assert_bits(a, b)
+        for a, b in zip(backing, before):
+            assert_bits(a, b)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        atomic_output = probe.run(
+            logits, bias, scoring, renormalize, scaling, block, False
+        )
+        output = probe.run(logits, bias, scoring, renormalize, scaling, block, True)
+    for case in cases + cases[::-1]:
+        before = set_inputs(case)
+        # Poison outputs to check every slot is written on every replay.
+        for t in atomic_output + output:
+            t.fill_(-123)
+        graph.replay()
+        native = control()
+        check_result(output, native, tokens, block)
+        canonicalize(*atomic_output[2:], tokens=tokens, block_size=block)
+        check_result(atomic_output, native, tokens, block)
+        for a, b in zip(backing, before):
+            assert_bits(a, b)
+
+
+@pytest.mark.parametrize("device", range(4))
+@pytest.mark.parametrize("stable", (False, True))
+def test_foreign_current_device(probe, device, stable):
+    with torch.cuda.device(device):
+        logits = torch.zeros(13, 288, device="cuda")
+        bias = torch.zeros(288, device="cuda")
+    with torch.cuda.device((device + 1) % 4):
+        current = torch.cuda.current_device()
+        result = probe.run(logits, bias, 0, True, 2.5, 8, stable)
+        assert torch.cuda.current_device() == current
+        if not stable:
+            with torch.cuda.device(device):
+                canonicalize(*result[2:], tokens=13, block_size=8)
+        for actual, expected in zip(result[2:], expected_alignment(result[1], 8)):
+            assert actual.device == logits.device
+            assert_bits(actual, expected)
+
+
+@pytest.mark.parametrize("stable", (False, True))
+@pytest.mark.parametrize("probe", ("native",), indirect=True)
+@pytest.mark.parametrize(
+    "bad",
+    (
+        "rows0",
+        "rows17",
+        "experts",
+        "dtype",
+        "bias_shape",
+        "bias_device",
+        "scoring",
+        "topk",
+        "block0",
+        "block128",
+        "capacity",
+        "blocks",
+        "strided",
+    ),
+)
+def test_native_rejects_invalid_contract(stable, bad):
+    import vllm._quixicore_C as native
+
+    logits, bias = torch.zeros(1, 288, device="cuda"), torch.zeros(288, device="cuda")
+    args = [logits, bias, 8, 0, True, 2.5, 8, 64, 8]
+    if bad == "rows0":
+        args[0] = logits[:0]
+    elif bad == "rows17":
+        args[0] = logits.expand(17, 288).contiguous()
+    elif bad == "experts":
+        args[0], args[1] = logits[:, :287].contiguous(), bias[:287]
+    elif bad == "dtype":
+        args[0] = logits.bfloat16()
+    elif bad == "bias_shape":
+        args[1] = bias.view(1, 288)
+    elif bad == "bias_device":
+        args[1] = bias.to("cuda:1")
+    elif bad == "scoring":
+        args[3] = 2
+    elif bad == "topk":
+        args[2] = 7
+    elif bad in ("block0", "block128"):
+        args[6] = 0 if bad == "block0" else 128
+    elif bad == "capacity":
+        args[7] = 63
+    elif bad == "blocks":
+        args[8] = 7
+    elif bad == "strided":
+        args[0] = torch.zeros(1, 576, device="cuda")[:, ::2]
+    call = native.glm_route_align_stable if stable else native.glm_route_align
+    with pytest.raises(RuntimeError):
+        call(*args)

--- a/tests/kernels/test_glm53_stable_route.py
+++ b/tests/kernels/test_glm53_stable_route.py
@@ -193,6 +193,7 @@ def test_changed_inputs(probe, tokens, scoring, renormalize, block):
 
 @pytest.mark.parametrize("device", range(4))
 @pytest.mark.parametrize("stable", (False, True))
+@pytest.mark.skipif(torch.cuda.device_count() < 4, reason="requires four CUDA devices")
 def test_foreign_current_device(probe, device, stable):
     with torch.cuda.device(device):
         logits = torch.zeros(13, 288, device="cuda")
@@ -219,7 +220,12 @@ def test_foreign_current_device(probe, device, stable):
         "experts",
         "dtype",
         "bias_shape",
-        "bias_device",
+        pytest.param(
+            "bias_device",
+            marks=pytest.mark.skipif(
+                torch.cuda.device_count() < 2, reason="requires two CUDA devices"
+            ),
+        ),
         "scoring",
         "topk",
         "block0",

--- a/tests/kernels/test_glm53_stable_route_custom_op.py
+++ b/tests/kernels/test_glm53_stable_route_custom_op.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Eager/compiled custom-op and changed-input CUDA graph qualification."""
+
+import pytest
+import torch
+
+from slimserve.canonical_moe import canonicalize
+from tests.kernels.test_glm53_stable_route import assert_bits, check_result
+from vllm.model_executor.layers.fused_moe.router import glm_route_align as route
+from vllm.quixicore.ops import quixicore_ops as qc
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+@pytest.mark.parametrize("tokens", (1, 2, 8, 13, 16))
+@pytest.mark.parametrize("stable", (False, True))
+@pytest.mark.parametrize("compiled", (False, True))
+def test_custom_op_graph(monkeypatch, tokens, stable, compiled):
+    monkeypatch.setattr(route, "_STABLE_ALIGNMENT_DIAGNOSTIC", stable)
+    capacity, blocks = route.alignment_geometry(tokens, 8, 288, 8)
+    generator = torch.Generator().manual_seed(53500 + tokens)
+    random_logits = torch.randn(tokens, 288, generator=generator)
+    random_bias = torch.randn(288, generator=generator)
+    cases = [
+        (random_logits, random_bias),
+        (torch.zeros_like(random_logits), torch.zeros_like(random_bias)),
+        (torch.full_like(random_logits, float("nan")), random_bias),
+        (-random_logits, -random_bias),
+    ]
+    logits, bias = random_logits.cuda(), random_bias.cuda()
+
+    def call(logits, bias):
+        return torch.ops.vllm.glm_route_align(
+            logits, bias, 8, 0, True, 2.5, 8, capacity, blocks
+        )
+
+    fn = torch.compile(call, fullgraph=True) if compiled else call
+
+    def check(result):
+        control = qc.glm_route_align(logits, bias, 8, 0, True, 2.5, 8, capacity, blocks)
+        if not stable:
+            canonicalize(*result[2:], tokens=tokens, block_size=8)
+        check_result(result, control, tokens, 8)
+
+    for x, b in cases:
+        logits.copy_(x)
+        bias.copy_(b)
+        check(fn(logits, bias))
+        assert_bits(logits, x)
+        assert_bits(bias, b)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        output = fn(logits, bias)
+    for x, b in cases + cases[::-1]:
+        logits.copy_(x)
+        bias.copy_(b)
+        for tensor in output:
+            tensor.fill_(-123)
+        graph.replay()
+        check(output)
+        assert_bits(logits, x)
+        assert_bits(bias, b)

--- a/tests/slimserve/test_canonical_indexer.py
+++ b/tests/slimserve/test_canonical_indexer.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+import inspect
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from slimserve import canonical_indexer as ci
+
+
+def test_disabled_is_original_callable(monkeypatch):
+    monkeypatch.delenv("SLIMSERVE_GLM53_CANONICAL_INDEX_ORDER", raising=False)
+    monkeypatch.delenv("SLIMSERVE_GLM53_CANONICAL_INDEX_TIES", raising=False)
+    monkeypatch.delenv("SLIMSERVE_GLM53_CANONICAL_INDEX_FUSED", raising=False)
+    function = lambda: None
+    assert ci.maybe_ordered_topk(function) is function
+
+
+@pytest.mark.parametrize("missing", ["MODEL_JOURNAL", "CANONICAL_MOE", "INDEX_JOURNAL"])
+def test_flag_prerequisites(monkeypatch, missing):
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_INDEX_ORDER", "1")
+    for name in ("MODEL_JOURNAL", "CANONICAL_MOE", "INDEX_JOURNAL"):
+        monkeypatch.setenv("SLIMSERVE_GLM53_" + name, "1")
+    monkeypatch.delenv("SLIMSERVE_GLM53_" + missing)
+    with pytest.raises(ValueError, match="requires"):
+        ci.enabled()
+
+
+def test_bad_flag_and_cpu_tensor_rejected(monkeypatch):
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_INDEX_ORDER", "yes")
+    with pytest.raises(ValueError, match="0 or 1"):
+        ci.enabled()
+    with pytest.raises(ValueError, match="CUDA int32"):
+        ci.canonicalize(torch.zeros(2, 512, dtype=torch.int32))
+
+
+@pytest.mark.parametrize("ties,fused", [(False, False), (True, False), (True, True)])
+def test_wrapper_preserves_arguments_result_and_orders_after_selection(
+    monkeypatch, ties, fused
+):
+    for name in (
+        "CANONICAL_INDEX_ORDER",
+        "MODEL_JOURNAL",
+        "CANONICAL_MOE",
+        "INDEX_JOURNAL",
+    ):
+        monkeypatch.setenv("SLIMSERVE_GLM53_" + name, "1")
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_INDEX_TIES", str(int(ties)))
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_INDEX_FUSED", str(int(fused)))
+    calls = []
+
+    def native(
+        logits,
+        cu_seqlen_ks,
+        cu_seqlen_ke,
+        raw_topk_indices,
+        num_rows,
+        stride0,
+        stride1,
+        topk_tokens,
+    ):
+        calls.append("native")
+        raw_topk_indices.fill_(3)
+        return logits
+
+    def order(indices):
+        assert (indices == 3).all()
+        calls.append("ordered")
+
+    monkeypatch.setattr(ci, "canonicalize", order)
+
+    def tie_selector():
+        assert ties and not fused
+        return native
+
+    def fused_selector():
+        assert fused
+        return native
+
+    monkeypatch.setattr(ci, "_native_tie_selector", tie_selector)
+    monkeypatch.setattr(ci, "_native_fused_selector", fused_selector)
+
+    def forbidden(*args):
+        raise AssertionError("generic selector must not run with ties enabled")
+
+    wrapped = ci.maybe_ordered_topk(forbidden if ties else native)
+    assert inspect.signature(wrapped) == inspect.signature(
+        forbidden if ties else native
+    )
+    logits = torch.zeros(2, 600)
+    indices = torch.zeros(2, 512, dtype=torch.int32)
+    assert wrapped(logits, None, None, indices, 2, 600, 1, 512) is logits
+    assert calls == (["native"] if fused else ["native", "ordered"])
+    with pytest.raises(ValueError, match="geometry"):
+        wrapped(logits, None, None, indices, 3, 600, 1, 512)
+
+
+@pytest.mark.parametrize("value", ["yes", "-1", "2"])
+def test_invalid_tie_flag_rejected(monkeypatch, value):
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_INDEX_TIES", value)
+    with pytest.raises(ValueError, match="0 or 1"):
+        ci.maybe_ordered_topk(lambda: None)
+
+
+def test_ties_require_order_and_its_observers(monkeypatch):
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_INDEX_TIES", "1")
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_INDEX_ORDER", "0")
+    with pytest.raises(ValueError, match="requires canonical index order"):
+        ci.maybe_ordered_topk(lambda: None)
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_INDEX_ORDER", "1")
+    monkeypatch.delenv("SLIMSERVE_GLM53_MODEL_JOURNAL", raising=False)
+    with pytest.raises(ValueError, match="requires model/index traces"):
+        ci.maybe_ordered_topk(lambda: None)
+
+
+@pytest.mark.parametrize("value", ["yes", "-1", "2"])
+def test_invalid_fusion_flag_rejected(monkeypatch, value):
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_INDEX_FUSED", value)
+    with pytest.raises(ValueError, match="0 or 1"):
+        ci.maybe_ordered_topk(lambda: None)
+
+
+def test_fusion_requires_ties_and_all_observers(monkeypatch):
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_INDEX_FUSED", "1")
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_INDEX_TIES", "0")
+    with pytest.raises(ValueError, match="requires canonical index ties"):
+        ci.maybe_ordered_topk(lambda: None)
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_INDEX_TIES", "1")
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_INDEX_ORDER", "0")
+    with pytest.raises(ValueError, match="requires canonical index order"):
+        ci.maybe_ordered_topk(lambda: None)
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_INDEX_ORDER", "1")
+    monkeypatch.delenv("SLIMSERVE_GLM53_MODEL_JOURNAL", raising=False)
+    with pytest.raises(ValueError, match="requires model/index traces"):
+        ci.maybe_ordered_topk(lambda: None)
+
+
+def test_missing_fused_native_entry_fails(monkeypatch):
+    monkeypatch.setattr(
+        ci, "torch", SimpleNamespace(ops=SimpleNamespace(_C=SimpleNamespace()))
+    )
+    with pytest.raises(RuntimeError, match="requires a rebuilt native selector"):
+        ci._native_fused_selector()

--- a/tests/slimserve/test_canonical_moe.py
+++ b/tests/slimserve/test_canonical_moe.py
@@ -5,6 +5,7 @@ from slimserve.canonical_moe import enabled, geometry
 
 
 def test_flag_is_off_and_requires_bounded_journal(monkeypatch):
+    monkeypatch.delenv("SLIMSERVE_GLM53_NATIVE_ORDER", raising=False)
     monkeypatch.delenv("SLIMSERVE_GLM53_CANONICAL_MOE", raising=False)
     assert not enabled()
     monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_MOE", "yes")

--- a/tests/slimserve/test_canonical_moe.py
+++ b/tests/slimserve/test_canonical_moe.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from slimserve.canonical_moe import enabled, geometry
+
+
+def test_flag_is_off_and_requires_bounded_journal(monkeypatch):
+    monkeypatch.delenv("SLIMSERVE_GLM53_CANONICAL_MOE", raising=False)
+    assert not enabled()
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_MOE", "yes")
+    with pytest.raises(ValueError, match="must be 0 or 1"):
+        enabled()
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_MOE", "1")
+    monkeypatch.delenv("SLIMSERVE_GLM53_MODEL_JOURNAL", raising=False)
+    with pytest.raises(ValueError, match="bounded model journal"):
+        enabled()
+    monkeypatch.setenv("SLIMSERVE_GLM53_MODEL_JOURNAL", "1")
+    assert enabled()
+
+
+@pytest.mark.parametrize("tokens", [0, 8193, True, 1.0])
+def test_geometry_rejects_out_of_scope(tokens):
+    with pytest.raises(ValueError):
+        geometry(tokens, 8, 288, 32)
+
+
+def test_geometry_matches_capacity_and_extreme_skew():
+    assert geometry(1, 8, 288, 8) == (64, 8, 8)
+    assert geometry(640, 8, 288, 32) == (14048, 439, 640)
+    assert geometry(7616, 8, 288, 64) == (79072, 1236, 7616)
+    for args in [(640, 7, 288, 32), (640, 8, 256, 32), (640, 8, 288, 128)]:
+        with pytest.raises(ValueError):
+            geometry(*args)

--- a/tests/slimserve/test_cuda_sass_comparison.py
+++ b/tests/slimserve/test_cuda_sass_comparison.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+from collections import Counter
+
+import pytest
+
+from benchmarks.kernels.compare_cuda_sass import body_sha, compare, function_bodies
+
+
+def fixture(control="0x000e220008000a00", spaces=True):
+    word = f"/* {control} */" if spaces else f"/*{control}*/"
+    return [
+        "arch = sm_120f\n",
+        "Function : selector\n",
+        " /*00f0*/ LDCU.64 UR4, c[0x4][0x150] ; /* 0x01002a00ff0477ac */\n",
+        "   " + word + "\n",
+    ]
+
+
+@pytest.mark.parametrize("spaces", [True, False])
+def test_parser_keeps_separate_scheduling_words(spaces):
+    name, body = list(function_bodies(fixture(spaces=spaces)))[0]
+    assert name == "arch = sm_120f selector"
+    assert "0x01002a00ff0477ac" in body[0xF0]
+    assert "0x000e220008000a00" in body[0xF0]
+    assert len(body[0xF0].splitlines()) == 2
+
+
+def test_scheduling_only_change_is_not_identical():
+    name, first = list(function_bodies(fixture()))[0]
+    _, second = list(function_bodies(fixture(control="0x000f220008000a00")))[0]
+    result = compare(
+        {name: Counter({body_sha(first): 1})}, {name: Counter({body_sha(second): 1})}
+    )
+    assert result["identical_common_functions"] == 0
+    assert result["changed_common_functions"] == [name]
+
+
+@pytest.mark.parametrize("tail", [[], ["Function : next\n"], ["/* 0x1 */\n"]])
+def test_missing_or_malformed_control_word_fails(tail):
+    with pytest.raises(AssertionError):
+        list(function_bodies(fixture()[:-1] + tail))
+
+
+def test_duplicate_function_copies_are_retained():
+    bodies = list(function_bodies(fixture() + fixture()))
+    assert len(bodies) == 2 and bodies[0] == bodies[1]
+    name, body = bodies[0]
+    result = compare(
+        {name: Counter({body_sha(body): 2})}, {name: Counter({body_sha(body): 1})}
+    )
+    assert result["identical_common_functions"] == 1
+    assert result["changed_common_functions"] == [name]

--- a/tests/slimserve/test_cuda_sass_comparison.py
+++ b/tests/slimserve/test_cuda_sass_comparison.py
@@ -50,3 +50,15 @@ def test_duplicate_function_copies_are_retained():
     )
     assert result["identical_common_functions"] == 1
     assert result["changed_common_functions"] == [name]
+
+
+@pytest.mark.parametrize("added", ["original", "different-codegen"])
+def test_added_common_function_copy_is_reported(added):
+    before = {"selector": Counter({"original": 1})}
+    candidate = {"selector": Counter({"original": 1})}
+    candidate["selector"][added] += 1
+    result = compare(before, candidate)
+    assert result["changed_common_functions"] == ["selector"]
+    assert result["identical_common_functions"] == 1
+    assert result["before_functions"] == 1
+    assert result["candidate_functions"] == 2

--- a/tests/slimserve/test_glm53_native_ordering.py
+++ b/tests/slimserve/test_glm53_native_ordering.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native-only policy does not enable observers, sorting fallbacks or stale graphs."""
+
+from dataclasses import replace
+
+import pytest
+import torch
+
+from slimserve import canonical_indexer, canonical_moe, cli
+from slimserve import glm53_ordering as order
+from slimserve.hardware import Machine
+from slimserve.registry import resolve
+from tests.slimserve.test_stable_align_wiring import invoke
+from vllm.model_executor.layers.fused_moe.experts import marlin_moe
+from vllm.quixicore.ops import quixicore_ops
+
+
+@pytest.fixture(autouse=True)
+def clean_flags(monkeypatch):
+    for key in order.LEGACY_FLAGS + (order.FLAG, "SLIMSERVE_GLM_ROUTE_ALIGN"):
+        monkeypatch.delenv(key, raising=False)
+    for suffix in ("MODEL_JOURNAL", "INDEX_JOURNAL", "SCORE_JOURNAL", "MOE_JOURNAL"):
+        monkeypatch.delenv("SLIMSERVE_GLM53_" + suffix, raising=False)
+
+
+def test_policy_is_off_by_default_and_does_not_mutate_environment(monkeypatch):
+    import os
+
+    assert not order.enabled()
+    monkeypatch.setenv(order.FLAG, "1")
+    before = dict(os.environ)
+    assert all(
+        call()
+        for call in (
+            canonical_moe.enabled,
+            canonical_moe.stable_route_enabled,
+            canonical_moe.stable_align_enabled,
+            canonical_indexer.enabled,
+            canonical_indexer.ties_enabled,
+            canonical_indexer.fused_enabled,
+        )
+    )
+    assert dict(os.environ) == before
+
+
+@pytest.mark.parametrize("value", ["", "yes", "-1", "2"])
+def test_invalid_policy_rejected(monkeypatch, value):
+    monkeypatch.setenv(order.FLAG, value)
+    with pytest.raises(ValueError, match="0 or 1"):
+        order.enabled()
+
+
+@pytest.mark.parametrize("legacy", order.LEGACY_FLAGS)
+def test_mixed_control_policies_rejected(monkeypatch, legacy):
+    monkeypatch.setenv(order.FLAG, "1")
+    monkeypatch.setenv(legacy, "1")
+    with pytest.raises(ValueError, match="cannot combine"):
+        order.enabled()
+
+
+def test_disabling_fused_router_rejected(monkeypatch):
+    monkeypatch.setenv(order.FLAG, "1")
+    monkeypatch.setenv("SLIMSERVE_GLM_ROUTE_ALIGN", "0")
+    with pytest.raises(ValueError, match="requires fused small-M"):
+        order.enabled()
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["profile", "platform", "gpus", "quant", "recipe", "tp", "ep", "spec", "moe"],
+)
+def test_plan_scope_fails_closed(monkeypatch, field):
+    plan = resolve("glm53-nvfp4-4", "rtx6000", 4, None)
+    monkeypatch.setenv(order.FLAG, "1")
+    order.validate_plan(plan)
+    changes = {
+        "profile": dict(profile_id="other"),
+        "platform": dict(platform="a100"),
+        "gpus": dict(gpus=8),
+        "quant": dict(quant=replace(plan.quant, name="FP8")),
+        "recipe": dict(weight_recipe=None),
+        "spec": dict(speculative=True),
+        "tp": dict(engine={**plan.engine, "tensor_parallel_size": 2}),
+        "ep": dict(engine={**plan.engine, "enable_expert_parallel": True}),
+        "moe": dict(engine={**plan.engine, "moe_backend": "other"}),
+    }
+    with pytest.raises(ValueError, match="requires glm53"):
+        order.validate_plan(replace(plan, **changes[field]))
+
+
+def test_cli_scope_and_recipe_unchanged(monkeypatch):
+    machine = Machine("rtx6000", "RTX PRO 6000 Blackwell", 4)
+    monkeypatch.setattr(cli.hardware, "detect", lambda: machine)
+    monkeypatch.setenv(order.FLAG, "1")
+    captured = []
+    monkeypatch.setattr(cli, "_show", captured.append)
+    monkeypatch.setattr(cli.fetch, "ensure", lambda *a, **k: pytest.fail("download"))
+    assert cli.main(["glm53-nvfp4-4", "--dry-run"]) == 0
+    assert captured == [resolve("glm53-nvfp4-4", "rtx6000", 4, None)]
+    monkeypatch.setattr(cli.hardware, "detect", lambda: Machine("a100", "A100", 4))
+    assert cli.main(["glm53-nvfp4-4", "--dry-run"]) == 2
+
+
+def test_cache_factor_reaches_actual_graph_capabilities(monkeypatch):
+    before = quixicore_ops.graph_factors()
+    assert order.cache_factor() in before
+    monkeypatch.setenv(order.FLAG, "1")
+    after = quixicore_ops.graph_factors()
+    assert order.cache_factor() in after
+    assert set(after) - set(before) == {"glm53_native_order_v1=1"}
+    assert set(before) - set(after) == {"glm53_native_order_v1=0"}
+
+
+def test_native_pool_selector_never_calls_sort_control(monkeypatch):
+    monkeypatch.setenv(order.FLAG, "1")
+    calls = []
+    monkeypatch.setattr(
+        canonical_indexer, "canonicalize", lambda *a: pytest.fail("sort")
+    )
+    monkeypatch.setattr(
+        canonical_indexer, "_native_tie_selector", lambda: pytest.fail("unfused")
+    )
+    monkeypatch.setattr(
+        canonical_indexer, "_native_fused_selector", lambda: lambda *a: calls.append(a)
+    )
+    function = canonical_indexer.maybe_ordered_topk(lambda *a: pytest.fail("atomic"))
+    ids = torch.empty((17, 512), dtype=torch.int32)
+    function(None, None, None, ids, 17, 600, 1, 512)
+    assert len(calls) == 1 and calls[0][3] is ids
+
+
+@pytest.mark.parametrize("tokens", [1, 16, 8193])
+def test_native_policy_refuses_sorting_fallback(monkeypatch, tokens):
+    monkeypatch.setattr(marlin_moe, "_NATIVE_ORDER", True)
+    with pytest.raises(ValueError, match="no sorting fallback"):
+        invoke(monkeypatch, tokens)
+
+
+@pytest.mark.parametrize("tokens", [17, 32, 33, 640, 8192])
+def test_native_policy_uses_qualified_alignment(monkeypatch, tokens):
+    monkeypatch.setattr(marlin_moe, "_NATIVE_ORDER", True)
+    assert invoke(monkeypatch, tokens) == ["native"]
+
+
+def test_native_policy_keeps_small_fused_alignment(monkeypatch):
+    monkeypatch.setattr(marlin_moe, "_NATIVE_ORDER", True)
+    assert invoke(monkeypatch, 16, reused=True) == []
+
+
+def test_explicit_index_observer_records_effective_native_policy(monkeypatch, tmp_path):
+    import json
+
+    from slimserve import index_journal
+    from tests.slimserve.test_index_journal import config
+
+    monkeypatch.setenv(order.FLAG, "1")
+    assert not index_journal.enabled()
+    monkeypatch.setenv("SLIMSERVE_GLM53_INDEX_JOURNAL", "test-config")
+    with pytest.raises(ValueError, match="requires bounded model journal"):
+        index_journal.enabled()
+    monkeypatch.setenv("SLIMSERVE_GLM53_MODEL_JOURNAL", "1")
+    assert index_journal.enabled()
+    journal = index_journal.IndexJournal(config(tmp_path))
+    journal.close()
+    header = json.loads(journal.path.read_text().splitlines()[0])
+    assert header["selection_order"] == "canonical-pool-id"
+    assert header["selection_ties"] == "smaller-pool-id"
+    assert header["selection_order_implementation"] == "native-bitonic"

--- a/tests/slimserve/test_index_journal.py
+++ b/tests/slimserve/test_index_journal.py
@@ -1,0 +1,308 @@
+# SPDX-License-Identifier: Apache-2.0
+import hashlib
+import inspect
+import json
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from slimserve import index_journal as ij
+
+
+def config(tmp_path, **changes):
+    values = dict(
+        schema=1,
+        prompt_ids=list(range(8199)),
+        max_matches=3,
+        output_directory=str(tmp_path / "trace"),
+    )
+    values.update(changes)
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps(values))
+    return path
+
+
+@pytest.fixture
+def journal(tmp_path):
+    value = ij.IndexJournal(config(tmp_path))
+    yield value
+    value.close()
+
+
+@pytest.fixture
+def enabled(monkeypatch):
+    monkeypatch.setenv("SLIMSERVE_GLM53_INDEX_JOURNAL", "config.json")
+    monkeypatch.setenv("SLIMSERVE_GLM53_MODEL_JOURNAL", "1")
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_MOE", "1")
+
+
+def native(
+    logits,
+    cu_seqlen_ks,
+    cu_seqlen_ke,
+    raw_topk_indices,
+    num_rows,
+    stride0,
+    stride1,
+    topk_tokens,
+):
+    raw_topk_indices.fill_(-1)
+    return logits
+
+
+def run_topk(function, rows=4, columns=12):
+    logits = torch.randn(rows, columns)
+    starts = torch.zeros(rows, dtype=torch.int32)
+    ends = torch.full_like(starts, columns)
+    indices = torch.empty(rows, 512, dtype=torch.int32)
+    assert function(logits, starts, ends, indices, rows, columns, 1, 512) is logits
+    return indices
+
+
+def test_disabled_identity_and_runner(monkeypatch):
+    monkeypatch.delenv("SLIMSERVE_GLM53_INDEX_JOURNAL", raising=False)
+    assert ij.instrument_topk(native) is native
+    assert ij.instrument_pooled_indexer(native) is native
+    runner = SimpleNamespace(_model_forward=native)
+    ij.install_index_journal(runner)
+    assert vars(runner) == {"_model_forward": native}
+
+
+@pytest.mark.parametrize("missing", ["MODEL_JOURNAL", "CANONICAL_MOE"])
+def test_prerequisites_fail_closed(enabled, monkeypatch, missing):
+    monkeypatch.delenv("SLIMSERVE_GLM53_" + missing)
+    with pytest.raises(ValueError, match="requires"):
+        ij.enabled()
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"schema": True},
+        {"schema": 2},
+        {"prompt_ids": [1]},
+        {"prompt_ids": [-1] * 8199},
+        {"prompt_ids": [True] * 8199},
+        {"max_matches": 4},
+        {"max_matches": 0},
+        {"max_matches": True},
+        {"output_directory": ""},
+        {"output_directory": 12},
+        {"extra": 1},
+        {"capture_layer": None},
+        {"capture_layer": True},
+        {"capture_layer": "23"},
+        {"capture_layer": 23.0},
+        {"capture_layer": 0},
+        {"capture_layer": 1},
+        {"capture_layer": 45},
+    ],
+)
+def test_config_strict(tmp_path, change):
+    with pytest.raises(ValueError, match="requires"):
+        ij.IndexJournal(config(tmp_path, **change))
+
+
+def test_three_requests_multiple_chunks_and_extra_match(journal):
+    for match in range(3):
+        for computed, rows in ((0, 7616), (7616, 583)):
+            journal.begin(str(match), computed, rows, "cpu")
+            journal.layers = list(ij.LAYERS)
+            journal.finish()
+    with pytest.raises(ValueError, match="extra"):
+        journal.begin("four", 0, 4, "cpu")
+    events = [json.loads(line) for line in journal.path.read_text().splitlines()]
+    assert len([e for e in events if e["kind"] == "request_complete"]) == 3
+    assert len([e for e in events if e["kind"] == "forward_complete"]) == 6
+    assert len(events[0]["implementation_sha256"]) == 10
+    assert "slimserve/glm53_ordering.py" in events[0]["implementation_sha256"]
+    assert events[0]["selection_order"] == "native"
+    assert events[0]["selection_ties"] == "native"
+    assert events[0]["selection_order_implementation"] == "native"
+    assert events[0]["capture_layer"] == 3
+
+
+def test_overlap_missing_layers_and_wrong_continuation(journal):
+    with pytest.raises(ValueError, match="incomplete"):
+        journal.finish()
+    journal.begin("one", 0, 4, "cpu")
+    with pytest.raises(ValueError, match="overlapping"):
+        journal.begin("two", 0, 4, "cpu")
+    with pytest.raises(ValueError, match="incomplete"):
+        journal.finish()
+    journal.layers = list(ij.LAYERS)
+    journal.finish()
+    for request, cursor, device in (
+        ("other", 4, "cpu"),
+        ("one", 3, "cpu"),
+        ("one", 4, "cuda:0"),
+    ):
+        with pytest.raises(ValueError, match="contract"):
+            journal.begin(request, cursor, 4, device)
+
+
+def test_chunk_bound(journal):
+    for cursor in range(8):
+        journal.begin("one", cursor, 1, "cpu")
+        journal.layers = list(ij.LAYERS)
+        journal.finish()
+    with pytest.raises(ValueError, match="contract"):
+        journal.begin("one", 8, 1, "cpu")
+
+
+def test_cpu_mask_is_private_and_preserves_defined_bits():
+    logits = torch.tensor(
+        [
+            [float("nan"), -0.0, 1.0, float("nan")],
+            [float("nan"), 2.0, float("nan"), -3.0],
+        ]
+    )
+    before = logits.view(torch.uint8).clone()
+    starts, ends = (
+        torch.tensor([1, 1], dtype=torch.int32),
+        torch.tensor([3, 2], dtype=torch.int32),
+    )
+    host, lo, hi = ij.cpu_logits(logits, starts, ends)
+    assert torch.equal(logits.view(torch.uint8), before)
+    assert host.data_ptr() != logits.data_ptr()
+    assert torch.equal(
+        host, torch.tensor([[0.0, -0.0, 1.0, 0.0], [0.0, 2.0, 0.0, 0.0]])
+    )
+    assert bool(torch.signbit(host[0, 1]))
+    assert torch.equal(lo, starts) and torch.equal(hi, ends)
+
+
+@pytest.mark.parametrize("starts,ends", [([-1], [2]), ([2], [1]), ([0], [4])])
+def test_invalid_ranges(starts, ends):
+    with pytest.raises(ValueError, match="ranges"):
+        ij.cpu_logits(
+            torch.zeros(1, 3),
+            torch.tensor(starts, dtype=torch.int32),
+            torch.tensor(ends, dtype=torch.int32),
+        )
+
+
+def test_snapshot_archive_compacts_storage_and_hashes_raw_bits(journal, monkeypatch):
+    journal.begin("one", 0, 4, "cpu")
+    large = torch.zeros(400, dtype=torch.bfloat16)
+    value = large[10:14]
+    value[0] = -0.0
+    journal.snapshot("sample", value, save=True)
+    row = json.loads(journal.path.read_text().splitlines()[-1])
+    path = journal.archive / "match-1-chunk-1-sample.pt"
+    actual = torch.load(path, weights_only=True)
+    assert actual.untyped_storage().nbytes() == value.numel() * value.element_size()
+    assert (
+        row["sha256"]
+        == hashlib.sha256(value.view(torch.uint8).numpy().tobytes()).hexdigest()
+    )
+    assert row["archive"]["sha256"] == hashlib.sha256(path.read_bytes()).hexdigest()
+    with pytest.raises(ValueError, match="duplicate"):
+        journal.snapshot("sample", value)
+    monkeypatch.setattr(ij, "MAX_TENSOR_BYTES", 1)
+    with pytest.raises(ValueError, match="byte bound"):
+        journal.snapshot("large", value)
+    monkeypatch.setattr(ij, "MAX_TENSOR_BYTES", 128 * 1024**2)
+    monkeypatch.setattr(ij, "MAX_FILE_BYTES", journal.saved_bytes + 1)
+    with pytest.raises(ValueError, match="worker byte bound"):
+        journal.snapshot("archive", value, save=True)
+
+
+def test_wrappers_forward_without_active_context(enabled):
+    wrapped = ij.instrument_topk(native)
+    assert inspect.signature(wrapped) == inspect.signature(native)
+    assert (run_topk(wrapped) == -1).all()
+    pooled = ij.instrument_pooled_indexer(lambda k_cache_prefix: k_cache_prefix)
+    assert pooled("arbitrary-untraced-layer") == "arbitrary-untraced-layer"
+
+
+def test_complete_layer_coverage_forwards_arguments_and_snapshots(journal, enabled):
+    journal.begin("one", 0, 4, "cpu")
+    topk = ij.instrument_topk(native)
+
+    @ij.instrument_pooled_indexer
+    def pooled(k_cache_prefix):
+        return run_topk(topk)
+
+    token = ij.ACTIVE.set(journal)
+    try:
+        for layer in ij.LAYERS:
+            assert (
+                pooled(f"model.layers.{layer}.self_attn.indexer.k_cache") == -1
+            ).all()
+            assert ij.LAYER.get() is None
+    finally:
+        ij.ACTIVE.reset(token)
+    journal.finish()
+    assert len(list(journal.archive.glob("*.pt"))) == 4
+    tensors = [
+        json.loads(line)
+        for line in journal.path.read_text().splitlines()
+        if json.loads(line)["kind"] == "tensor"
+    ]
+    assert len(tensors) == 44
+
+
+def test_missing_layer_and_selector_rejected_with_context_reset(journal, enabled):
+    journal.begin("one", 0, 4, "cpu")
+    token = ij.ACTIVE.set(journal)
+    try:
+        with pytest.raises(ValueError, match="missing"):
+            run_topk(ij.instrument_topk(native))
+        pooled = ij.instrument_pooled_indexer(lambda k_cache_prefix: None)
+        with pytest.raises(ValueError, match="order"):
+            pooled("model.layers.7.self_attn.k_cache")
+        with pytest.raises(ValueError, match="unrecognized"):
+            pooled("bad-prefix")
+        with pytest.raises(ValueError, match="coverage"):
+            pooled("model.layers.3.self_attn.k_cache")
+        assert ij.LAYER.get() is None
+    finally:
+        ij.ACTIVE.reset(token)
+
+
+@pytest.mark.parametrize("layer", ij.LAYERS)
+def test_configured_layer_is_the_only_archived_layer(tmp_path, enabled, layer):
+    value = ij.IndexJournal(config(tmp_path, capture_layer=layer))
+    value.begin("selected-layer", 0, 4, "cpu")
+    topk = ij.instrument_topk(native)
+
+    @ij.instrument_pooled_indexer
+    def pooled(k_cache_prefix):
+        return run_topk(topk)
+
+    token = ij.ACTIVE.set(value)
+    try:
+        for current in ij.LAYERS:
+            pooled(f"model.layers.{current}.self_attn.indexer.k_cache")
+        value.finish()
+    finally:
+        ij.ACTIVE.reset(token)
+        value.close()
+    paths = list(value.archive.glob("*.pt"))
+    assert len(paths) == 4
+    assert all(f"layer-{layer:02d}.call-0." in p.name for p in paths)
+    header = json.loads(value.path.read_text().splitlines()[0])
+    assert header["capture_layer"] == layer
+
+
+def test_runner_configuration_and_unmatched_request(tmp_path, monkeypatch, enabled):
+    monkeypatch.setenv("SLIMSERVE_GLM53_INDEX_JOURNAL", str(config(tmp_path)))
+    runner = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_text_config=SimpleNamespace(hidden_size=4096, num_hidden_layers=45)
+        ),
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=2, pipeline_parallel_size=1
+        ),
+        speculative_config=None,
+        _model_forward=lambda **kw: kw,
+        num_prompt_logprobs={},
+    )
+    with pytest.raises(ValueError, match="TP4"):
+        ij.install_index_journal(runner)
+    runner.parallel_config.tensor_parallel_size = 4
+    ij.install_index_journal(runner)
+    assert runner._model_forward(test="unmatched") == {"test": "unmatched"}
+    runner._slimserve_index_journal.close()

--- a/tests/slimserve/test_index_journal.py
+++ b/tests/slimserve/test_index_journal.py
@@ -2,6 +2,7 @@
 import hashlib
 import inspect
 import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -190,7 +191,8 @@ def test_snapshot_archive_compacts_storage_and_hashes_raw_bits(journal, monkeypa
     value[0] = -0.0
     journal.snapshot("sample", value, save=True)
     row = json.loads(journal.path.read_text().splitlines()[-1])
-    path = journal.archive / "match-1-chunk-1-sample.pt"
+    path = Path(row["archive"]["path"])
+    assert path == journal.archive / "match-1-chunk-1-sample.pt"
     actual = torch.load(path, weights_only=True)
     assert actual.untyped_storage().nbytes() == value.numel() * value.element_size()
     assert (

--- a/tests/slimserve/test_indexer_bound_leaves.py
+++ b/tests/slimserve/test_indexer_bound_leaves.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from benchmarks.kernels import audit_glm53_indexer_correction_loader as audit
+from benchmarks.kernels import audit_glm53_kv_loader as common_audit
+from benchmarks.kernels import glm53_indexer_bound_leaves as leaves
+from benchmarks.kernels import prepare_glm53_indexer_correction_loader as prep
+from benchmarks.kernels.check_glm53_indexer_correction_loader import read_manifest
+from slimserve.rmsnorm_diagnostic import sha
+from tests.slimserve.test_kv_loader_audit import actual_receipts, prepared_fixture
+
+
+def leaf_fixture(tmp_path, mode="correction"):
+    qualified = dict(
+        input_sha256=["i0", "i1"],
+        phases=[
+            dict(
+                baseline_sha256=["kv", "q", f"old{p}"],
+                candidate_sha256=["kv", "q", f"new{p}"],
+                selected_sha256=f"flags{p}",
+            )
+            for p in range(2)
+        ],
+    )
+    path = tmp_path / "qualified.json"
+    path.write_text(json.dumps(qualified))
+    entry = dict(
+        path=str(path),
+        sha256=sha(path),
+        case=dict(rank=0, rows=1, seed=530901, magnitude=0.125),
+    )
+    binding = dict(graph="g.py", symbol="combo", source="combo.py")
+    record = dict(
+        status="complete",
+        binding=binding,
+        qualified_case=entry,
+        input_sha256=qualified["input_sha256"],
+        replay_guards_pass=True,
+        observations=[
+            dict(
+                phase=p,
+                outputs=qualified["phases"][p][
+                    "candidate_sha256" if mode == "correction" else "baseline_sha256"
+                ],
+                **(
+                    dict(selection_sha256=f"flags{p}", arena_guards_pass=True)
+                    if mode == "correction"
+                    else {}
+                ),
+            )
+            for p in leaves.PHASE_ORDER
+        ],
+    )
+    return record, binding, entry
+
+
+@pytest.mark.parametrize("mode", ["control", "correction"])
+def test_leaf_auditor_joins_each_phase_to_qualified_outputs(tmp_path, mode):
+    record, binding, entry = leaf_fixture(tmp_path, mode)
+    leaves.audit_leaf(record, binding, entry, mode)
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        "phase",
+        "missing",
+        "output",
+        "flags",
+        "guard",
+        "input",
+        "binding",
+        "failed",
+        "replay",
+    ],
+)
+def test_leaf_auditor_rejects_output_replay_or_guard_drift(tmp_path, change):
+    record, binding, entry = leaf_fixture(tmp_path)
+    record = copy.deepcopy(record)
+    if change == "phase":
+        record["observations"][0]["phase"] = 1
+    elif change == "missing":
+        record["observations"].pop()
+    elif change == "output":
+        record["observations"][2]["outputs"][2] = "bad"
+    elif change == "flags":
+        record["observations"][3]["selection_sha256"] = "bad"
+    elif change == "guard":
+        record["observations"][4]["arena_guards_pass"] = False
+    elif change == "input":
+        record["input_sha256"][0] = "bad"
+    elif change == "binding":
+        record["binding"]["symbol"] = "other"
+    elif change == "failed":
+        record["status"] = "failed"
+    else:
+        record["replay_guards_pass"] = False
+    with pytest.raises(ValueError):
+        leaves.audit_leaf(record, binding, entry, "correction")
+
+
+def test_control_cannot_claim_a_selection_write(tmp_path):
+    record, binding, entry = leaf_fixture(tmp_path, "control")
+    record["observations"][0]["selection_sha256"] = "bad"
+    with pytest.raises(ValueError, match="control unexpectedly"):
+        leaves.audit_leaf(record, binding, entry, "control")
+
+
+def test_actual_controller_receipt_policy_requires_distinct_correction_namespace(
+    tmp_path, monkeypatch
+):
+    # Re-label real CPU-observed KV events as a fixture for the generic join.
+    # This is not represented as a live correction-kernel qualification.
+    manifest, _, graphs, binaries, events = actual_receipts(tmp_path, monkeypatch)
+    manifest["mode"] = "correction"
+    manifest["selection_capacity"] = 8192
+    for target in manifest["targets"]["0"]:
+        target["correction"] = target.pop("kv")
+    for row in graphs["bindings"]:
+        row["dispatch"] = audit.DISPATCH
+        row["appended"].update(
+            selection_capacity=8192,
+            selection_bytes=8194 * 128,
+            selection_dtype="uint8",
+            selection_device="cuda:0",
+        )
+    for event in events:
+        event["event"] = event["event"].replace("kv_", "indexer_correction_", 1)
+        if "mode" in event:
+            event["mode"] = "correction"
+    events[0]["source_sha256"] = sha(audit.LOADER_SOURCE)
+    result = common_audit.check_graph_records(
+        manifest, events[0]["manifest_sha256"], graphs, binaries, events, workflow=audit
+    )
+    assert result["appended_launchers"] == 2
+    graphs["bindings"][0]["appended"]["selection_bytes"] += 1
+    with pytest.raises(ValueError, match="arena"):
+        common_audit.check_graph_records(
+            manifest,
+            events[0]["manifest_sha256"],
+            graphs,
+            binaries,
+            events,
+            workflow=audit,
+        )
+
+
+def test_series_copies_private_sources_and_read_manifest_checks_order(
+    tmp_path, monkeypatch
+):
+    base = prepared_fixture(tmp_path, monkeypatch)
+    base.update(
+        schema=prep.SCHEMA,
+        qualification_sha256=prep.QUALIFICATION_SHA,
+        selection_capacity=8192,
+        qualified_leaf_cases=[],
+    )
+    from benchmarks.kernels.check_glm53_attention_overwrite import matrix
+
+    base["qualified_leaf_cases"] = [
+        dict(case=case, path="fixture", sha256="fixture") for case in matrix()
+    ]
+    for ts in base["targets"].values():
+        ts[0]["correction"] = ts[0].pop("kv")
+    monkeypatch.setattr(prep, "build_base", lambda: copy.deepcopy(base))
+    output = tmp_path / "series"
+    prep.prepare_series(output)
+    for mode, rank in prep.ORDER:
+        path = output / f"{mode}-rank{rank}/manifest.json"
+        data, prepared = read_manifest(path)
+        assert len(prepared["runs"]) == 8
+        for name, digest in data["private_sources"].items():
+            assert sha(Path(data["private_namespace"]) / name) == digest
+    prepared["runs"].reverse()
+    (output / "preparation.json").write_text(json.dumps(prepared))
+    with pytest.raises(ValueError, match="prepared correction"):
+        read_manifest(output / "control-rank0/manifest.json")
+    with pytest.raises(ValueError, match="preserve"):
+        prep.prepare_series(output)

--- a/tests/slimserve/test_indexer_correction.py
+++ b/tests/slimserve/test_indexer_correction.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+import copy
+import json
+
+import pytest
+import torch
+
+from benchmarks.kernels import check_glm53_indexer_correction as probe
+from benchmarks.kernels import glm53_indexer_correction as kernel
+
+
+def tensors(rows=3):
+    packed = torch.zeros(rows, 2336, dtype=torch.bfloat16)
+    weights = [torch.ones(n, dtype=torch.bfloat16) for n in (512, 1536, 128, 128)]
+    outputs = [torch.empty(rows, n, dtype=torch.bfloat16) for n in (512, 1536)]
+    outputs.append(torch.empty(rows, 256, dtype=torch.bfloat16)[:, :128])
+    selected = torch.empty(rows, 128, dtype=torch.uint8)
+    return (packed, *weights, *outputs, rows, rows, rows), selected
+
+
+def test_jit_import_is_gpu_inert_and_fixed_precision_policy():
+    assert not torch.cuda.is_initialized()
+    assert kernel.correct_indexer.arg_names == [
+        "Packed",
+        "Gamma",
+        "Bias",
+        "Output",
+        "Selected",
+        "N",
+    ]
+    assert kernel.EXPONENT == -12
+    assert kernel.OPTIONS == {
+        "num_warps": 1,
+        "num_stages": 1,
+        "enable_fp_fusion": False,
+    }
+    source = kernel.correct_indexer.src
+    assert "0.000244140625 * scale" in source
+    assert "row * 2336 + 2048 + col" in source
+    assert "row * 256 + col" in source
+    assert "tl.sum(centered * centered, 0)" in source
+    assert "value.to(tl.bfloat16), selected" in source
+    assert "tl.full((), 1e-6, tl.float64)" in source
+    assert ".to(tl.float64)" in source
+
+
+def test_adapter_preserves_exact_abi_stream_and_order():
+    args, selected = tensors()
+    calls = []
+
+    def combo(*a, **kw):
+        calls.append(("combo", a, kw))
+        return "original result"
+
+    def correction(*a, **kw):
+        calls.append(("correction", a, kw))
+
+    adapter = kernel.IndexerOnlyCorrection(combo, correction, selected)
+    assert adapter(*args, stream=123) == "original result"
+    assert calls[0] == ("combo", args, dict(stream=123))
+    expected = (args[0], args[3], args[4], args[7], selected, 3)
+    assert all(a is b for a, b in zip(calls[1][1][:-1], expected[:-1]))
+    assert calls[1][1][-1] == 3 and calls[1][2] == dict(stream=123)
+    assert adapter.combo_calls == adapter.correction_calls == 1
+
+
+@pytest.mark.parametrize(
+    "bad", ["rows", "bool_rows", "short_abi", "stride", "packed", "dtype", "selection"]
+)
+def test_adapter_rejects_invalid_layout_before_original_launch(bad):
+    args, selected = tensors()
+    args = list(args)
+    if bad == "rows":
+        args[-1] = 2
+    elif bad == "bool_rows":
+        args[-3:] = [True] * 3
+    elif bad == "short_abi":
+        args.pop()
+    elif bad == "stride":
+        args[7] = args[7].contiguous()
+    elif bad == "packed":
+        args[0] = args[0][:, :2335]
+    elif bad == "dtype":
+        args[3] = args[3].float()
+    else:
+        selected = selected[:, :127]
+
+    def forbidden(*a, **kw):
+        raise AssertionError("launch forbidden")
+
+    with pytest.raises(ValueError):
+        kernel.IndexerOnlyCorrection(forbidden, forbidden, selected)(*args, stream=0)
+
+
+def test_failed_original_does_not_launch_correction():
+    args, selected = tensors()
+
+    def fail(*a, **kw):
+        raise RuntimeError("original failed")
+
+    def forbidden(*a, **kw):
+        raise AssertionError("correction forbidden")
+
+    adapter = kernel.IndexerOnlyCorrection(fail, forbidden, selected)
+    with pytest.raises(RuntimeError, match="original failed"):
+        adapter(*args, stream=0)
+    assert adapter.combo_calls == adapter.correction_calls == 0
+
+
+def phase_fixture():
+    baseline = [torch.ones(3, w, dtype=torch.bfloat16) for w in (512, 1536, 128)]
+    baseline[2][1, 60] = 4.0605664253234863e-7
+    reference = baseline[2].clone()
+    reference[1, 60] = 3.986060619354248e-7
+    candidate = [t.clone() for t in baseline]
+    candidate[2] = reference.clone()
+    bias = torch.full((128,), -0.57421875, dtype=torch.bfloat16)
+    selected = probe.precision.cancellation_mask(baseline[2], bias, -12).byte()
+    return baseline, candidate, selected, reference, bias
+
+
+def test_phase_metrics_count_actual_selection_and_require_exact_neighbors():
+    baseline, candidate, selected, reference, bias = phase_fixture()
+    metrics = probe.phase_metrics(baseline, candidate, selected, reference, bias)
+    assert (
+        metrics["selected_elements"]
+        == metrics["selected_rows"]
+        == metrics["changed_elements"]
+        == 1
+    )
+    assert metrics["missed_original_failures"] == 0
+    assert metrics["corrected_oracle"]["max_bf16_ulp"] == 0
+    selected[1, 60] = 0
+    with pytest.raises(ValueError, match="detector disagrees"):
+        probe.phase_metrics(baseline, candidate, selected, reference, bias)
+
+
+@pytest.mark.parametrize("slot,column", [(0, 0), (1, 0), (2, 59)])
+def test_any_non_target_or_unselected_change_rejected(slot, column):
+    args = phase_fixture()
+    args[1][slot][0, column] = 2
+    with pytest.raises(ValueError, match="Q/KV changed|unselected indexer"):
+        probe.phase_metrics(*args)
+
+
+def record_fixture():
+    baseline, candidate, selected, reference, bias = phase_fixture()
+    phase = probe.phase_metrics(baseline, candidate, selected, reference, bias)
+    case = dict(rank=0, rows=3, seed=530901, magnitude=0.125)
+    historical = dict(
+        inputs=["input0", "input1"], outputs={"combo": [phase["baseline_sha256"]] * 2}
+    )
+    record = dict(
+        **case,
+        input_sha256=historical["inputs"],
+        phases=[phase, copy.deepcopy(phase)],
+        replay_guards_mutation_passed=True,
+    )
+    return record, case, historical
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("missed_original_failures", 1),
+        ("non_target_and_unselected_exact", False),
+        ("detector_exact", False),
+        ("changed_elements", 2),
+    ],
+)
+def test_audit_rejects_missing_coverage_or_preservation(key, value):
+    record, case, historical = record_fixture()
+    probe.audit_record(record, case, historical)
+    record["phases"][0][key] = value
+    with pytest.raises(ValueError):
+        probe.audit_record(record, case, historical)
+
+
+def test_audit_keeps_one_ulp_floor_and_historical_output_checks():
+    record, case, historical = record_fixture()
+    record["phases"][0]["corrected_oracle"]["max_bf16_ulp"] = 2
+    with pytest.raises(ValueError, match="one-ULP"):
+        probe.audit_record(record, case, historical)
+    record, case, historical = record_fixture()
+    record["phases"][0]["candidate_sha256"][0] = "changed"
+    with pytest.raises(ValueError, match="Q/KV hashes"):
+        probe.audit_record(record, case, historical)
+
+
+def test_matrix_and_timing_are_fixed_before_gpu():
+    cases = probe.previous.matrix()
+    assert len(cases) == 120
+    assert [(r["rank"], r["rows"]) for r in cases[::30]] == [(r, 1) for r in range(4)]
+    assert probe.TIMING == {
+        "rank": 0,
+        "seed": 530901,
+        "magnitude": 1.0,
+        "repeats": 3,
+        "graph_calls": 32,
+        "warmup": 10,
+    }
+    assert probe.TIMING_ROWS == (1, 16, 640, 7616)
+
+
+def test_real_preparation_does_not_run_expired_historical_freeze(tmp_path):
+    if not probe.SCREEN.exists():
+        pytest.skip("local campaign evidence absent")
+    path = tmp_path / "manifest.json"
+    probe.prepare(path)
+    manifest = json.loads(path.read_text())
+    assert len(manifest["cases"]) == 120 and len(manifest["records"]) == 4
+    assert manifest["exponent"] == -12
+    probe.verify(manifest)
+    with pytest.raises(ValueError, match="preserve prior"):
+        probe.prepare(path)
+
+
+def test_existing_attempt_never_restarted(tmp_path):
+    output = tmp_path / "attempt"
+    output.mkdir()
+    with pytest.raises(ValueError, match="no retry"):
+        probe.run(tmp_path / "absent-manifest", output)

--- a/tests/slimserve/test_indexer_correction_loader.py
+++ b/tests/slimserve/test_indexer_correction_loader.py
@@ -1,0 +1,260 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU launcher mechanics; native driver and device allocation are simulated."""
+
+import base64
+import hashlib
+from types import SimpleNamespace
+
+import pytest
+import torch
+from triton.compiler import ASTSource
+
+from benchmarks.kernels import glm53_indexer_correction_loader as module
+from benchmarks.kernels import prepare_glm53_indexer_correction_loader as prepare
+from benchmarks.kernels.audit_glm53_indexer_correction_graphs import inventory
+from benchmarks.kernels.glm53_binary_observer import StaticCudaBinaryObserver
+from benchmarks.kernels.glm53_indexer_correction import correct_indexer
+from tests.slimserve.test_indexer_correction import tensors
+from tests.slimserve.test_kv_loader import fixture as kv_fixture
+from tests.slimserve.test_kv_loader import load_graphs
+
+
+def triton_image(tmp_path):
+    identity = hashlib.sha256(b"fixture key").hexdigest()
+    key = base64.b32encode(bytes.fromhex(identity)).decode().rstrip("=")
+    path = tmp_path / key / "correct_indexer.cubin"
+    path.parent.mkdir(parents=True)
+    image = b"fixture cubin"
+    path.write_bytes(image)
+    compiled = SimpleNamespace(
+        hash=identity,
+        src=ASTSource(correct_indexer, signature=module.SIGNATURE),
+        asm={"cubin": image},
+        metadata=SimpleNamespace(**module.OPTIONS, shared=0, num_ctas=1),
+    )
+    record = dict(
+        kernel="correct_indexer",
+        selected=dict(hash=key, config=dict(num_warps=1, num_stages=1)),
+        cubin_sha256=module.sha(path),
+    )
+    return compiled, record, path
+
+
+def test_actual_static_constructor_observer_and_n_grid_preserve_six_argument_abi(
+    tmp_path,
+):
+    compiled, record, path = triton_image(tmp_path)
+    result = module.to_static(compiled, record, 0, tmp_path)
+    assert result.kernel.cubin_raw == b"fixture cubin"
+    assert result.kernel.function is None
+    calls = []
+    result.kernel.C_impl = SimpleNamespace(
+        _load_kernel=lambda *a: (10, 20, 32, 0),
+        _launch_kernel=lambda *a: calls.append(a),
+        _unload_kernel=lambda *_: None,
+    )
+    observer = StaticCudaBinaryObserver(
+        0,
+        [tmp_path],
+        expected_images={
+            (path.parent.name, record["kernel"]): {record["cubin_sha256"]}
+        },
+    )
+    with observer.intercept():
+        launcher = result.make_launcher()
+        observer.verify_launcher(result, launcher)
+        args = (*[object() for _ in range(5)], 7616)
+        launcher(*args, stream=123)
+        assert calls == [(20, 7616, 1, 1, 1, 0, "OOOOOi", args, 123)]
+        assert observer.digest(result) == record["cubin_sha256"]
+    assert not torch.cuda.is_initialized()
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        "key",
+        "bytes",
+        "disk",
+        "signature",
+        "warps",
+        "fusion",
+        "name",
+        "config",
+        "arg_order",
+    ],
+)
+def test_static_bridge_rejects_unqualified_kernel_before_driver_load(tmp_path, change):
+    compiled, record, path = triton_image(tmp_path)
+    if change == "key":
+        record["selected"]["hash"] = "wrong"
+    elif change == "bytes":
+        compiled.asm["cubin"] = b"other image"
+    elif change == "disk":
+        path.write_bytes(b"changed")
+    elif change == "signature":
+        compiled.src.signature = {**module.SIGNATURE, "N": "i64"}
+    elif change == "warps":
+        compiled.metadata.num_warps = 4
+    elif change == "fusion":
+        compiled.metadata.enable_fp_fusion = True
+    elif change == "config":
+        record["selected"]["config"]["num_stages"] = 2
+    elif change == "arg_order":
+        compiled.src.fn = SimpleNamespace(
+            __name__="correct_indexer", arg_names=list(reversed(module.SIGNATURE))
+        )
+    else:
+        record["kernel"] = "wrong"
+    with pytest.raises(ValueError):
+        module.to_static(compiled, record, 0, tmp_path)
+    assert not torch.cuda.is_initialized()
+
+
+def test_bound_adapter_uses_fixed_guarded_arena_views_without_allocating(monkeypatch):
+    args, _ = tensors(3)
+    storage = torch.full((10, 128), 171, dtype=torch.uint8)
+    calls = []
+
+    def combo(*a, **kw):
+        calls.append(("combo", a, kw))
+        return "original result"
+
+    def extra(*a, **kw):
+        calls.append(("extra", a, kw))
+
+    adapter = module.BoundIndexerCorrection(combo, extra, storage, 8)
+
+    def forbidden(*a, **kw):
+        raise AssertionError("allocation forbidden in dispatch")
+
+    monkeypatch.setattr(torch, "empty", forbidden)
+    monkeypatch.setattr(torch, "full", forbidden)
+    assert adapter.run(*args, stream=123) == "original result"
+    assert [c[0] for c in calls] == ["combo", "extra"]
+    launched = calls[1][1]
+    assert (
+        launched[0] is args[0]
+        and launched[1] is args[3]
+        and launched[2] is args[4]
+        and launched[3] is args[7]
+    )
+    assert launched[4].data_ptr() == storage.data_ptr() + 128
+    assert launched[4].shape == (3, 128) and launched[5] == 3
+    assert calls[1][2] == dict(stream=123)
+
+
+@pytest.mark.parametrize(
+    "change", ["overflow", "rebound", "dtype", "shape", "run", "combo", "correction"]
+)
+def test_arena_and_dispatch_drift_are_rejected(change):
+    args, _ = tensors(3)
+
+    def original(*a, **kw):
+        raise AssertionError("must not launch")
+
+    def extra(*a, **kw):
+        raise AssertionError("must not launch")
+
+    storage = torch.full((10, 128), 171, dtype=torch.uint8)
+    adapter = module.BoundIndexerCorrection(original, extra, storage, 8)
+    if change == "overflow":
+        with pytest.raises(ValueError, match="exceed"):
+            adapter.run(*args[:-3], 9, 9, 9, stream=0)
+        return
+    if change == "rebound":
+        adapter.storage = storage.clone()
+    elif change == "dtype":
+        adapter.storage = storage.float()
+    elif change == "shape":
+        adapter.capacity = 7
+    elif change == "run":
+        adapter.run = original
+    elif change == "combo":
+        adapter.combo = extra
+    else:
+        adapter.correction = original
+    with pytest.raises(ValueError):
+        module.check_adapter(adapter, original, extra, 8)
+
+
+def correction_fixture(tmp_path, monkeypatch, mode):
+    f = kv_fixture(tmp_path, monkeypatch, mode="control")
+    f.manifest["schema"] = module.SCHEMA
+    f.manifest["selection_capacity"] = 8192
+    target = f.manifest["targets"]["0"][0]
+    target["correction"] = target.pop("kv")
+    f.loader = module.IndexerCorrectionLoader(
+        0, f.manifest, tmp_path / "manifest.json", mode
+    )
+    f.loader.compile_replacement = lambda _: f.results["kv"]
+
+    def make_adapter(controller, launcher, pair):
+        storage = torch.full((8194, 128), 171, dtype=torch.uint8)
+        adapter = module.BoundIndexerCorrection(launcher, pair[1], storage, 8192)
+        return adapter, adapter.run
+
+    monkeypatch.setattr(
+        module.IndexerCorrectionIntervention, "make_adapter", make_adapter
+    )
+    return f
+
+
+def test_control_actual_future_and_graph_inventory_preserve_original_dispatch(
+    tmp_path, monkeypatch
+):
+    f = correction_fixture(tmp_path, monkeypatch, "control")
+    with f.loader.intercept():
+        modules = load_graphs(f)
+        report = inventory(modules, f.manifest, 0, "control", f.loader.observer)
+        assert report["target_bindings"] == 2
+        assert all(r["dispatch"] == "direct_combo" for r in report["bindings"])
+        f.loader.controller.seal(modules)
+
+
+def test_candidate_controller_binds_extra_static_image_and_rejects_arena_drift(
+    tmp_path, monkeypatch
+):
+    f = correction_fixture(tmp_path, monkeypatch, "correction")
+    with f.loader.intercept():
+        modules = load_graphs(f)
+        binding = next(iter(f.loader.controller.owners.values()))
+        f.loader.controller.verify(binding)
+        assert (
+            f.tuner.run.__self__.correction.__globals__["runner"].__self__
+            is f.results["kv"].kernel
+        )
+        # The CPU arena is deliberately not claimed to be a rank0 GPU tensor.
+        with pytest.raises(ValueError, match="wrong rank"):
+            inventory(modules, f.manifest, 0, "correction", f.loader.observer)
+        binding["adapter"].storage = binding["adapter"].storage.clone()
+        with pytest.raises(ValueError, match="arena"):
+            f.loader.controller.verify(binding)
+
+
+def test_candidate_binding_rejects_changed_extra_handle(tmp_path, monkeypatch):
+    f = correction_fixture(tmp_path, monkeypatch, "correction")
+    with f.loader.intercept():
+        load_graphs(f)
+        binding = next(iter(f.loader.controller.owners.values()))
+        f.results["kv"].kernel.function = -1
+        with pytest.raises(ValueError, match="handles"):
+            f.loader.controller.verify(binding)
+
+
+def test_cpu_base_joins_completed_correction_and_actual_aot_roots():
+    if not (prepare.RESULTS / "indexer-correction-v1/analysis.json").exists():
+        pytest.skip("campaign evidence unavailable")
+    base = prepare.build_base()
+    assert base["schema"] == module.SCHEMA
+    assert base["selection_capacity"] == 8192
+    assert all(len(base["artifact_roots"][str(r)]) == 7 for r in range(4))
+    assert all(
+        len(base["targets"][str(r)][0]["static_graph_uses"]) == 2 for r in range(4)
+    )
+    cubins = {
+        base["targets"][str(r)][0]["correction"]["cubin_sha256"] for r in range(4)
+    }
+    assert cubins == {
+        "bd00effc35c7c0619ce74d3819aa3322cc110e423ce157ce855994f30188453e"
+    }

--- a/tests/slimserve/test_indexer_correction_serving.py
+++ b/tests/slimserve/test_indexer_correction_serving.py
@@ -1,0 +1,405 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU integration tests; CUDA allocation/driver/stream queries are simulated."""
+
+import copy
+from types import SimpleNamespace as NS
+
+import pytest
+import torch
+
+from benchmarks.kernels import glm53_indexer_correction_serving as serving
+from benchmarks.kernels import prepare_glm53_indexer_correction_serving as preparation
+from benchmarks.kernels.audit_glm53_geometry_loader import json_lines
+from benchmarks.kernels.audit_glm53_geometry_serving import audit_worker
+from benchmarks.kernels.glm53_indexer_correction_loader import (
+    BoundIndexerCorrection,
+    IndexerCorrectionIntervention,
+)
+from slimserve import glm53_ordering
+from slimserve import indexer_correction_diagnostic as policy
+from slimserve.glm53_serving_diagnostic import cases
+from slimserve.glm53_serving_diagnostic import policy as serving_policy
+from slimserve.registry import resolve
+from tests.slimserve.test_indexer_correction_loader import correction_fixture
+from tests.slimserve.test_kv_serving import serving_fixture
+
+
+def runner_fixture():
+    return NS(
+        max_num_tokens=8192,
+        scheduler_config=NS(max_num_batched_tokens=8192),
+        cudagraph_batch_sizes=[1, 2, 4, 8, 16, 32, 64],
+        parallel_config=NS(
+            data_parallel_size=1,
+            decode_context_parallel_size=1,
+            use_ubatching=False,
+            tensor_parallel_size=4,
+            pipeline_parallel_size=1,
+            enable_expert_parallel=False,
+            rank=0,
+        ),
+        compilation_config=NS(
+            pass_config=NS(enable_sp=False), inductor_compile_config={}
+        ),
+        model_config=NS(hf_text_config=NS(hidden_size=4096, num_hidden_layers=45)),
+        dtype=torch.bfloat16,
+        kv_cache_dtype=torch.bfloat16,
+        speculative_config=None,
+    )
+
+
+def runtime_fixture(monkeypatch):
+    diagnostic = serving.ServingIndexerCorrection.__new__(
+        serving.ServingIndexerCorrection
+    )
+    diagnostic.summary = dict(
+        status="installed",
+        runtime_envelope=serving.runtime_envelope(runner_fixture(), 8192),
+    )
+    diagnostic.owner_thread = diagnostic.last_stream = diagnostic.live_stream = None
+    diagnostic.observed = set()
+    events, barriers = [], []
+    diagnostic.emit = lambda kind, row: events.append(row)
+    stream = NS(cuda_stream=123)
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: stream)
+    monkeypatch.setattr(
+        torch.cuda, "synchronize", lambda: barriers.append(stream.cuda_stream)
+    )
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+    return diagnostic, events, barriers, stream
+
+
+def result(padded, ubatch=False, dp=None):
+    return None, NS(num_tokens=padded), ubatch, dp, None
+
+
+@pytest.mark.parametrize(
+    "change",
+    ["capacity", "maximum", "scheduler", "capture", "dp", "dcp", "ubatch", "sp"],
+)
+def test_actual_runtime_configuration_rejected(change):
+    runner, capacity = runner_fixture(), 8192
+    if change == "capacity":
+        capacity = 16384
+    elif change == "maximum":
+        runner.max_num_tokens = 16384
+    elif change == "scheduler":
+        runner.scheduler_config.max_num_batched_tokens = 4096
+    elif change == "capture":
+        runner.cudagraph_batch_sizes.append(8193)
+    elif change == "dp":
+        runner.parallel_config.data_parallel_size = 2
+    elif change == "dcp":
+        runner.parallel_config.decode_context_parallel_size = 2
+    elif change == "ubatch":
+        runner.parallel_config.use_ubatching = True
+    else:
+        runner.compilation_config.pass_config.enable_sp = True
+    with pytest.raises(ValueError, match="bounded serialized"):
+        serving.runtime_envelope(runner, capacity)
+
+
+@pytest.mark.parametrize(
+    "tokens,padded,ubatch,dp",
+    [
+        (8192, 8193, False, None),
+        (0, 1, False, None),
+        (2, 1, False, None),
+        (True, 1, False, None),
+        (1, 1, True, None),
+        (1, 1, False, []),
+    ],
+)
+def test_real_padding_output_is_checked_before_forward(
+    monkeypatch, tokens, padded, ubatch, dp
+):
+    diagnostic, events, _, _ = runtime_fixture(monkeypatch)
+    with pytest.raises(ValueError, match="actual padded"):
+        diagnostic.observe_padding(tokens, result(padded, ubatch, dp))
+    assert not events
+
+
+def test_stream_transitions_serialize_and_live_stream_is_fixed(monkeypatch):
+    diagnostic, events, barriers, stream = runtime_fixture(monkeypatch)
+    diagnostic.observe_padding(3, result(4))
+    diagnostic.observe_padding(3, result(4))
+    assert len(events) == 1 and not barriers
+    stream.cuda_stream = 456
+    diagnostic.observe_padding(3, result(4))
+    assert barriers == [456] and events[-1]["transition_barrier"]
+    diagnostic.summary["status"] = "capture-qualified"
+    stream.cuda_stream = 123
+    diagnostic.observe_padding(1, result(1))
+    assert barriers == [456, 123]
+    stream.cuda_stream = 789
+    with pytest.raises(ValueError, match="live forward stream"):
+        diagnostic.observe_padding(1, result(1))
+    monkeypatch.setattr(serving.threading, "get_ident", lambda: -1)
+    with pytest.raises(ValueError, match="concurrent worker thread"):
+        diagnostic.observe_padding(1, result(1))
+
+
+def test_no_transition_barrier_can_be_inserted_inside_capture(monkeypatch):
+    diagnostic, _, barriers, stream = runtime_fixture(monkeypatch)
+    diagnostic.observe_padding(1, result(1))
+    stream.cuda_stream = 456
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+    with pytest.raises(ValueError, match="transition inside capture"):
+        diagnostic.observe_padding(1, result(1))
+    assert not barriers
+
+
+class SimulatedCudaTensor(torch.Tensor):
+    """CPU storage reporting the rank device only for plumbing tests."""
+
+    @property
+    def device(self):
+        return torch.device("cuda:0")
+
+
+def native_fixture(tmp_path, monkeypatch, mode):
+    fixture = correction_fixture(tmp_path, monkeypatch, mode)
+
+    def adapter(controller, launcher, pair):
+        storage = torch.full((8194, 128), 171, dtype=torch.uint8).as_subclass(
+            SimulatedCudaTensor
+        )
+        instance = BoundIndexerCorrection(launcher, pair[1], storage, 8192)
+        return instance, instance.run
+
+    monkeypatch.setattr(IndexerCorrectionIntervention, "make_adapter", adapter)
+    return fixture
+
+
+@pytest.mark.parametrize("mode", ["control", "correction"])
+def test_real_torch_aot_capture_and_independent_worker_audit(
+    tmp_path, monkeypatch, mode
+):
+    runtime_fixture(monkeypatch)
+    diagnostic, store, _ = serving_fixture(
+        tmp_path,
+        monkeypatch,
+        mode,
+        kernel_fixture=native_fixture,
+        serving_type=serving.ServingIndexerCorrection,
+        serving_policy=policy,
+        separate_owners=True,
+    )
+    runner = runner_fixture()
+    runner._determine_batch_execution_and_padding = lambda num_tokens: result(
+        num_tokens
+    )
+
+    def capture():
+        assert diagnostic.loader.controller.sealed
+        runner._determine_batch_execution_and_padding(num_tokens=64)
+        return 42
+
+    runner.capture_model = capture
+    diagnostic.install(runner)
+    try:
+        store.load_all()
+        runner._determine_batch_execution_and_padding(8192)
+        assert runner.capture_model() == 42
+        runner._determine_batch_execution_and_padding(1)
+    finally:
+        diagnostic.close()
+    assert all(s.closed for s in diagnostic.streams.values())
+    assert runner.capture_model is capture
+    assert all(
+        r["event"].startswith("binary_")
+        for r in json_lines(diagnostic.folder / "binary-loads.jsonl")
+    )
+    assert all(
+        r["event"].startswith("indexer_correction_")
+        for r in json_lines(diagnostic.folder / "loader-events.jsonl")
+    )
+    report = audit_worker(diagnostic.path, diagnostic.manifest, 0)
+    assert report["status"] == "complete", report
+    assert report["runtime_envelope"]["max_padded"] == 8192
+    assert report["runtime_envelope"]["arena_bindings"] == (
+        2 if mode == "correction" else 0
+    )
+    assert report["phases"]["capture-after"]["appended_launchers"] == (
+        2 if mode == "correction" else 0
+    )
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [None, "barrier", "padding", "thread", "stream", "arena", "coverage", "phase"],
+)
+def test_runtime_audit_rejects_mutated_receipts(monkeypatch, mutation):
+    diagnostic, events, _, stream = runtime_fixture(monkeypatch)
+    diagnostic.observe_padding(8192, result(8192))
+    stream.cuda_stream = 456
+    diagnostic.summary["status"] = "capture-qualified"
+    diagnostic.observe_padding(1, result(1))
+    diagnostic.observe_padding(3, result(4))
+    summary = dict(
+        diagnostic.summary,
+        arena_snapshots={
+            p: [
+                dict(address=1234, bytes=8194 * 128),
+                dict(address=5678, bytes=8194 * 128),
+            ]
+            for p in ("before-forward", "capture-before", "capture-after")
+        },
+    )
+    if mutation == "barrier":
+        events[1]["transition_barrier"] = False
+    elif mutation == "padding":
+        events[0]["padded"] = 8193
+    elif mutation == "thread":
+        events[-1]["thread"] = -1
+    elif mutation == "stream":
+        events[-1]["stream"] = 789
+    elif mutation == "arena":
+        summary["arena_snapshots"]["capture-after"][0]["address"] += 1
+    elif mutation == "coverage":
+        events[:] = events[:1]
+    elif mutation == "phase":
+        events[-1]["phase"] = "startup"
+    if mutation is None:
+        assert serving.check_runtime_records(
+            dict(mode="correction", selection_capacity=8192), summary, events
+        )["single_live_stream"]
+    else:
+        with pytest.raises(ValueError):
+            serving.check_runtime_records(
+                dict(mode="correction", selection_capacity=8192), summary, events
+            )
+
+
+def test_disabled_policy_is_inert(monkeypatch):
+    monkeypatch.delenv(policy.FLAG, raising=False)
+    policy.install(object())
+    policy.validate_plan(object())
+
+
+@pytest.mark.parametrize(
+    "conflict",
+    [
+        "SLIMSERVE_GLM53_KV_DIAGNOSTIC",
+        "SLIMSERVE_GLM53_RMSNORM_GEOMETRY",
+        "SLIMSERVE_GLM53_RMSNORM_DIAGNOSTIC",
+        "TORCHINDUCTOR_DETERMINISTIC",
+    ],
+)
+def test_conflicting_diagnostics_rejected(monkeypatch, conflict):
+    monkeypatch.setenv(policy.FLAG, "correction")
+    monkeypatch.setenv(glm53_ordering.FLAG, "1")
+    monkeypatch.setenv("VLLM_FORCE_AOT_LOAD", "1")
+    monkeypatch.setenv(conflict, "1")
+    with pytest.raises(ValueError):
+        policy.validate_environment()
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        None,
+        "gpu",
+        "dtype",
+        "kv",
+        "model",
+        "tp",
+        "pp",
+        "ep",
+        "speculation",
+        "compiler",
+        "rows",
+    ],
+)
+def test_worker_admission_and_single_install(monkeypatch, tmp_path, change):
+    monkeypatch.setenv(policy.FLAG, "correction")
+    monkeypatch.setenv(glm53_ordering.FLAG, "1")
+    monkeypatch.setenv("VLLM_FORCE_AOT_LOAD", "1")
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_capability",
+        lambda: (8, 0) if change == "gpu" else (12, 0),
+    )
+    monkeypatch.setattr(
+        policy,
+        "read_manifest",
+        lambda: ({"selection_capacity": 8192}, tmp_path / "manifest.json"),
+    )
+    installed = []
+    monkeypatch.setattr(
+        serving,
+        "ServingIndexerCorrection",
+        lambda *a: NS(install=lambda runner: installed.append(runner)),
+    )
+    runner = runner_fixture()
+    if change == "dtype":
+        runner.dtype = torch.float16
+    elif change == "kv":
+        runner.kv_cache_dtype = torch.float16
+    elif change == "model":
+        runner.model_config.hf_text_config.hidden_size = 2048
+    elif change == "tp":
+        runner.parallel_config.tensor_parallel_size = 2
+    elif change == "pp":
+        runner.parallel_config.pipeline_parallel_size = 2
+    elif change == "ep":
+        runner.parallel_config.enable_expert_parallel = True
+    elif change == "speculation":
+        runner.speculative_config = object()
+    elif change == "compiler":
+        runner.compilation_config.inductor_compile_config["combo_kernels"] = False
+    elif change == "rows":
+        runner.max_num_tokens = 16384
+    if change:
+        with pytest.raises(ValueError):
+            policy.install(runner)
+        assert not installed
+    else:
+        policy.install(runner)
+        assert installed == [runner]
+        with pytest.raises(ValueError, match="once"):
+            policy.install(runner)
+
+
+@pytest.mark.parametrize("change", [None, "dtype", "kv", "combo", "deterministic"])
+def test_plan_preserves_recipe_and_compiler(monkeypatch, change):
+    monkeypatch.setenv(policy.FLAG, "correction")
+    monkeypatch.setenv(glm53_ordering.FLAG, "1")
+    monkeypatch.setenv("VLLM_FORCE_AOT_LOAD", "1")
+    plan = copy.deepcopy(resolve("glm53-nvfp4-4", "rtx6000", 4, None))
+    seen = []
+    monkeypatch.setattr(policy, "read_manifest", lambda: seen.append(True))
+    if change == "dtype":
+        plan.engine["dtype"] = "float16"
+    elif change == "kv":
+        plan.engine["kv_cache_dtype"] = "fp8"
+    elif change in ("combo", "deterministic"):
+        plan.engine["compilation_config"]["inductor_compile_config"] = (
+            {"combo_kernels": False} if change == "combo" else {"deterministic": True}
+        )
+    if change:
+        with pytest.raises(ValueError):
+            policy.validate_plan(plan)
+        assert not seen
+    else:
+        policy.validate_plan(plan)
+        assert seen == [True]
+
+
+def test_completed_evidence_joins_every_bound_leaf_without_expired_reader():
+    if not preparation.PAIR.exists():
+        pytest.skip("campaign receipts unavailable")
+    base, graphs, reference, receipts = preparation.completed_evidence(preparation.PAIR)
+    assert base["selection_capacity"] == 8192
+    assert len(base["qualified_leaf_cases"]) == 120
+    assert set(graphs) == {"control", "correction"}
+    assert all(len(ranks) == 4 for ranks in graphs.values())
+    assert reference["path"] in receipts
+    assert not torch.cuda.is_initialized()
+
+
+@pytest.mark.parametrize("mode", ["control", "correction"])
+def test_schema_and_case_dispatch(mode):
+    manifest = dict(serving_schema=policy.SERVING_SCHEMA, mode=mode)
+    assert serving_policy(manifest) is policy
+    assert cases(manifest) == policy.CASES

--- a/tests/slimserve/test_indexer_order_fusion.py
+++ b/tests/slimserve/test_indexer_order_fusion.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+import xml.etree.ElementTree as ET
+from itertools import islice
+
+import pytest
+import torch
+
+from benchmarks.kernels.benchmark_glm53_indexer_order_fusion import (
+    make_call,
+    timing_cases,
+    verify_assertion_only_changes,
+    verify_generic_decode_qualification,
+)
+from benchmarks.kernels.replay_glm53_indexer import sha
+
+
+@pytest.mark.parametrize("label", ["post-sort", "fused"])
+def test_timing_callback_only_sorts_control(label):
+    values = [torch.zeros(3, 600), torch.zeros(3), torch.zeros(3)]
+    output = torch.empty(3, 512, dtype=torch.int32)
+    calls = []
+
+    def operation(*args):
+        assert all(a is b for a, b in zip(args[:3], values))
+        assert args[3] is output and args[4:] == (3, 600, 1, 512)
+        output.fill_(42)
+        calls.append("native")
+
+    def order(value):
+        assert value is output and (output == 42).all()
+        calls.append("order")
+
+    callback = make_call(operation, label, *values, output, order)
+    callback()
+    assert calls == (["native", "order"] if label == "post-sort" else ["native"])
+
+
+def test_prefill_cases_copy_actual_rows_without_changing_ranges():
+    captured = dict(
+        logits=torch.arange(7616 * 2).reshape(7616, 2).float(),
+        starts=torch.zeros(7616, dtype=torch.int32),
+        ends=torch.arange(7616, dtype=torch.int32),
+    )
+    cases = list(islice(timing_cases(captured), 2))
+    assert [name for name, _ in cases] == ["actual-prefill-7616", "actual-prefill-583"]
+    for (_, values), begin in zip(cases, (0, 7033)):
+        for key in captured:
+            assert torch.equal(values[key], captured[key][begin:])
+            assert values[key].is_contiguous()
+            assert values[key].data_ptr() != captured[key][begin:].data_ptr()
+
+
+def test_synthetic_decode_uses_registered_physical_width_and_exact_visible_range():
+    captured = dict(
+        logits=torch.zeros(7616, 1), starts=torch.zeros(7616), ends=torch.zeros(7616)
+    )
+    first = list(islice(timing_cases(captured), 2, 6))
+    second = list(islice(timing_cases(captured), 2, 6))
+    for (name, values), (repeat_name, repeat_values), visible in zip(
+        first, second, (250, 8192, 32768, 262144)
+    ):
+        assert name == repeat_name == f"synthetic-decode-1-visible-{visible}"
+        assert values["logits"].shape == (1, 262144)
+        assert values["starts"].dtype == values["ends"].dtype == torch.int32
+        assert (values["starts"] == 0).all() and (values["ends"] == visible).all()
+        assert (values["logits"][:, visible:] == 0).all()
+        assert torch.isfinite(values["logits"]).all()
+        assert all(torch.equal(values[k], repeat_values[k]) for k in values)
+
+
+@pytest.mark.parametrize("extra_change", [None, "math", "schedule", "branch"])
+def test_binary_exception_rejects_any_selection_or_control_change(extra_change):
+    before = {
+        0xE0: "@!P0 BRA P1, 0x200\ncontrol",
+        0xF0: "metadata f0\ncontrol",
+        0x100: "metadata100\ncontrol",
+        0x110: "metadata110\ncontrol",
+        0x130: "metadata130\ncontrol",
+        0x1E0: "CALL.ABS.NOINC R2\ncontrol",
+        0x200: "real selection instruction\ncontrol",
+    }
+    after = dict(before)
+    for pc in (0xF0, 0x100, 0x110, 0x130):
+        after[pc] = "relocated " + after[pc]
+    if extra_change == "math":
+        after[0x200] = "changed math\ncontrol"
+    elif extra_change == "schedule":
+        after[0x100] += "changed control"
+    elif extra_change == "branch":
+        after[0xE0] = "changed branch\ncontrol"
+    if extra_change is None:
+        assert len(verify_assertion_only_changes(before, after)) == 4
+    else:
+        with pytest.raises(AssertionError):
+            verify_assertion_only_changes(before, after)
+
+
+@pytest.mark.parametrize(
+    "damage", [None, "native", "source", "failure", "missing", "names"]
+)
+def test_generic_decode_receipts_are_bound_to_binary_source_and_cases(tmp_path, damage):
+    source = tmp_path / "test_source.py"
+    source.write_text("fixture")
+    paths = [tmp_path / "control.xml", tmp_path / "candidate.xml"]
+    proof = {arm + "_binary": {"sha256": arm} for arm in ("before", "candidate")}
+    for path, arm in zip(paths, ("before", "candidate")):
+        suite = ET.Element("testsuite", failures="0", errors="0", skipped="0")
+        for index in range(32):
+            test = ET.SubElement(
+                suite,
+                "testcase",
+                classname="fixture",
+                name=f"test_single_block_decode_changed_inputs[{index}]",
+            )
+            props = ET.SubElement(test, "properties")
+            ET.SubElement(props, "property", name="native_sha256", value=arm)
+            ET.SubElement(
+                props, "property", name="test_source_sha256", value=sha(source)
+            )
+        if arm == "candidate":
+            if damage == "native":
+                props[0].set("value", "wrong native")
+            elif damage == "source":
+                props[1].set("value", "wrong source")
+            elif damage == "failure":
+                ET.SubElement(test, "failure")
+            elif damage == "missing":
+                suite.remove(test)
+            elif damage == "names":
+                test.set("name", "test_single_block_decode_changed_inputs[different]")
+        ET.ElementTree(suite).write(path)
+    if damage is None:
+        assert (
+            verify_generic_decode_qualification(*paths, proof, source)[
+                "tests_per_binary"
+            ]
+            == 32
+        )
+    else:
+        with pytest.raises(AssertionError):
+            verify_generic_decode_qualification(*paths, proof, source)

--- a/tests/slimserve/test_indexer_order_probe.py
+++ b/tests/slimserve/test_indexer_order_probe.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+import torch
+
+from benchmarks.kernels.check_glm53_indexer_order import selection_validity
+
+
+def test_membership_checker_accepts_order_and_ties_but_not_bad_selection():
+    scores = torch.tensor([[1.0, 3.0, 3.0, 0.0]])
+    assert selection_validity(scores, torch.tensor([[2, 1]]), 2)
+    assert selection_validity(scores, torch.tensor([[1]]), 1)
+    assert selection_validity(scores, torch.tensor([[2]]), 1)
+    for ids in ([[1, 1]], [[0, 1]], [[1, -1]], [[1, 4]]):
+        assert not selection_validity(scores, torch.tensor(ids), 2)
+
+
+def test_membership_checker_checks_short_row_padding():
+    scores = torch.tensor([[1.0, 3.0]])
+    assert selection_validity(scores, torch.tensor([[1, 0, -1, -1]]), 4)
+    assert not selection_validity(scores, torch.tensor([[1, 0, -1, 99]]), 4)

--- a/tests/slimserve/test_indexer_precision_analysis.py
+++ b/tests/slimserve/test_indexer_precision_analysis.py
@@ -1,0 +1,275 @@
+# SPDX-License-Identifier: Apache-2.0
+import copy
+from itertools import product
+
+import pytest
+import torch
+
+from benchmarks import analyze_glm53_indexer_precision as probe
+
+
+def closed_evidence():
+    checks = []
+    for rank, rows, seed, magnitude in product(
+        range(4), probe.ROWS, probe.SEEDS, probe.MAGNITUDES
+    ):
+        failed = rows == 7616 and (seed, magnitude) != (530901, 8.0)
+        checks.append(
+            dict(
+                rank=rank,
+                rows=rows,
+                seed=seed,
+                magnitude=magnitude,
+                passed=not failed,
+                repeat_graph_guards_mutation_pass=True,
+                oracle={
+                    arm: [[{"max_bf16_ulp": 2 if failed else 0}]]
+                    for arm in ("combo", "split")
+                },
+                inputs=["first", "second"],
+            )
+        )
+    summary = dict(
+        status="failed",
+        manifest_sha256=probe.PINS["manifest"][1],
+        weights={},
+        checks=checks,
+    )
+    manifest = dict(
+        rows=list(probe.ROWS),
+        seeds=list(probe.SEEDS),
+        magnitudes=list(probe.MAGNITUDES),
+        expected_pairs=120,
+        weight_sha256={},
+    )
+    audit = dict(
+        status="complete",
+        numerical_pass=False,
+        manifest_sha256=probe.PINS["manifest"][1],
+        summary_sha256=probe.PINS["summary"][1],
+        pairs=120,
+        failed_cases=[
+            {k: r[k] for k in ("rank", "rows", "seed", "magnitude")}
+            for r in checks
+            if not r["passed"]
+        ],
+    )
+    supplement = dict(
+        status="complete",
+        manifest_sha256=probe.PINS["manifest"][1],
+        summary_sha256=probe.PINS["summary"][1],
+        audit_sha256=probe.PINS["audit"][1],
+        failed_pairs=20,
+        all_four_rank_records_exact=True,
+    )
+    return dict(summary=summary, audit=audit, manifest=manifest, supplement=supplement)
+
+
+def test_closed_evidence_deduplicates_only_identical_ranks():
+    documents = closed_evidence()
+    cases = probe.joined_cases(**documents)
+    assert len(cases) == 30
+    assert sum(not r["passed"] for r in cases) == 5
+    assert all(r["rank"] == 0 for r in cases)
+    documents["summary"]["checks"][30]["inputs"][0] = "changed"
+    with pytest.raises(ValueError, match="rank numerical drift"):
+        probe.joined_cases(**documents)
+
+
+@pytest.mark.parametrize(
+    "document,field,value",
+    [
+        ("summary", "status", "complete"),
+        ("audit", "status", "running"),
+        ("audit", "numerical_pass", True),
+        ("audit", "manifest_sha256", "changed"),
+        ("supplement", "summary_sha256", "changed"),
+        ("supplement", "audit_sha256", "changed"),
+        ("supplement", "failed_pairs", 19),
+        ("supplement", "all_four_rank_records_exact", False),
+        ("manifest", "expected_pairs", 119),
+        ("manifest", "weight_sha256", {"new": "weight"}),
+        ("manifest", "rows", [1]),
+    ],
+)
+def test_changed_joins_and_failed_gate_rejected(document, field, value):
+    documents = closed_evidence()
+    documents[document][field] = value
+    with pytest.raises(ValueError):
+        probe.joined_cases(**documents)
+
+
+@pytest.mark.parametrize("change", ["missing", "reorder", "pass_flag", "guards"])
+def test_incomplete_matrix_or_bad_flags_rejected(change):
+    documents = closed_evidence()
+    checks = documents["summary"]["checks"]
+    if change == "missing":
+        checks.pop()
+    elif change == "reorder":
+        checks[0], checks[1] = checks[1], checks[0]
+    elif change == "pass_flag":
+        checks[0]["passed"] = False
+    else:
+        checks[0]["repeat_graph_guards_mutation_pass"] = False
+    with pytest.raises(ValueError):
+        probe.joined_cases(**documents)
+
+
+def test_pinned_file_digest_checked_before_parsing(tmp_path):
+    path = tmp_path / "receipt.json"
+    path.write_text('{"status": "complete"}')
+    digest = probe.sha(path)
+    assert probe.load_checked(path, digest)["status"] == "complete"
+    path.write_text("broken JSON")
+    with pytest.raises(ValueError, match="receipt changed"):
+        probe.load_checked(path, digest)
+
+
+def test_arithmetic_boundaries_and_chunked_control_preserve_inputs():
+    packed = probe.packed_inputs(129, 530901, 0.125)
+    x = packed[:, 2048:2176]
+    weight = torch.linspace(0.25, 1.75, 128).bfloat16()
+    bias = torch.linspace(-1, 1, 128).bfloat16()
+    originals = [t.clone() for t in (packed, weight, bias)]
+    values = probe.arithmetic_models(x, weight, bias)
+    assert set(values) == set(probe.MODELS)
+    assert values["fp32_separate"].dtype == torch.float32
+    assert values["fp32_fused_affine"].dtype == torch.float32
+    assert values["fp64_control"].dtype == torch.float64
+    assert torch.equal(
+        values["fp32_fused_affine"], values["fp32_norm_fp64_affine"].float()
+    )
+    d = x.double()
+    centered = d - d.mean(-1, keepdim=True)
+    norm = centered / (centered.square().mean(-1, keepdim=True) + 1e-6).sqrt()
+    torch.testing.assert_close(
+        values["fp64_control"],
+        norm * weight.double() + bias.double(),
+        rtol=1e-14,
+        atol=1e-14,
+    )
+    outputs = probe.modeled_outputs(x, weight, bias)
+    assert torch.equal(outputs["fp64_control"], probe.layernorm_oracle(x, weight, bias))
+    for name in values:
+        assert torch.equal(outputs[name], values[name].bfloat16())
+    assert all(torch.equal(a, b) for a, b in zip((packed, weight, bias), originals))
+
+
+def test_constant_rows_return_bias_without_nonfinite_values():
+    x = torch.full((3, 128), 2, dtype=torch.bfloat16)
+    weight = torch.ones(128, dtype=torch.bfloat16)
+    bias = torch.linspace(-1, 1, 128).bfloat16()
+    for value in probe.modeled_outputs(x, weight, bias).values():
+        assert torch.equal(value, bias.expand_as(x))
+
+
+@pytest.mark.parametrize("bad", ["dtype", "width", "weight", "nan"])
+def test_invalid_arithmetic_inputs_rejected(bad):
+    x = torch.ones(2, 128, dtype=torch.bfloat16)
+    weight = bias = torch.ones(128, dtype=torch.bfloat16)
+    if bad == "dtype":
+        x = x.float()
+    elif bad == "width":
+        x = x[:, :127]
+    elif bad == "weight":
+        weight = weight[:127]
+    else:
+        x[0, 0] = float("nan")
+    with pytest.raises(ValueError):
+        probe.arithmetic_models(x, weight, bias)
+
+
+def test_historical_scalar_is_checked_and_both_arms_retained():
+    x = torch.ones(3, 128, dtype=torch.bfloat16)
+    weight = bias = torch.ones(128, dtype=torch.bfloat16)
+    reference = probe.layernorm_oracle(x, weight, bias)
+    example = dict(row=1, column=2, actual=1.015625, reference=1.0, bf16_ulp=2)
+    failures = dict(count=1, worst=[example])
+    case = {
+        "mismatch_examples": {
+            arm: [[None, None, copy.deepcopy(failures)]] for arm in ("combo", "split")
+        }
+    }
+    result = probe.retained_examples(case, 0, x, weight, bias, reference)
+    assert len(result) == 2 and result[0]["fp64_result"] == 1.0
+    case["mismatch_examples"]["split"][0][2]["worst"][0]["reference"] = 2.0
+    with pytest.raises(ValueError, match="oracle scalar drift"):
+        probe.retained_examples(case, 0, x, weight, bias, reference)
+    case["mismatch_examples"]["combo"][0][2]["count"] = 17
+    with pytest.raises(ValueError, match="truncated historical failures"):
+        probe.retained_examples(case, 0, x, weight, bias, reference)
+
+
+def test_cpu_analysis_requires_hidden_gpu(monkeypatch):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    with pytest.raises(ValueError, match="hide GPUs"):
+        probe.analyze()
+
+
+def test_failed_attempt_preserved_and_output_never_overwritten(tmp_path, monkeypatch):
+    output = tmp_path / "analysis.json"
+    monkeypatch.setattr("sys.argv", ["analysis", "--output", str(output)])
+
+    def fail(**kwargs):
+        raise ValueError("fixture failure")
+
+    monkeypatch.setattr(probe, "analyze", fail)
+    with pytest.raises(ValueError, match="fixture failure"):
+        probe.main()
+    original = output.read_bytes()
+    assert b'"status": "failed"' in original
+    with pytest.raises(FileExistsError):
+        probe.main()
+    assert output.read_bytes() == original
+
+
+def test_detector_uses_only_output_and_bias_and_handles_zero():
+    output = torch.tensor([[0, 0, 1e-6, 1e-2, 1]], dtype=torch.bfloat16)
+    bias = torch.tensor([0, -1, -1, -1, 0], dtype=torch.bfloat16)
+    saved = output.clone(), bias.clone()
+    masks = [
+        probe.cancellation_mask(output, bias, e) for e in probe.CANCELLATION_EXPONENTS
+    ]
+    assert masks[0].tolist() == [[False, True, True, False, False]]
+    assert all(torch.all(a <= b) for a, b in zip(masks, masks[1:]))
+    assert torch.equal(output, saved[0]) and torch.equal(bias, saved[1])
+    with pytest.raises(ValueError, match="prescribed"):
+        probe.cancellation_mask(output, bias, -20)
+
+
+def test_detector_coverage_counts_misses_not_just_selected_elements():
+    reference = torch.tensor([[0, 1, -1, 0]], dtype=torch.bfloat16)
+    output = torch.tensor([[1e-7, 1.015625, -1.015625, 0]], dtype=torch.bfloat16)
+    bias = torch.tensor([-1, 0, 0, 0], dtype=torch.bfloat16)
+    historical = [
+        dict(arm=arm, row=0, column=col, actual=float(output[0, col]), bf16_ulp=2)
+        for arm in ("combo", "split")
+        for col in (0, 1)
+    ]
+    outputs = {name: output for name in probe.SCREEN_MODELS}
+    screen = probe.screen_cancellation(outputs, reference, bias, historical)
+    for entry in screen.values():
+        for value in entry["cpu_models"].values():
+            assert value["selected_elements"] == value["selected_rows"] == 1
+            assert value["failures"] == 3
+            assert value["detected_failures"] == 1
+            assert value["missed_failures"] == 2
+        for value in entry["historical_gpu_failures"].values():
+            assert value["examples"] == 2 and value["detected"] == 1
+            assert len(value["missed"]) == 1 and value["missed"][0]["column"] == 1
+    totals = probe.aggregate_screen([{"cancellation_screen": screen}] * 2)
+    for entry in totals.values():
+        assert entry["cpu_models"]["fp32_separate"]["elements"] == 8
+        assert entry["cpu_models"]["fp32_separate"]["selected_element_fraction"] == 0.25
+        assert entry["cpu_models"]["fp32_separate"]["selected_row_fraction"] == 1
+        assert entry["historical_gpu_failures"]["combo"]["missed"] == 2
+
+
+def test_one_ulp_mask_preserves_existing_signed_zero_and_distance_convention():
+    actual = torch.tensor(
+        [[0, -0.0, 1.0078125, 1.015625, -1.015625]], dtype=torch.bfloat16
+    )
+    reference = torch.tensor([[-0.0, 0, 1, 1, -1]], dtype=torch.bfloat16)
+    assert probe.above_one_ulp(actual, reference).tolist() == [
+        [False, False, False, True, True]
+    ]

--- a/tests/slimserve/test_indexer_replay.py
+++ b/tests/slimserve/test_indexer_replay.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+
+from benchmarks.kernels.replay_glm53_indexer import verified_selection
+
+
+def fixture():
+    logits = torch.tensor([[0.0, 0.0, 0.0], [1.0, 3.0, 2.0], [2.0, 0.0, 0.0]])
+    starts = torch.zeros(3, dtype=torch.int32)
+    ends = torch.tensor([0, 3, 1], dtype=torch.int32)
+    indices = torch.tensor([[-1, -1], [2, 1], [0, -1]], dtype=torch.int32)
+    return logits, starts, ends, indices
+
+
+def test_ragged_selection_oracle_and_ties():
+    data = fixture()
+    ordered, ties = verified_selection(*data, k=2)
+    assert ties == 0 and torch.equal(ordered, data[-1].sort(dim=1).values)
+    data[0][1] = 0
+    _, ties = verified_selection(*data, k=2)
+    assert ties == 1
+
+
+@pytest.mark.parametrize(
+    "bad", ["range", "duplicate", "score", "tail", "nan", "padding"]
+)
+def test_bad_capture_rejected(bad):
+    logits, starts, ends, indices = fixture()
+    if bad == "range":
+        indices[1, 0] = 3
+    elif bad == "duplicate":
+        indices[1, 0] = 1
+    elif bad == "score":
+        indices[1, 0] = 0
+    elif bad == "tail":
+        logits[0, 0] = 1
+    elif bad == "nan":
+        logits[1, 0] = float("nan")
+    elif bad == "padding":
+        indices[0, 0] = 0
+    with pytest.raises(AssertionError):
+        verified_selection(logits, starts, ends, indices, k=2)

--- a/tests/slimserve/test_indexer_replay.py
+++ b/tests/slimserve/test_indexer_replay.py
@@ -1,8 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
+import hashlib
+
 import pytest
 import torch
 
-from benchmarks.kernels.replay_glm53_indexer import verified_selection
+from benchmarks.kernels.replay_glm53_indexer import sha, verified_selection
+
+
+def test_shared_sha_does_not_require_python311_file_digest(tmp_path, monkeypatch):
+    from benchmarks.kernels.check_glm53_indexer_order import sha as order_sha
+
+    monkeypatch.delattr(hashlib, "file_digest", raising=False)
+    path = tmp_path / "archive"
+    data = b"indexer capture\0" * 100000
+    path.write_bytes(data)
+    assert order_sha is sha
+    assert sha(path) == hashlib.sha256(data).hexdigest()
 
 
 def fixture():

--- a/tests/slimserve/test_indexer_serving_preparation.py
+++ b/tests/slimserve/test_indexer_serving_preparation.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+import copy
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from benchmarks.kernels import glm53_geometry_workload as workload
+from benchmarks.kernels import prepare_glm53_indexer_correction_serving as preparation
+from benchmarks.kernels import run_glm53_geometry_serving as runner
+from slimserve import glm53_ordering
+from slimserve import indexer_correction_diagnostic as policy
+from slimserve.rmsnorm_diagnostic import sha
+from tests.slimserve.test_geometry_serving_runner import fixture as runner_fixture
+from tests.slimserve.test_kv_loader_audit import prepared_fixture
+
+
+def completed_fixture(tmp_path, monkeypatch):
+    base = prepared_fixture(tmp_path, monkeypatch)
+    base.update(
+        schema=policy.SCHEMA,
+        selection_capacity=8192,
+        weight_sha256={},
+        qualified_leaf_cases=[],
+        expected_gpu_config="hardware",
+    )
+    # All four ranks share one qualified JIT file; copy exactly once per cache.
+    correction = base["targets"]["0"][0]["kv"]
+    for targets in base["targets"].values():
+        for target in targets:
+            target.pop("kv")
+            target["correction"] = copy.deepcopy(correction)
+    base["private_sources"] = {correction["relative"]: correction["source_sha256"]}
+    path = tmp_path / "qualified.json"
+    path.write_text(json.dumps(base))
+    reference = dict(path=str(path), sha256=sha(path))
+    graphs = {
+        m: {str(r): reference for r in range(4)} for m in ("control", "correction")
+    }
+    monkeypatch.setattr(
+        preparation,
+        "completed_evidence",
+        lambda *_: (base, graphs, reference, {str(path): sha(path)}),
+    )
+    monkeypatch.setattr(workload, "reference_evidence", lambda: ({}, {}, {}, {}))
+    original_check = subprocess.check_output
+    monkeypatch.setattr(
+        subprocess,
+        "check_output",
+        lambda cmd, **kw: (
+            "" if cmd == ["git", "status", "--short"] else original_check(cmd, **kw)
+        ),
+    )
+    return base
+
+
+def test_private_shared_source_copies_and_manifest_roundtrip(tmp_path, monkeypatch):
+    base = completed_fixture(tmp_path, monkeypatch)
+    output = tmp_path / "serving"
+    preparation.prepare(tmp_path / "pair.json", output)
+    prepared = json.loads((output / "preparation.json").read_text())
+    assert [(r["label"], r["mode"]) for r in prepared["runs"]] == list(policy.CASES)
+    monkeypatch.setenv(glm53_ordering.FLAG, "1")
+    monkeypatch.setenv("VLLM_FORCE_AOT_LOAD", "1")
+    private_sources = []
+    relative = next(iter(base["private_sources"]))
+    for label, mode in policy.CASES:
+        path = output / label / "manifest.json"
+        manifest = json.loads(path.read_text())
+        private = Path(manifest["private_namespace"])
+        monkeypatch.setenv(policy.FLAG, mode)
+        monkeypatch.setenv(policy.MANIFEST, str(path))
+        monkeypatch.setenv("VLLM_CACHE_ROOT", manifest["cache_root"])
+        monkeypatch.setenv("TORCHINDUCTOR_CACHE_DIR", str(private / "inductor_cache"))
+        assert policy.read_manifest() == (manifest, path)
+        assert runner.inventory(private) == {
+            **base["original_files"],
+            **base["private_sources"],
+        }
+        private_sources.append(private / relative)
+    assert len({p.stat().st_ino for p in private_sources}) == 3
+    private_sources[1].write_text("mutated candidate copy")
+    assert (
+        sha(private_sources[0])
+        == sha(private_sources[2])
+        == base["private_sources"][relative]
+    )
+    with pytest.raises(ValueError, match="preserve previous"):
+        preparation.prepare(tmp_path / "pair.json", output)
+    manifest["selection_capacity"] = 16384
+    path.write_text(json.dumps(manifest))
+    with pytest.raises(ValueError, match="manifest changed"):
+        policy.read_manifest()
+
+
+def test_qualified_kernel_and_loader_never_released(tmp_path):
+    path = tmp_path / "qualified.py"
+    path.write_text("original")
+    digest = sha(path)
+    path.write_text("changed")
+    with pytest.raises(ValueError, match="non-integration source changed"):
+        preparation.serving_sources({str(path): digest})
+
+
+@pytest.mark.parametrize("kind,memory", [("serve", 150), ("audit", 8)])
+def test_correction_runner_separate_flag_resources(tmp_path, monkeypatch, kind, memory):
+    path, manifest = runner_fixture(tmp_path, "correction")
+    manifest.update(serving_schema=policy.SERVING_SCHEMA, mode="correction")
+    env = runner.environment(path, manifest)
+    assert env[policy.FLAG] == "correction"
+    assert env[policy.MANIFEST] == str(path)
+    assert "SLIMSERVE_GLM53_KV_DIAGNOSTIC" not in env
+
+    def execute(argv, **kwargs):
+        assert f"MemoryMax={memory}G" in argv and "MemorySwapMax=0" in argv
+        assert argv[3].startswith("--unit=glm53-correction-")
+        assert kwargs["env"][policy.FLAG] == "correction"
+        kwargs["stdout"].write("prescribed attempt\n")
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(runner.subprocess, "run", execute)
+    record = {}
+    assert runner.execute(kind, path, manifest, record) == 0
+
+
+def test_return_checks_control_and_correction_predecessors(tmp_path, monkeypatch):
+    path, manifest = runner_fixture(tmp_path, "return-control")
+    manifest["serving_schema"] = policy.SERVING_SCHEMA
+    seen = []
+    monkeypatch.setattr(runner, "check_completed", lambda p: seen.append(p.parent.name))
+    monkeypatch.setattr(runner, "inventory", lambda _: {"wrong": "cache"})
+    with pytest.raises(ValueError, match="fresh private cache"):
+        runner.preflight(path, manifest)
+    assert seen == ["control", "correction"]
+
+
+@pytest.mark.parametrize("change", [None, "count", "phases", "capacity", "leaves"])
+def test_bound_leaf_qualification_is_required(change):
+    report, row = dict(leaf_cases=60, leaf_phase_observations=300), dict(leaf_cases=60)
+    manifest = dict(selection_capacity=8192, qualified_leaf_cases=[None] * 120)
+    if change == "count":
+        report["leaf_cases"] = 59
+    elif change == "phases":
+        report["leaf_phase_observations"] = 299
+    elif change == "capacity":
+        manifest["selection_capacity"] = 16384
+    elif change == "leaves":
+        manifest["qualified_leaf_cases"].pop()
+    if change:
+        with pytest.raises(ValueError, match="bound-leaf"):
+            preparation.check_completed_report(report, row, manifest)
+    else:
+        preparation.check_completed_report(report, row, manifest)

--- a/tests/slimserve/test_indexer_shard_probe.py
+++ b/tests/slimserve/test_indexer_shard_probe.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from benchmarks.kernels import benchmark_glm53_indexer_shard as probe
+
+
+@pytest.mark.parametrize("change", ["order", "region-swap", "tail-order"])
+def test_comparison_keeps_pool_sets_separate_from_exact_tail(monkeypatch, change):
+    group = SimpleNamespace(world_size=1, cpu_group=object())
+
+    def gather(output, local, *, group):
+        output[:] = [local]
+
+    monkeypatch.setattr(probe.dist, "all_gather_object", gather)
+    a = torch.arange(2051, dtype=torch.int32)[None, :]
+    b = a.clone()
+    left, right = {
+        "order": (0, 1),
+        "region-swap": (0, 2048),
+        "tail-order": (2048, 2049),
+    }[change]
+    b[:, [left, right]] = b[:, [right, left]]
+    assert torch.equal(a.sort(1).values, b.sort(1).values)
+    result = probe.compare_outputs(a, b, group)
+    assert result["sets_and_tail_exact_all_ranks"] is (change == "order")
+    assert not result["rank0_order_equal"]
+    assert result["per_rank"][0]["tail_equal"] is (change == "order")
+
+
+def test_comparison_records_other_rank_failure_and_rank0_order(monkeypatch):
+    cpu_group = object()
+    group = SimpleNamespace(world_size=2, cpu_group=cpu_group)
+    remote = dict(pool_sets_equal=True, tail_equal=False, order_equal=False)
+
+    def gather(output, local, *, group):
+        assert group is cpu_group
+        assert local == dict(pool_sets_equal=True, tail_equal=True, order_equal=True)
+        output[:] = [remote, local]
+
+    monkeypatch.setattr(probe.dist, "all_gather_object", gather)
+    a = torch.arange(2051, dtype=torch.int32)[None, :]
+    result = probe.compare_outputs(a, a.clone(), group)
+    assert not result["sets_and_tail_exact_all_ranks"]
+    assert not result["rank0_order_equal"]
+    assert result["per_rank"][0] == remote
+    assert result["per_rank"][1]["tail_equal"]

--- a/tests/slimserve/test_indexer_tie_replay.py
+++ b/tests/slimserve/test_indexer_tie_replay.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+
+from benchmarks.kernels.replay_glm53_indexer_ties import canonical_selection
+
+
+def test_score_then_pool_id_without_score_perturbation():
+    logits = torch.tensor([[0.0, -0.0, 0.0, -0.0], [-8.0, -7.0, -8.0, -9.0]])
+    before = logits.view(torch.uint8).clone()
+    result = canonical_selection(
+        logits,
+        torch.zeros(2, dtype=torch.int32),
+        torch.full((2,), 4, dtype=torch.int32),
+        k=2,
+    )
+    assert torch.equal(result, torch.tensor([[0, 1], [0, 1]], dtype=torch.int32))
+    assert torch.equal(before, logits.view(torch.uint8))
+
+
+def test_neighboring_float_scores_are_not_ties():
+    value = torch.tensor(-8.358503341674805, dtype=torch.float32)
+    larger = torch.nextafter(value, torch.tensor(torch.inf))
+    logits = torch.stack([value, larger, value])[None, :]
+    result = canonical_selection(
+        logits,
+        torch.zeros(1, dtype=torch.int32),
+        torch.tensor([3], dtype=torch.int32),
+        k=1,
+    )
+    assert result.item() == 1
+
+
+def test_empty_short_rows_and_undefined_nan_tails():
+    logits = torch.tensor([[float("nan")] * 4, [-3.0, 7.0, float("nan"), float("nan")]])
+    result = canonical_selection(
+        logits,
+        torch.zeros(2, dtype=torch.int32),
+        torch.tensor([0, 2], dtype=torch.int32),
+        k=3,
+    )
+    assert result.tolist() == [[-1, -1, -1], [0, 1, -1]]
+
+
+@pytest.mark.parametrize("bad", ["start", "end", "nan"])
+def test_invalid_oracle_input(bad):
+    logits = torch.zeros(1, 3)
+    starts, ends = (
+        torch.tensor([0], dtype=torch.int32),
+        torch.tensor([3], dtype=torch.int32),
+    )
+    if bad == "start":
+        starts[0] = 1
+    elif bad == "end":
+        ends[0] = 4
+    else:
+        logits[0, 1] = float("nan")
+    with pytest.raises(AssertionError):
+        canonical_selection(logits, starts, ends, k=2)

--- a/tests/slimserve/test_indexer_tile_probe.py
+++ b/tests/slimserve/test_indexer_tile_probe.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+import torch
+
+from benchmarks.kernels.benchmark_glm53_indexer_tiles import (
+    BASELINE,
+    configurations,
+    oracle,
+    selected_pools,
+)
+
+
+def test_indexer_geometries_include_production_and_no_duplicates():
+    configs = configurations()
+    assert BASELINE in configs
+    assert len(configs) == len(set(configs)) == 30
+
+
+def test_indexer_cpu_oracle_reduces_heads_after_relu_and_masks_visibility():
+    query = torch.ones((2, 32, 128), dtype=torch.bfloat16)
+    keys = torch.ones((1, 3, 128), dtype=torch.bfloat16)
+    keys[:, 1] = -1
+    weights = torch.full((2, 32), 0.5)
+    visible = torch.tensor([4, 8])
+    scores, valid = oracle(query, weights, keys, visible, [0, 1], [0, 1, 2])
+    assert torch.equal(valid, torch.tensor([[True, False, False], [True, True, False]]))
+    assert scores[:, 1].eq(0).all()
+    torch.testing.assert_close(
+        scores[:, 0], torch.full((2,), 16 * 128**0.5, dtype=torch.float64)
+    )
+
+
+def test_early_prefill_selection_ignores_unwritten_future_pools():
+    scores = torch.tensor([[float("nan")] * 3, [2, 1, float("nan")], [1, 3, 2]])
+    selected = selected_pools(scores, torch.tensor([1, 8, 12]))
+    assert [row.tolist() for row in selected] == [[], [0, 1], [0, 1, 2]]

--- a/tests/slimserve/test_routing_journal.py
+++ b/tests/slimserve/test_routing_journal.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+import json
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+
+from benchmarks.analyze_routing_journal import analyze
+from slimserve.routing_journal import RoutingJournal, diagnostic_plan
+
+
+def journal(tmp_path, **kwargs):
+    return RoutingJournal(
+        tmp_path,
+        model="test",
+        num_layers=3,
+        first_moe_layer=1,
+        num_experts=8,
+        top_k=2,
+        **kwargs,
+    )
+
+
+def inputs():
+    return dict(
+        data=np.array([[[0, 0], [1, 2], [3, 4]], [[0, 0], [5, 6], [1, 7]]]),
+        slots=np.array([91, 22]),
+        req_ids=["second", "first"],
+        scheduled={"first": 1, "second": 1},
+        computed={"first": 1002, "second": 1003},
+        prompt_lengths={"first": 1000, "second": 1000},
+    )
+
+
+def rows(j):
+    return [json.loads(line) for line in j.path.read_text().splitlines()]
+
+
+def test_preserves_actual_step_order_and_excludes_dense_layers(tmp_path):
+    j = journal(tmp_path)
+    j.record(**inputs())
+    j.close()
+    row = rows(j)[1]
+    assert row["request_ids"] == ["second", "first"]
+    assert row["computed_tokens"] == [1003, 1002]
+    assert row["slots"] == [91, 22]
+    assert row["routes"] == [[[1, 2], [3, 4]], [[5, 6], [1, 7]]]
+
+
+@pytest.mark.parametrize("kind", ["prefill", "one_token_prefill", "too_large"])
+def test_skips_are_explicit(tmp_path, kind):
+    j = journal(tmp_path, max_tokens=1 if kind == "too_large" else 16)
+    args = inputs()
+    if kind == "prefill":
+        args["scheduled"]["first"] = 64
+    if kind == "one_token_prefill":
+        args["computed"]["first"] = 1000
+    j.record(**args)
+    j.close()
+    assert rows(j)[1]["kind"] == "skip"
+    assert j.recorded == 0
+
+
+@pytest.mark.parametrize("kind", ["shape", "slots", "range", "duplicates", "dtype"])
+def test_bad_capture_is_retained_and_rejected(tmp_path, kind):
+    j = journal(tmp_path)
+    args = inputs()
+    if kind == "shape":
+        args["data"] = args["data"][:1]
+    elif kind == "slots":
+        args["slots"] = args["slots"][:1]
+    elif kind == "range":
+        args["data"][0, 1, 0] = 8
+    elif kind == "duplicates":
+        args["data"][0, 1, 0] = 2
+    else:
+        args["data"] = args["data"].astype(float)
+    with pytest.raises(ValueError):
+        j.record(**args)
+    j.close()
+    assert rows(j)[1]["kind"] == "invalid"
+
+
+def test_record_bound_does_not_overwrite_evidence(tmp_path):
+    j = journal(tmp_path, max_records=1)
+    j.record(**inputs())
+    j.record(**inputs())
+    j.close()
+    assert [r["kind"] for r in rows(j)] == ["header", "decode", "limit"]
+    with pytest.raises(FileExistsError):
+        journal(tmp_path)
+
+
+def test_non_decode_steps_are_also_bounded(tmp_path):
+    j = journal(tmp_path, max_records=1, max_tokens=1)
+    for _ in range(8):
+        j.record(**inputs())
+    j.close()
+    assert [r["kind"] for r in rows(j)] == ["header"] + ["skip"] * 4 + ["step_limit"]
+
+
+def test_analysis_counts_unique_experts_in_the_same_step(tmp_path):
+    j = journal(tmp_path)
+    args = inputs()
+    # One shared expert in layer 1, two in layer 2: 3 + 2 unique experts.
+    args["data"][1, 1] = [2, 5]
+    args["data"][1, 2] = [3, 4]
+    j.record(**args)
+    j.close()
+    result = analyze(j.path, per_expert_bytes=100)
+    row = result["summary"][2]
+    assert row["sum_layer_unique_experts"]["mean"] == 5
+    assert row["max_tokens_per_expert"] == 2
+    assert row["marlin_m8_route_utilization"]["mean"] == 8 / 40
+    assert row["unique_weight_footprint_bytes_not_dram"]["mean"] == 500
+
+
+def test_analysis_rejects_failed_capture(tmp_path):
+    j = journal(tmp_path)
+    args = inputs()
+    args["data"].fill(0)
+    with pytest.raises(ValueError):
+        j.record(**args)
+    j.close()
+    with pytest.raises(ValueError, match="invalid routing capture"):
+        analyze(j.path)
+
+
+@dataclass
+class Plan:
+    profile_id: str
+    platform: str
+    speculative: bool
+    engine: dict
+
+
+def test_capture_plan_is_explicit_and_preserves_the_original(tmp_path):
+    original = Plan("glm53-nvfp4-4", "rtx6000", False, {"additional_config": {"a": 1}})
+    changed = diagnostic_plan(original, tmp_path)
+    assert changed.engine["enable_return_routed_experts"] is True
+    assert changed.engine["async_scheduling"] is False
+    assert changed.engine["additional_config"]["a"] == 1
+    assert original.engine == {"additional_config": {"a": 1}}
+    with pytest.raises(ValueError, match="no-spec"):
+        diagnostic_plan(Plan(original.profile_id, "rtx6000", True, {}), tmp_path)
+    with pytest.raises(ValueError, match="RTX6000"):
+        diagnostic_plan(Plan(original.profile_id, "a100", False, {}), tmp_path)
+
+
+def test_real_profile_serializes_explicit_capture(tmp_path):
+    from slimserve import cli, registry
+    from slimserve.engine import serve_argv
+
+    args = cli._parser().parse_args(
+        ["glm53-nvfp4-4", "--route-profile-dir", str(tmp_path)]
+    )
+    original = registry.resolve("glm53-nvfp4-4", "rtx6000", 4, None)
+    plan = diagnostic_plan(original, args.route_profile_dir)
+    argv = serve_argv(plan, "127.0.0.1", 8000)
+    assert "--enable-return-routed-experts" in argv
+    assert "--no-async-scheduling" in argv
+    additional = json.loads(argv[argv.index("--additional-config") + 1])
+    assert additional["slimserve_routing_journal"] == str(tmp_path)
+    assert "enable_return_routed_experts" not in original.engine

--- a/tests/slimserve/test_routing_journal.py
+++ b/tests/slimserve/test_routing_journal.py
@@ -126,6 +126,15 @@ def test_analysis_rejects_failed_capture(tmp_path):
         analyze(j.path)
 
 
+def test_analysis_rejects_unknown_record_after_valid_decode(tmp_path):
+    j = journal(tmp_path)
+    j.record(**inputs())
+    j._write({"kind": "decdoe"})
+    j.close()
+    with pytest.raises(ValueError, match="unsupported schema-1.*decdoe"):
+        analyze(j.path)
+
+
 @dataclass
 class Plan:
     profile_id: str

--- a/tests/slimserve/test_stable_align_wiring.py
+++ b/tests/slimserve/test_stable_align_wiring.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Large alignment dispatch, fail-closed scope, and canonical provenance."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from slimserve import canonical_moe
+from vllm.model_executor.layers.fused_moe.experts import marlin_moe
+from vllm.model_executor.layers.fused_moe.router import glm_route_align as route
+from vllm.model_executor.layers.fused_moe.router import glm_stable_align as stable
+from vllm.quixicore import ops
+from vllm.scalar_type import scalar_types
+
+
+def test_stable_align_requires_canonical_diagnostic(monkeypatch):
+    monkeypatch.delenv("SLIMSERVE_GLM53_STABLE_ALIGN", raising=False)
+    assert not canonical_moe.stable_align_enabled()
+    for value in ("yes", "true", "-1", "2"):
+        monkeypatch.setenv("SLIMSERVE_GLM53_STABLE_ALIGN", value)
+        with pytest.raises(ValueError, match="0 or 1"):
+            canonical_moe.stable_align_enabled()
+    monkeypatch.setenv("SLIMSERVE_GLM53_STABLE_ALIGN", "1")
+    monkeypatch.delenv("SLIMSERVE_GLM53_CANONICAL_MOE", raising=False)
+    with pytest.raises(ValueError, match="requires canonical MoE"):
+        canonical_moe.stable_align_enabled()
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_MOE", "1")
+    monkeypatch.delenv("SLIMSERVE_GLM53_MODEL_JOURNAL", raising=False)
+    with pytest.raises(ValueError, match="bounded model journal"):
+        canonical_moe.stable_align_enabled()
+    monkeypatch.setenv("SLIMSERVE_GLM53_MODEL_JOURNAL", "1")
+    assert canonical_moe.stable_align_enabled()
+
+
+def test_missing_native_fails_closed(monkeypatch):
+    monkeypatch.setattr(ops, "_qc", lambda: SimpleNamespace())
+    with pytest.raises(RuntimeError, match="requires rebuilt native"):
+        ops.quixicore_ops.glm_stable_align(None, None, None, None, None, 8)
+
+
+@pytest.mark.parametrize("tokens", [17, 32, 33, 640, 8192])
+@pytest.mark.parametrize("block", [8, 16, 32, 48, 64])
+def test_fake_geometry(tokens, block):
+    ids = torch.empty((tokens, 8), device="meta", dtype=torch.int32)
+    outputs = stable._glm_stable_align_fake(ids, block)
+    capacity, blocks = route.alignment_geometry(tokens, 8, 288, block)
+    assert [tuple(t.shape) for t in outputs] == [(capacity,), (blocks,), (1,)]
+    assert all(t.device.type == "meta" and t.dtype == torch.int32 for t in outputs)
+
+
+def invoke(monkeypatch, tokens, *, active=True, invalid=None, reused=False):
+    monkeypatch.setattr(marlin_moe, "_STABLE_ALIGN_DIAGNOSTIC", active)
+    monkeypatch.setattr(marlin_moe, "_CANONICAL_MOE_DIAGNOSTIC", True)
+    monkeypatch.setattr(route, "_published", None)
+    hidden = 2048 if invalid == "hidden" else 4096
+    experts = 287 if invalid == "experts" else 288
+    topk = 7 if invalid == "topk" else 8
+    dtype = torch.float16 if invalid == "dtype" else torch.bfloat16
+    quant = scalar_types.uint4b8 if invalid == "quant" else scalar_types.float4_e2m1f
+    ids = torch.empty(tokens, topk, dtype=torch.int32, device="meta")
+    result = [torch.empty(1, device="meta", dtype=torch.int32) for _ in range(3)]
+    calls = []
+
+    def align(*args, **kwargs):
+        calls.append("atomic")
+        assert args[0] is ids
+        return result
+
+    def canonical(ids_arg, block):
+        calls.append("native")
+        assert ids_arg is ids and block == route.marlin_block_size_m(tokens, 8, 288)
+        return result
+
+    def gemm(**kwargs):
+        assert kwargs["sorted_token_ids"] is result[0]
+        return torch.empty(tokens * topk, hidden, device="meta", dtype=dtype)
+
+    monkeypatch.setattr(marlin_moe, "moe_align_block_size", align)
+    monkeypatch.setattr(stable, "align", canonical)
+    monkeypatch.setattr(
+        canonical_moe, "canonicalize", lambda *a, **k: calls.append("sort")
+    )
+    monkeypatch.setattr(marlin_moe, "_fused_marlin_moe", gemm)
+    if reused:
+        route.publish(
+            route.RoutingAlignment(ids, *result, 8, canonical_assignment_order=True)
+        )
+    args = (
+        torch.empty(tokens, hidden, device="meta", dtype=dtype),
+        torch.empty(experts, hidden // 16, 1, device="meta", dtype=torch.int32),
+        torch.empty(experts, 1, hidden * 2, device="meta", dtype=torch.int32),
+        None,
+        None,
+        torch.empty(0),
+        torch.empty(0),
+        torch.empty(tokens, topk),
+        ids,
+        quant.id,
+    )
+    kwargs = dict(
+        expert_map=torch.arange(experts) if invalid == "ep" else None,
+        global_num_experts=576 if invalid == "global" else -1,
+    )
+    if invalid:
+        with pytest.raises(ValueError, match="requires GLM53 NVFP4 TP"):
+            marlin_moe.fused_marlin_moe(*args, **kwargs)
+        assert calls == []
+    else:
+        assert marlin_moe.fused_marlin_moe(*args, **kwargs).shape == (tokens, hidden)
+    return calls
+
+
+@pytest.mark.parametrize("tokens", [1, 16, 17, 32, 33, 640, 8192, 8193])
+@pytest.mark.parametrize("active", [False, True])
+def test_dispatch_only_skips_sort_for_actual_native_result(monkeypatch, tokens, active):
+    expected = ["native"] if active and 17 <= tokens <= 8192 else ["atomic", "sort"]
+    assert invoke(monkeypatch, tokens, active=active) == expected
+
+
+def test_small_fused_alignment_still_reused(monkeypatch):
+    assert invoke(monkeypatch, 16, reused=True) == []
+
+
+@pytest.mark.parametrize(
+    "invalid", ["hidden", "experts", "topk", "dtype", "quant", "ep", "global"]
+)
+def test_invalid_model_scope_fails_before_alignment(monkeypatch, invalid):
+    invoke(monkeypatch, 640, invalid=invalid)

--- a/tests/slimserve/test_stable_route_wiring.py
+++ b/tests/slimserve/test_stable_route_wiring.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU dispatch/provenance checks; no real GEMM or GPU allocation."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from slimserve import canonical_moe
+from vllm.model_executor.layers.fused_moe.experts import marlin_moe
+from vllm.model_executor.layers.fused_moe.router import glm_route_align as route
+from vllm.scalar_type import scalar_types
+
+
+def test_stale_native_fails_only_when_stable_requested(monkeypatch):
+    from vllm.quixicore import ops
+
+    sentinel = object()
+    monkeypatch.setattr(
+        ops, "_qc", lambda: SimpleNamespace(glm_route_align=lambda *args: sentinel)
+    )
+    args = (None, None, 8, 0, True, 2.5, 8, 64, 8)
+    assert ops.quixicore_ops.glm_route_align(*args) is sentinel
+    with pytest.raises(RuntimeError, match="requires rebuilt native"):
+        ops.quixicore_ops.glm_route_align(*args, stable=True)
+
+
+def test_stable_routing_flag_requires_canonical_diagnostic(monkeypatch):
+    key = "SLIMSERVE_GLM53_STABLE_ROUTE"
+    monkeypatch.delenv(key, raising=False)
+    assert not canonical_moe.stable_route_enabled()
+    for bad in ("yes", "true", "-1", "2"):
+        monkeypatch.setenv(key, bad)
+        with pytest.raises(ValueError, match="0 or 1"):
+            canonical_moe.stable_route_enabled()
+    monkeypatch.setenv(key, "1")
+    monkeypatch.delenv("SLIMSERVE_GLM53_CANONICAL_MOE", raising=False)
+    with pytest.raises(ValueError, match="requires canonical MoE"):
+        canonical_moe.stable_route_enabled()
+    monkeypatch.setenv("SLIMSERVE_GLM53_CANONICAL_MOE", "1")
+    monkeypatch.delenv("SLIMSERVE_GLM53_MODEL_JOURNAL", raising=False)
+    with pytest.raises(ValueError, match="bounded model journal"):
+        canonical_moe.stable_route_enabled()
+    monkeypatch.setenv("SLIMSERVE_GLM53_MODEL_JOURNAL", "1")
+    assert canonical_moe.stable_route_enabled()
+
+
+@pytest.mark.parametrize("stable", (False, True))
+def test_router_dispatch_and_published_provenance(monkeypatch, stable):
+    calls = []
+    result = [
+        torch.empty(8, 8),
+        torch.empty(8, 8, dtype=torch.int32),
+        torch.empty(512, dtype=torch.int32),
+        torch.empty(64, dtype=torch.int32),
+        torch.empty(1, dtype=torch.int32),
+    ]
+
+    def native(*args, **kwargs):
+        calls.append((args, kwargs))
+        return result
+
+    monkeypatch.setattr(route, "_STABLE_ALIGNMENT_DIAGNOSTIC", stable)
+    monkeypatch.setattr(route.quixicore_ops, "glm_route_align", native)
+    monkeypatch.setattr(torch.ops.vllm, "glm_route_align", route._glm_route_align_impl)
+    monkeypatch.setattr(route, "_published", None)
+    router = SimpleNamespace(
+        top_k=8,
+        e_score_correction_bias=torch.zeros(288),
+        scoring_func="sigmoid",
+        renormalize=True,
+        routed_scaling_factor=2.5,
+    )
+    logits = torch.empty(8, 288)
+    weights, ids = route.route(router, logits)
+    assert weights is result[0] and ids is result[1]
+    assert len(calls) == 1 and calls[0][0][0] is logits
+    assert calls[0][1] == ({"stable": True} if stable else {})
+    aligned = route.consume(ids)
+    assert aligned.canonical_assignment_order is stable
+    assert aligned.sorted_token_ids is result[2]
+    assert route.consume(ids) is None
+
+
+@pytest.mark.parametrize(
+    "kind,diagnostic,sort_calls,align_calls",
+    (
+        ("stable", True, 0, 0),
+        ("atomic", True, 1, 0),
+        ("wrong-block", True, 1, 1),
+        ("wrong-ids", True, 1, 1),
+        ("missing", True, 1, 1),
+        ("stable", False, 0, 0),
+        ("expert-map", False, 0, 1),
+    ),
+)
+def test_sort_skip_depends_on_actual_reused_alignment(
+    monkeypatch,
+    kind,
+    diagnostic,
+    sort_calls,
+    align_calls,
+):
+    monkeypatch.setattr(route, "_published", None)
+    monkeypatch.setattr(marlin_moe, "_CANONICAL_MOE_DIAGNOSTIC", diagnostic)
+    counts = {"sort": 0, "align": 0}
+    ids = torch.zeros(8, 8, dtype=torch.int32)
+    original = [
+        torch.zeros(512, dtype=torch.int32),
+        torch.zeros(64, dtype=torch.int32),
+        torch.zeros(1, dtype=torch.int32),
+    ]
+    fallback = [t.clone() for t in original]
+    if kind != "missing":
+        route.publish(
+            route.RoutingAlignment(
+                ids.clone() if kind == "wrong-ids" else ids,
+                *original,
+                16 if kind == "wrong-block" else 8,
+                canonical_assignment_order=kind != "atomic",
+            )
+        )
+
+    def align(*args, **kwargs):
+        counts["align"] += 1
+        return fallback
+
+    def sort(*args, **kwargs):
+        counts["sort"] += 1
+        assert args[0] is (fallback if align_calls else original)[0]
+
+    def gemm(**kwargs):
+        assert kwargs["sorted_token_ids"] is (fallback if align_calls else original)[0]
+        assert kwargs["block_size_m"] == 8
+        return torch.zeros(64, 4096, dtype=torch.bfloat16)
+
+    monkeypatch.setattr(marlin_moe, "moe_align_block_size", align)
+    monkeypatch.setattr(canonical_moe, "canonicalize", sort)
+    monkeypatch.setattr(marlin_moe, "_fused_marlin_moe", gemm)
+    monkeypatch.setattr(marlin_moe.ops, "moe_sum", lambda x, out, *args: out.zero_())
+    out = marlin_moe.fused_marlin_moe(
+        torch.zeros(8, 4096, dtype=torch.bfloat16),
+        torch.empty(288, 256, 1, device="meta", dtype=torch.int32),
+        torch.empty(288, 1, 8192, device="meta", dtype=torch.int32),
+        None,
+        None,
+        torch.empty(0),
+        torch.empty(0),
+        torch.empty(8, 8),
+        ids,
+        scalar_types.float4_e2m1f.id,
+        expert_map=torch.arange(288) if kind == "expert-map" else None,
+    )
+    assert out.shape == (8, 4096)
+    assert counts == {"sort": sort_calls, "align": align_calls}
+    assert route.consume(ids) is None

--- a/tests/slimserve/test_stable_route_wiring.py
+++ b/tests/slimserve/test_stable_route_wiring.py
@@ -12,6 +12,19 @@ from vllm.model_executor.layers.fused_moe.router import glm_route_align as route
 from vllm.scalar_type import scalar_types
 
 
+def test_benchmark_source_paths_do_not_depend_on_cwd(tmp_path, monkeypatch):
+    from benchmarks.kernels.benchmark_glm53_stable_route import ROOT, source_paths
+
+    native = SimpleNamespace(__file__=str(tmp_path / "native.so"))
+    probe = SimpleNamespace(__file__=str(tmp_path / "probe.so"))
+    before = source_paths(native, probe)
+    monkeypatch.chdir(tmp_path)
+    assert source_paths(native, probe) == before
+    assert all(path.is_absolute() for path in before)
+    assert ROOT / "csrc/quixicore/serving/glm_moe_routing.cuh" in before
+    assert before[-1] == tmp_path / "probe.so"
+
+
 def test_stale_native_fails_only_when_stable_requested(monkeypatch):
     from vllm.quixicore import ops
 


### PR DESCRIPTION
## Scope — part 4/5 (57 files)

Indexer/routing/canonical-order diagnostics and tests, precision/replay tools, TP-sharding probes and preserved correction protocols. Runtime hooks are in the preceding integration layers; these opt-in tools do not change the production recipe.

## Review stack — ready

Dependency order: #26 → #27 → #28 → #25 → #24. Each PR targets the preceding layer; #26 targets main. Retarget the next layer after its base lands. Do not land later layers independently or merge automatically.

| Part | PR | Scope | Files |
|---|---|---|---:|
| 1 | #26 | Native kernels, bindings, focused probes/tests | 94 |
| 2 | #27 | Serving recipe, platform integration, regressions | 83 |
| 3 | #28 | Numerical diagnostics and prefill qualification | 83 |
| 4 | #25 | Indexer/routing diagnostics and qualification | 57 |
| 5 | #24 | Campaign harnesses, evidence and roadmap | 55 |

## Review outcome — 2026-09-11

- #26: 13 inline findings resolved; 14 nits dispositioned. 99 CPU / 172 GPU passes, plus18 cold-compilation/dispatch regressions.
- #27: 17 inline findings resolved; six nits dispositioned. Layer/microbatch-owned Marlin scratch, BF16 combine fallback, sidecar/MTP/journal/sampler contract fixes. 137 CPU / 11 GPU passes plus17 final CPU cleanup checks. [Disposition](https://github.com/QuixiAI/SlimServe/pull/27#issuecomment-5640839113).
- #28: CodeRabbit completed a full83-file static review with no actionable defects. This is a [review comment](https://github.com/QuixiAI/SlimServe/pull/28#issuecomment-5640985715), not a formal GitHub approval.
- #25: nine inline findings resolved; four nits dispositioned. Fix172c68bf7 tightens diagnostic per-rank/set-tail/SASS/archive evidence and path/environment/device/probe handling. 107 CPU +1 inherited-environment +1 compiled-indexer GPU pass;23 expected unavailable-device/probe skips. [Disposition](https://github.com/QuixiAI/SlimServe/pull/25#issuecomment-5641266239).
- #24: ten actionable findings resolved; two test nits addressed,128 CPU passes.

All49 inline threads are resolved. CI guards pass and main conflicts are resolved. Fixes are committed as Auroter on their owning branches and merged forward, without force-push. No merge into main has occurred.

## Combined serving qualification

Target: four RTX PRO6000 Blackwell SM120 GPUs, stock600W, TP4/no EP/no speculation, explicit V1 runner. Canonical profile `glm53f-nvfp4-4` (alias `glm53-nvfp4-4`), recipe `glm53-redhatai-nvfp4-fp8-kda-tp4-v1`: RedHatAI NVFP4 experts, pinned FP8 sidecars/FP32 repairs, BF16 KV/head.

Final clean-tree `f9963f878` includes main0313f5228, the rebuilt native binding, independent Marlin scratch and all serving-review fixes. One boot, three exact1000-input/300-output cold-prefix repeats, no source changes/restarts/exclusions:

| Measurement | Median [min,max] |
|---|---:|
| c1 E2E tok/s | 156.838 [156.689,157.100] |
| c8 E2E tok/s | 577.605 [577.499,578.503] |
| c16 E2E tok/s | 782.960 [781.820,784.241] |
| cold32K engine TTFT ms | 2511.369 [2508.355,2513.162] |
| cold128K engine TTFT ms | 9921.773 [9896.923,9948.182] |

Exact tokens, text/image canaries and six retrieval contrasts pass;4096 scored text tokens, mean logprob -2.731236241. Exit0 and GPU release verified. Later part4 fixes change only diagnostics/tests/docs: no changes under csrc/, slimserve/ or vllm/ since this serving qualification. No additional model boot.

This preserves performance, not a paired speedup or a resolution of historical score-repeatability limits. Known recovered prompt-score allocation warnings remain; chunked scoring stays opt-in. Earlier failed startup receipts remain preserved. No A100, DBO, MTP or disabled-tier qualification is implied.

Raw local receipts: `perf/results/2026-09-11/pr-review/`, including `serving-final-review/` and `part4-{cpu,env,gpu}.xml`. [Baseline and limitations](https://github.com/QuixiAI/SlimServe/blob/glm53-flash-sm120/perf/baseline_status.md#rtx6000-final-combined-review-qualification---2026-09-11), [review map](https://github.com/QuixiAI/SlimServe/blob/glm53-flash-sm120/docs/glm53-flash-sm120-review.md), [roadmap](https://github.com/QuixiAI/SlimServe/blob/glm53-flash-sm120/docs/glm53-flash-sm120-plan.md).

## Why the split and remaining scope

The user authorized splitting only if needed. CodeRabbit confirmed the original365-file diff exceeded the configured100-file and absolute300-file limits, with no supported within-PR file batching. Every file remains in this stack; no test/diagnostic exclusions or path filters were added. The history join `e5d0ec096` preserved all original campaign commits and was byte-identical to `c41148025`. Intermediate layers are review units, not independently serving-qualified releases.

The17 original main conflicts and two later binding/indexer conflicts are resolved. SM120 retains its qualified BF16/raw-cache/V1 path; A100's compact-cache/FP8-decode/V2/DFlash2 work remains intact. The unrelated main defect in `glm53f-q2-1/metal` (missing `glm53f-gguf` source/FP8-KV note; eight known registry failures) remains documented rather than hidden by invented metadata.

Foundry, disabled host/NVMe tiers and external QuixiCore port-back are out of scope. Broader next-layer prefetch and persistent decode remain explicitly deferred, not claimed implemented or exhausted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostic and benchmarking tools for GLM-5.3 indexer precision, ordering, routing, alignment, tiling, sharding, and correction workflows.
  * Added routing-journal analysis with validation, utilization metrics, and JSON reporting.
  * Added optional indexer-correction loading and serving diagnostics with artifact and runtime validation.

* **Documentation**
  * Added protocols documenting correction qualification, loader validation, serving behavior, and diagnostic results.

* **Tests**
  * Added extensive CPU/GPU coverage for canonical ordering, tie handling, graph replay, routing, journaling, correction, and serving safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->