### PR TITLE
[1/5] GLM53 SM120 native kernels and focused probes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1305,6 +1305,22 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
     endif()
 
     set(MARLIN_MOE_OTHER_SRC "csrc/libtorch_stable/moe/marlin_moe_wna16/ops.cu")
+    if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 13.0)
+      cuda_archs_loose_intersection(GLM53_MARLIN_ARCHS "12.0f" "${CUDA_ARCHS}")
+    else()
+      cuda_archs_loose_intersection(GLM53_MARLIN_ARCHS "12.0a" "${CUDA_ARCHS}")
+    endif()
+    if(GLM53_MARLIN_ARCHS)
+      set(GLM53_MARLIN_SRC
+        "csrc/libtorch_stable/moe/marlin_moe_wna16/glm53_sm120_prefill.cu")
+      set_gencode_flags_for_srcs(
+        SRCS "${GLM53_MARLIN_SRC}" CUDA_ARCHS "${GLM53_MARLIN_ARCHS}")
+      set_source_files_properties(${GLM53_MARLIN_SRC}
+        PROPERTIES COMPILE_FLAGS "-static-global-template-stub=false")
+      set_property(SOURCE ${MARLIN_MOE_OTHER_SRC} APPEND PROPERTY
+        COMPILE_DEFINITIONS VLLM_BUILD_GLM53_SM120_PREFILL=1)
+      list(APPEND VLLM_MOE_EXT_SRC ${GLM53_MARLIN_SRC})
+    endif()
     set_gencode_flags_for_srcs(
       SRCS "${MARLIN_MOE_OTHER_SRC}"
       CUDA_ARCHS "${MARLIN_MOE_OTHER_ARCHS}")
@@ -1448,6 +1464,22 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
   set_gencode_flags_for_srcs(
     SRCS "${VLLM_QUIXICORE_EXT_SRC}"
     CUDA_ARCHS "${QUIXICORE_ARCHS}")
+
+  # The warp-specialized GLM prefill kernel uses SM120 bulk async copies.
+  # Keep it in its own architecture-scoped translation unit.
+  if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 13.0)
+    cuda_archs_loose_intersection(GLM53_SPARSE_ARCHS "12.0f" "${CUDA_ARCHS}")
+  elseif(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8)
+    cuda_archs_loose_intersection(GLM53_SPARSE_ARCHS "12.0a" "${CUDA_ARCHS}")
+  endif()
+  if(GLM53_SPARSE_ARCHS)
+    set(GLM53_SPARSE_SRC "csrc/quixicore/tm_cuda/tm_cuda_glm53_sparse.cu")
+    set_gencode_flags_for_srcs(
+      SRCS "${GLM53_SPARSE_SRC}" CUDA_ARCHS "${GLM53_SPARSE_ARCHS}")
+    set_property(SOURCE "csrc/quixicore/tm_cuda/tm_cuda_ext.cu" APPEND PROPERTY
+      COMPILE_DEFINITIONS VLLM_BUILD_GLM53_SM120_SPARSE=1)
+    list(APPEND VLLM_QUIXICORE_EXT_SRC ${GLM53_SPARSE_SRC})
+  endif()
 
   define_extension_target(
     _quixicore_C

--- a/benchmarks/analyze_marlin_counters.py
+++ b/benchmarks/analyze_marlin_counters.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Join isolated Marlin counter rows to the exact recorded routing cases.
+
+Cold-cache measurements are not end-to-end throughput or a serving ceiling.
+Missing metrics, units, launches or incomplete case records are hard errors.
+"""
+
+import argparse
+import csv
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+
+METRICS = {
+    "gpu__time_duration.sum": "us",
+    "dram__bytes_op_read.sum": "byte",
+    "dram__bytes_op_write.sum": "byte",
+    "lts__t_sectors_op_read.sum": "sector",
+    "smsp__inst_executed.sum": "inst",
+}
+UNIT_SCALES = {
+    "us": {"ns": 1e-3, "us": 1.0, "ms": 1e3, "s": 1e6},
+    "byte": {"byte": 1.0, "Kbyte": 1e3, "Mbyte": 1e6, "Gbyte": 1e9},
+    "sector": {"sector": 1.0},
+    "inst": {"inst": 1.0},
+}
+
+
+def analyze(raw, cases):
+    with raw.open() as stream:
+        reader = csv.DictReader(stream)
+        units = next(reader, None)
+        rows = list(reader)
+    if units is None or any(
+        units.get(name) not in UNIT_SCALES[unit] for name, unit in METRICS.items()
+    ):
+        raise ValueError(f"missing metrics or unexpected units; require {METRICS}")
+    factors = {name: UNIT_SCALES[unit][units[name]] for name, unit in METRICS.items()}
+    if cases["status"] != "complete" or len(rows) != 2 * len(cases["cases"]):
+        raise ValueError("incomplete cases or unexpected number of Marlin launches")
+    measured, groups = [], defaultdict(list)
+    for i, row in enumerate(rows):
+        if int(row["ID"]) != i or "Marlin<" not in row["Kernel Name"]:
+            raise ValueError(
+                "counter order/name does not match the bracketed execution"
+            )
+        values = {
+            name: float(row[name].replace(",", "")) * factors[name] for name in METRICS
+        }
+        if not all(math.isfinite(v) and v >= 0 for v in values.values()):
+            raise ValueError("invalid counter value")
+        us = values["gpu__time_duration.sum"]
+        if us <= 0:
+            raise ValueError("nonpositive kernel duration")
+        case = cases["cases"][i // 2]
+        gate_up = i % 2 == 0
+        n, k = (1024, 4096) if gate_up else (4096, 512)
+        unique_bytes = case["unique_experts"] * n * k * (0.5 + 1 / 16)
+        item = {
+            "case": case["label"],
+            "phase": "gate_up" if gate_up else "down",
+            "batch": case["batch"],
+            "layer": case["layer"],
+            "kernel_id": i,
+            "unique_experts": case["unique_experts"],
+            "kernel_name": row["Kernel Name"],
+            "unique_weight_footprint_bytes": unique_bytes,
+            "dram_read_bytes": values["dram__bytes_op_read.sum"],
+            "dram_write_bytes": values["dram__bytes_op_write.sum"],
+            "l2_read_sectors": values["lts__t_sectors_op_read.sum"],
+            "warp_instructions": values["smsp__inst_executed.sum"],
+            "profiled_us": us,
+            "dram_read_to_unique_weight_footprint": values["dram__bytes_op_read.sum"]
+            / unique_bytes,
+            "l2_read_bytes_to_unique_weight_footprint": values[
+                "lts__t_sectors_op_read.sum"
+            ]
+            * 32
+            / unique_bytes,
+            "profiled_dram_read_GB_per_s": values["dram__bytes_op_read.sum"]
+            / us
+            / 1000,
+        }
+        measured.append(item)
+        groups[(case["batch"], item["phase"])].append(item)
+    summary = []
+    for (batch, phase), items in sorted(groups.items()):
+        entry = {"batch": batch, "phase": phase, "count": len(items)}
+        for key in (
+            "profiled_us",
+            "dram_read_to_unique_weight_footprint",
+            "l2_read_bytes_to_unique_weight_footprint",
+            "profiled_dram_read_GB_per_s",
+        ):
+            values = [r[key] for r in items]
+            entry[key] = {
+                "min": min(values),
+                "median": statistics.median(values),
+                "max": max(values),
+            }
+        summary.append(entry)
+    return {"diagnostic_only": True, "rows": measured, "summary": summary}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--raw", type=Path, required=True)
+    parser.add_argument("--cases", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    if args.output.exists():
+        parser.error("output must be new")
+    result = analyze(args.raw, json.loads(args.cases.read_text()))
+    result["inputs"] = {"raw": str(args.raw), "cases": str(args.cases)}
+    with args.output.open("x") as stream:
+        json.dump(result, stream, indent=2)
+        stream.write("\n")
+    print(json.dumps(result["summary"], indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_glm53_fp8_cache.py
+++ b/benchmarks/kernels/benchmark_glm53_fp8_cache.py
@@ -125,16 +125,18 @@ def main():
 
     save()
     try:
+        import vllm._quixicore_C as native
         from vllm.quixicore.ops import quixicore_ops
 
         torch.set_num_threads(4)
         if torch.cuda.get_device_capability() != (12, 0):
             raise ValueError("requires the SM120 128-MiB-L2 target")
         result["gpu"] = torch.cuda.get_device_name()
-        with Path("vllm/_quixicore_C.cpython-312-x86_64-linux-gnu.so").open(
-            "rb"
-        ) as handle:
-            result["native_sha256"] = hashlib.file_digest(handle, "sha256").hexdigest()
+        native_digest = hashlib.sha256()
+        with Path(native.__file__).open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                native_digest.update(chunk)
+        result["native_sha256"] = native_digest.hexdigest()
         sidecar = args.model / "fp8-swapset.safetensors"
         for layer in args.layers:
             for kind, (cpu_q, cpu_s) in load_weights(sidecar, layer, args.rank).items():

--- a/benchmarks/kernels/benchmark_glm53_fp8_cache.py
+++ b/benchmarks/kernels/benchmark_glm53_fp8_cache.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Actual-weight FP8 shared-expert cache sensitivity, not serving throughput.
+
+Compare the old 24-copy rotation against a byte-sized rotation exceeding three
+SM120 L2 capacities, then return to 24 copies. Same installed production kernel,
+same checkpoint weight, synthetic BF16 inputs. All fixed A/B/A samples survive.
+Run only on an idle GPU under an external memory cap, never beside serving.
+"""
+
+import argparse
+import hashlib
+import json
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+
+L2_BYTES = 128 * 2**20
+
+
+def rotation_count(weight_bytes):
+    if weight_bytes <= 0:
+        raise ValueError("positive weight bytes required")
+    return 3 * L2_BYTES // weight_bytes + 1
+
+
+def load_weights(path, layer, rank):
+    """Same TP4 row/column slices and gate-up order as the shared expert."""
+    prefix = f"model.language_model.layers.{layer}.mlp.shared_experts."
+    with safe_open(path, framework="pt", device="cpu") as source:
+
+        def tensor(suffix):
+            return source.get_tensor(prefix + suffix)
+
+        row = slice(rank * 512, (rank + 1) * 512)
+        scale_row = slice(rank * 4, (rank + 1) * 4)
+        gate, up = tensor("gate_proj.weight"), tensor("up_proj.weight")
+        down = tensor("down_proj.weight")
+        if any(weight.dtype != torch.float8_e4m3fn for weight in (gate, up, down)):
+            raise ValueError("expected actual FP8 shared-expert weights")
+        if (
+            gate.shape != (2048, 4096)
+            or up.shape != gate.shape
+            or down.shape != (4096, 2048)
+        ):
+            raise ValueError("unexpected actual shared-expert checkpoint shapes")
+        gate_up = torch.cat(
+            [gate[row].view(torch.uint8), up[row].view(torch.uint8)]
+        ).view(torch.float8_e4m3fn)
+        scales = torch.cat(
+            [
+                tensor("gate_proj.weight_scale")[scale_row],
+                tensor("up_proj.weight_scale")[scale_row],
+            ]
+        )
+        return {
+            "gate_up": (gate_up, scales),
+            "down": (
+                down[:, row].contiguous(),
+                tensor("down_proj.weight_scale")[:, scale_row].contiguous(),
+            ),
+        }
+
+
+def oracle_weight(q, scale):
+    n, k = q.shape
+    # Match the defined FP32 product -> BF16 weight, then independent FP64 GEMM.
+    return (
+        (q.float().view(n // 128, 128, k // 128, 128) * scale[:, None, :, None])
+        .reshape(n, k)
+        .bfloat16()
+        .double()
+    )
+
+
+def digest_tensor(tensor):
+    return hashlib.sha256(
+        tensor.contiguous().view(torch.uint8).numpy().tobytes()
+    ).hexdigest()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--layers", type=int, nargs="+", default=[3, 23, 44])
+    parser.add_argument("--batches", type=int, nargs="+", default=[1, 8, 16])
+    parser.add_argument("--rank", type=int, default=0)
+    parser.add_argument("--rounds", type=int, default=5)
+    parser.add_argument("--replays", type=int, default=16)
+    args = parser.parse_args()
+    if (
+        not 0 <= args.rank < 4
+        or min(args.rounds, args.replays) < 1
+        or any(not 3 <= layer <= 44 for layer in args.layers)
+        or any(not 1 <= batch <= 16 for batch in args.batches)
+    ):
+        parser.error("TP4 rank0..3, MoE layers3..44, batch1..16, positive counts")
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"], text=True
+    ).strip()
+    if active:
+        parser.error(f"GPU compute processes already active: {active}")
+    args.output.mkdir(parents=True, exist_ok=False)
+    record = args.output / "summary.json"
+    result = {
+        "status": "running",
+        "diagnostic_only": True,
+        "method": __doc__,
+        "command": sys.argv,
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "source_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        "l2_bytes": L2_BYTES,
+        "weights": [],
+        "cases": [],
+    }
+
+    def save():
+        record.write_text(json.dumps(result, indent=2) + "\n")
+
+    save()
+    try:
+        from vllm.quixicore.ops import quixicore_ops
+
+        torch.set_num_threads(4)
+        if torch.cuda.get_device_capability() != (12, 0):
+            raise ValueError("requires the SM120 128-MiB-L2 target")
+        result["gpu"] = torch.cuda.get_device_name()
+        with Path("vllm/_quixicore_C.cpython-312-x86_64-linux-gnu.so").open(
+            "rb"
+        ) as handle:
+            result["native_sha256"] = hashlib.file_digest(handle, "sha256").hexdigest()
+        sidecar = args.model / "fp8-swapset.safetensors"
+        for layer in args.layers:
+            for kind, (cpu_q, cpu_s) in load_weights(sidecar, layer, args.rank).items():
+                weight_bytes = cpu_q.numel() * cpu_q.element_size()
+                count = rotation_count(weight_bytes)
+                identity = {
+                    "layer": layer,
+                    "kind": kind,
+                    "shape": list(cpu_q.shape),
+                    "weight_sha256": digest_tensor(cpu_q),
+                    "scale_sha256": digest_tensor(cpu_s),
+                    "weight_bytes": weight_bytes,
+                    "old_rotation_bytes": 24 * weight_bytes,
+                    "streaming_copies": count,
+                    "streaming_weight_bytes": count * weight_bytes,
+                }
+                result["weights"].append(identity)
+                save()
+                banks = [(cpu_q.cuda(), cpu_s.cuda()) for _ in range(count)]
+                if len({q.data_ptr() for q, _ in banks}) != count:
+                    raise ValueError("weight rotation aliases allocations")
+                dequant = oracle_weight(cpu_q, cpu_s)
+                for batch in args.batches:
+                    generator = torch.Generator().manual_seed(3100 + layer * 31 + batch)
+                    cpu_x = torch.randn(
+                        batch, cpu_q.shape[1], generator=generator
+                    ).bfloat16()
+                    x = cpu_x.cuda()
+                    expected = cpu_x.double() @ dequant.t()
+                    eager = quixicore_ops.decode_gemm_fp8(x, *banks[0]).cpu()
+                    delta = eager.double() - expected
+                    nrms = float(
+                        delta.square().mean().sqrt()
+                        / expected.square().mean().sqrt().clamp_min(1e-30)
+                    )
+                    peak = float(
+                        (
+                            delta.abs()
+                            / expected.abs().amax(1, keepdim=True).clamp_min(1e-30)
+                        ).max()
+                    )
+                    row = {
+                        "layer": layer,
+                        "kind": kind,
+                        "batch": batch,
+                        "status": "running",
+                        "input_sha256": digest_tensor(cpu_x),
+                        "oracle_nrms": nrms,
+                        "oracle_row_peak_error": peak,
+                        "rounds": [],
+                    }
+                    result["cases"].append(row)
+                    save()
+                    if not torch.isfinite(eager).all() or nrms > 0.004 or peak > 2**-7:
+                        raise ValueError("independent FP64 GEMM oracle failed")
+                    graphs = {}
+                    for name, copies in (("old24", 24), ("streaming", count)):
+                        for _ in range(3):
+                            quixicore_ops.decode_gemm_fp8(x, *banks[0])
+                        torch.cuda.synchronize()
+                        graph = torch.cuda.CUDAGraph()
+                        with torch.cuda.graph(graph):
+                            outputs = [
+                                quixicore_ops.decode_gemm_fp8(x, *banks[i])
+                                for i in range(copies)
+                            ]
+                        graph.replay()
+                        torch.cuda.synchronize()
+                        if not all(torch.equal(out.cpu(), eager) for out in outputs):
+                            raise ValueError("rotation graph differs from eager")
+                        graphs[name] = (graph, outputs, copies)
+                    for repeat in range(args.rounds):
+                        sample = {"repeat": repeat + 1}
+                        row["rounds"].append(sample)
+                        for phase, name in (
+                            ("A", "old24"),
+                            ("B", "streaming"),
+                            ("A2", "old24"),
+                        ):
+                            graph, outputs, copies = graphs[name]
+                            # Changed inputs, exact equality: multiplication by -1.
+                            x.copy_(cpu_x if repeat % 2 == 0 else -cpu_x)
+                            graph.replay()
+                            torch.cuda.synchronize()
+                            begin, end = (
+                                torch.cuda.Event(enable_timing=True),
+                                torch.cuda.Event(enable_timing=True),
+                            )
+                            begin.record()
+                            for _ in range(args.replays):
+                                graph.replay()
+                            end.record()
+                            end.synchronize()
+                            sample[phase] = (
+                                begin.elapsed_time(end) * 1000 / (args.replays * copies)
+                            )
+                            expected_eager = eager if repeat % 2 == 0 else -eager
+                            if not all(
+                                torch.equal(out.cpu(), expected_eager)
+                                for out in outputs
+                            ):
+                                raise ValueError(
+                                    "changed-input rotation graph mismatch"
+                                )
+                            save()
+                    row["median_us"] = {
+                        phase: statistics.median(
+                            sample[phase] for sample in row["rounds"]
+                        )
+                        for phase in ("A", "B", "A2")
+                    }
+                    row["status"] = "complete"
+                    save()
+                    print(json.dumps(row), flush=True)
+                    del graphs, graph, outputs
+                del banks, dequant
+        result["status"] = "complete"
+    except BaseException as error:
+        result["status"], result["error"] = "failed", repr(error)
+        raise
+    finally:
+        save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_glm53_fp8_launch.py
+++ b/benchmarks/kernels/benchmark_glm53_fp8_launch.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Cold-working-set FP8 shared-expert launch sweep, not serving performance.
+
+Same installed baseline, actual TP4 checkpoint bytes and BF16 inputs as the
+cache control. Both A/A2 and B rotate distinct weight allocations exceeding
+three SM120 L2 capacities. Sweep existing kernel NT/warp/stage settings only.
+Independent FP64 oracle: NRMS <= .004 and per-row peak-normalized error <= 2^-7;
+every graph output must equal its eager variant on initial and changed inputs.
+All prescribed configurations and A/B/A samples are recorded. A candidate must
+also pass a routed-expert contention test and real-profile validation before
+any serving change: small isolated shared-expert wins can be completely hidden.
+"""
+
+import argparse
+import hashlib
+import json
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.benchmark_glm53_fp8_cache import (
+    digest_tensor,
+    load_weights,
+    oracle_weight,
+    rotation_count,
+)
+from benchmarks.kernels.benchmark_mhc_output_parallel import build
+
+CONFIGS = tuple((n, w, s) for n in (8, 16, 32) for w in (4, 8) for s in (4, 8))
+
+
+def parse_config(text):
+    try:
+        config = tuple(map(int, text.split(",")))
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("expected NT,WARPS,STAGES") from error
+    if config not in CONFIGS:
+        raise argparse.ArgumentTypeError("configuration is not in the fixed probe set")
+    return config
+
+
+def oracle_errors(value, expected):
+    if value.shape != expected.shape:
+        raise ValueError("oracle output shapes differ")
+    if not torch.isfinite(value).all() or not torch.isfinite(expected).all():
+        return {
+            "finite": False,
+            "normalized_rms": None,
+            "row_peak_error": None,
+            "passed": False,
+        }
+    delta = value.double() - expected
+    result = {
+        "finite": True,
+        "normalized_rms": float(
+            delta.square().mean().sqrt()
+            / expected.square().mean().sqrt().clamp_min(1e-30)
+        ),
+        "row_peak_error": float(
+            (delta.abs() / expected.abs().amax(1, keepdim=True).clamp_min(1e-30)).max()
+        ),
+    }
+    result["passed"] = (
+        result["finite"]
+        and result["normalized_rms"] <= 0.004
+        and result["row_peak_error"] <= 2**-7
+    )
+    return result
+
+
+def capture(call, x, banks, expected):
+    for _ in range(3):
+        call(x, *banks[0])
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        outputs = [call(x, q, scale) for q, scale in banks]
+    graph.replay()
+    if not torch.equal(
+        torch.stack(outputs), expected.expand(len(banks), *expected.shape)
+    ):
+        raise ValueError("initial rotation graph disagrees with its eager variant")
+    return graph, outputs
+
+
+def measure(graph, copies, replays):
+    for _ in range(3):
+        graph.replay()
+    start, end = (torch.cuda.Event(enable_timing=True) for _ in range(2))
+    start.record()
+    for _ in range(replays):
+        graph.replay()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) * 1000 / (copies * replays)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--build-dir", type=Path, required=True)
+    parser.add_argument("--build-only", action="store_true")
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--layers", type=int, nargs="+", default=[3, 23, 44])
+    parser.add_argument("--batches", type=int, nargs="+", default=[1, 8, 16])
+    parser.add_argument("--rank", type=int, default=0)
+    parser.add_argument("--configs", type=parse_config, nargs="+", default=CONFIGS)
+    parser.add_argument("--rounds", type=int, default=5)
+    parser.add_argument("--replays", type=int, default=16)
+    args = parser.parse_args()
+    if (
+        not 0 <= args.rank < 4
+        or min(args.rounds, args.replays) < 1
+        or any(not 3 <= layer <= 44 for layer in args.layers)
+        or any(not 1 <= batch <= 16 for batch in args.batches)
+        or len(set(args.configs)) != len(args.configs)
+    ):
+        parser.error("TP4 rank, target layers/batches, positive counts, unique configs")
+    if not args.build_only:
+        if args.output is None or args.output.exists():
+            parser.error("a run requires a new output directory")
+        active = subprocess.check_output(
+            ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"],
+            text=True,
+        ).strip()
+        if active:
+            parser.error(f"GPU compute processes already active: {active}")
+    extension = build(args.build_dir, name="fp8_launch_probe")
+    if args.build_only:
+        return
+    args.output.mkdir(parents=True)
+    record = args.output / "summary.json"
+    root = Path(__file__).resolve().parents[2]
+    sources = [
+        Path(__file__),
+        Path(__file__).with_name("fp8_launch_probe.cu"),
+        Path(__file__).with_name("benchmark_glm53_fp8_cache.py"),
+        Path(__file__).with_name("benchmark_mhc_output_parallel.py"),
+        root / "csrc/quixicore/serving/fp8_decode_gemm.cuh",
+        root / "csrc/quixicore/serving/bf16_decode_gemm.cuh",
+    ]
+    result = {
+        "status": "running",
+        "diagnostic_only": True,
+        "method": __doc__,
+        "command": sys.argv,
+        "settings": {
+            k: str(v) if isinstance(v, Path) else v for k, v in vars(args).items()
+        },
+        "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "git_status": subprocess.check_output(
+            ["git", "status", "--short"], text=True
+        ).strip(),
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "source_sha256": {
+            str(p.relative_to(root)): hashlib.sha256(p.read_bytes()).hexdigest()
+            for p in sources
+        },
+        "extension_sha256": hashlib.sha256(
+            Path(extension.__file__).read_bytes()
+        ).hexdigest(),
+        "weights": [],
+        "baseline_checks": [],
+        "cases": [],
+    }
+
+    def save():
+        record.write_text(json.dumps(result, indent=2) + "\n")
+
+    save()
+    try:
+        import vllm._quixicore_C as native
+
+        from vllm.quixicore.ops import quixicore_ops as qc
+
+        torch.set_num_threads(4)
+        if torch.cuda.get_device_capability() != (12, 0):
+            raise ValueError("requires the SM120 target with 128 MiB L2")
+        result["gpu"] = torch.cuda.get_device_name()
+        result["resources"] = extension.resources()
+        if {tuple(r["config"]) for r in result["resources"]} != set(CONFIGS):
+            raise ValueError("compiled and requested configuration sets disagree")
+        native_path = Path(native.__file__).resolve()
+        result["native_path"] = str(native_path)
+        with native_path.open("rb") as handle:
+            result["native_sha256"] = hashlib.file_digest(handle, "sha256").hexdigest()
+        for layer in args.layers:
+            weights = load_weights(
+                args.model / "fp8-swapset.safetensors", layer, args.rank
+            )
+            for kind, (cpu_q, cpu_s) in weights.items():
+                count = rotation_count(cpu_q.numel() * cpu_q.element_size())
+                result["weights"].append(
+                    {
+                        "layer": layer,
+                        "kind": kind,
+                        "rank": args.rank,
+                        "shape": list(cpu_q.shape),
+                        "weight_sha256": digest_tensor(cpu_q),
+                        "scale_sha256": digest_tensor(cpu_s),
+                        "copies": count,
+                        "weight_bytes": count * cpu_q.numel() * cpu_q.element_size(),
+                    }
+                )
+                save()
+                banks = [(cpu_q.cuda(), cpu_s.cuda()) for _ in range(count)]
+                if len({q.data_ptr() for q, _ in banks}) != count:
+                    raise ValueError("weight rotation aliases allocations")
+                dequant = oracle_weight(cpu_q, cpu_s)
+                for batch in args.batches:
+                    generator = torch.Generator().manual_seed(3100 + layer * 31 + batch)
+                    cpu_x = torch.randn(
+                        batch, cpu_q.shape[1], generator=generator
+                    ).bfloat16()
+                    x = cpu_x.cuda()
+                    expected = cpu_x.double() @ dequant.t()
+                    baseline_row = {
+                        "layer": layer,
+                        "kind": kind,
+                        "batch": batch,
+                        "input_sha256": digest_tensor(cpu_x),
+                        "status": "checking",
+                    }
+                    result["baseline_checks"].append(baseline_row)
+                    save()
+                    installed = qc.decode_gemm_fp8(x, *banks[0])
+                    baseline_errors = oracle_errors(installed.cpu(), expected)
+                    baseline_row["oracle"] = baseline_errors
+                    if not baseline_errors["passed"]:
+                        baseline_row["status"] = "failed"
+                        raise ValueError(
+                            f"installed baseline fails oracle: {baseline_errors}"
+                        )
+                    baseline_row["isolated_auto_exact"] = torch.equal(
+                        installed, extension.run(x, *banks[0], 0, 0, 0)
+                    )
+                    if not baseline_row["isolated_auto_exact"]:
+                        baseline_row["status"] = "failed"
+                        raise ValueError(
+                            "isolated auto config differs from installed serving"
+                        )
+                    baseline_row["status"] = "complete"
+                    save()
+                    a_graph, a_outputs = capture(
+                        qc.decode_gemm_fp8, x, banks, installed
+                    )
+                    for config in args.configs:
+                        x.copy_(cpu_x)
+
+                        def candidate(activation, q, scales, config=config):
+                            return extension.run(activation, q, scales, *config)
+
+                        eager = candidate(x, *banks[0])
+                        row = {
+                            "layer": layer,
+                            "kind": kind,
+                            "batch": batch,
+                            "config": config,
+                            "input_sha256": digest_tensor(cpu_x),
+                            "status": "checking",
+                            "baseline_oracle": baseline_errors,
+                            "candidate_oracle": oracle_errors(eager.cpu(), expected),
+                            "rounds": [],
+                        }
+                        result["cases"].append(row)
+                        save()
+                        if not row["candidate_oracle"]["passed"]:
+                            raise ValueError("candidate fails independent FP64 oracle")
+                        b_graph, b_outputs = capture(candidate, x, banks, eager)
+                        for repeat in range(args.rounds):
+                            x.copy_(cpu_x if repeat % 2 == 0 else -cpu_x)
+                            sample = {"repeat": repeat + 1}
+                            row["rounds"].append(sample)
+                            for phase, graph, outputs, reference in (
+                                ("A", a_graph, a_outputs, installed),
+                                ("B", b_graph, b_outputs, eager),
+                                ("A2", a_graph, a_outputs, installed),
+                            ):
+                                sample[phase] = measure(graph, count, args.replays)
+                                ref = reference if repeat % 2 == 0 else -reference
+                                if not torch.equal(
+                                    torch.stack(outputs), ref.expand(count, *ref.shape)
+                                ):
+                                    raise ValueError(
+                                        "changed-input graph/eager mismatch"
+                                    )
+                                save()
+                        row["median_us"] = {
+                            phase: statistics.median(r[phase] for r in row["rounds"])
+                            for phase in ("A", "B", "A2")
+                        }
+                        row["median_paired_throughput_change_pct"] = statistics.median(
+                            (0.5 * (r["A"] + r["A2"]) / r["B"] - 1) * 100
+                            for r in row["rounds"]
+                        )
+                        row["status"] = "complete"
+                        save()
+                        print(json.dumps(row), flush=True)
+                        del b_graph, b_outputs, graph, outputs
+                    del a_graph, a_outputs
+                del banks, dequant
+        result["status"] = "complete"
+    except BaseException as error:
+        result["status"], result["error"] = "failed", repr(error)
+        raise
+    finally:
+        save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_glm53_kda_core.py
+++ b/benchmarks/kernels/benchmark_glm53_kda_core.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 4.2: one full-head conv/KDA/norm fusion, complete-window comparison.
+
+Reuses the completed prefetch experiment's actual-weight windows, without any
+prefetch. 51 allocations exceed3xL2. Fixed eight-warps/full-head ownership;
+no tile sweep. FP32 recurrent state, BF16 conv state, original projections.
+"""
+
+import argparse
+import hashlib
+import json
+import statistics
+import subprocess
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.benchmark_glm53_kda_prefetch import (
+    load_weights,
+    reset_states,
+    window,
+)
+from benchmarks.kernels.benchmark_glm53_marlin_schedule import measure
+from benchmarks.kernels.glm53_kda_core import core
+from vllm.model_executor.layers.mamba.ops.causal_conv1d import causal_conv1d_update
+from vllm.models.kimi_k3.nvidia.ops.third_party.kda import (
+    fused_recurrent_kda_packed_decode,
+)
+from vllm.quixicore.ops import quixicore_ops
+
+
+def fused_window(weights, inputs, state, indices, output):
+    batch = inputs.shape[0]
+    mixed, beta, fg_a = inputs.split([6144, 128, 256], dim=-1)
+    fg_a = fg_a.view(batch, 2, 128).transpose(0, 1)
+    g1, g2 = torch.bmm(fg_a, weights["fg"].transpose(1, 2)).unbind(0)
+    normalized = torch.empty(batch, 2048, dtype=inputs.dtype, device=inputs.device)
+    kernel = core(mixed, g1, g2, beta, weights, *state, indices, normalized)
+    output.copy_(
+        quixicore_ops.decode_gemm_fp8(
+            normalized,
+            weights["weight"],
+            weights["scale"],
+        )
+    )
+    return kernel
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    if args.output.exists():
+        parser.error("output must be NEW")
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"],
+        text=True,
+    ).strip()
+    if active:
+        parser.error(f"GPUs busy: {active}")
+    assert torch.cuda.get_device_capability() == (12, 0)
+    torch.manual_seed(4201)
+    cpu = [load_weights(args.model, layer) for layer in (0, 22, 44)]
+    banks = [
+        {name: value.cuda() for name, value in w.items()}
+        for _ in range(17)
+        for w in cpu
+    ]
+    result = {
+        "status": "running",
+        "roadmap": "4.2",
+        "diagnostic_only": True,
+        "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "source_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        "kernel_sha256": hashlib.sha256(
+            Path(__file__).with_name("glm53_kda_core.py").read_bytes()
+        ).hexdigest(),
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "cases": [],
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    def save():
+        args.output.write_text(json.dumps(result, indent=2) + "\n")
+
+    save()
+    try:
+        for batch in (1, 8, 16):
+            indices = torch.arange(1, batch + 1, device="cuda", dtype=torch.int32)
+            inputs = [
+                torch.randn(batch, 6528, device="cuda", dtype=torch.bfloat16)
+                for _ in banks
+            ]
+            initial = [
+                (
+                    torch.randn(
+                        batch + 1, 3, 6144, device="cuda", dtype=torch.bfloat16
+                    ).transpose(-1, -2),
+                    torch.randn(batch + 1, 16, 128, 128, device="cuda") * 0.1,
+                )
+                for _ in banks
+            ]
+            states = [
+                [tuple(s.clone() for s in pair) for pair in initial] for _ in range(2)
+            ]
+            outputs = [
+                [
+                    torch.empty(batch, 4096, device="cuda", dtype=torch.bfloat16)
+                    for _ in banks
+                ]
+                for _ in range(2)
+            ]
+            graphs = []
+            kernel = None
+            for arm, fn in enumerate((window, fused_window)):
+                for weights, x, state, out in zip(
+                    banks, inputs, states[arm], outputs[arm]
+                ):
+                    found = fn(weights, x, state, indices, out)
+                    if found is not None:
+                        kernel = found
+                torch.cuda.synchronize()
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph):
+                    for weights, x, state, out in zip(
+                        banks, inputs, states[arm], outputs[arm]
+                    ):
+                        fn(weights, x, state, indices, out)
+                graphs.append(graph)
+            checks = []
+            args.output.with_suffix(".core.ptx").write_text(kernel.asm["ptx"])
+            for changed in (False, True):
+                if changed:
+                    for x in inputs:
+                        x.mul_(0.5)
+                    indices.copy_(indices.flip(0))
+                    indices[0] = 0  # null slot: neither state may be written
+                for arm in range(2):
+                    reset_states(initial, states[arm])
+                    graphs[arm].replay()
+                torch.cuda.synchronize()
+                for index, (a, b) in enumerate(zip(outputs[0], outputs[1])):
+                    torch.testing.assert_close(b, a, rtol=0.01, atol=0.01)
+                    conv_a, state_a = states[0][index]
+                    conv_b, state_b = states[1][index]
+                    torch.testing.assert_close(conv_b, conv_a, rtol=0, atol=0)
+                    try:
+                        torch.testing.assert_close(
+                            state_b, state_a, rtol=1e-4, atol=1e-5
+                        )
+                    except AssertionError:
+                        mixed, beta, fg_a = inputs[index].split(
+                            [6144, 128, 256], dim=-1
+                        )
+                        g1, g2 = torch.bmm(
+                            fg_a.view(batch, 2, 128).transpose(0, 1),
+                            banks[index]["fg"].transpose(1, 2),
+                        ).unbind(0)
+                        conv_src, state_src = initial[index]
+                        conv_ref = causal_conv1d_update(
+                            mixed,
+                            conv_src.clone(),
+                            banks[index]["conv"],
+                            activation="silu",
+                            conv_state_indices=indices,
+                            validate_data=True,
+                            out=torch.empty_like(mixed),
+                        )
+                        conv_debug = torch.zeros_like(mixed)
+                        debug_state = state_src.clone()
+                        reference_state = state_src.clone()
+                        fused_recurrent_kda_packed_decode(
+                            conv_ref,
+                            g1.view(1, batch, 16, 128),
+                            beta[:, :16].unsqueeze(0),
+                            banks[index]["a_log"],
+                            banks[index]["dt_bias"],
+                            -5.0,
+                            reference_state,
+                            indices,
+                        )
+                        debug_kernel = core(
+                            mixed,
+                            g1,
+                            g2,
+                            beta,
+                            banks[index],
+                            conv_src.clone(),
+                            debug_state,
+                            indices,
+                            torch.empty(
+                                batch, 2048, device="cuda", dtype=torch.bfloat16
+                            ),
+                            debug=conv_debug,
+                        )
+                        torch.cuda.synchronize()
+                        result["failure_fixture"] = {
+                            "batch": batch,
+                            "index": index,
+                            "changed": changed,
+                            "conv_output_exact": torch.equal(conv_debug, conv_ref),
+                            "conv_max_abs": (conv_debug.float() - conv_ref.float())
+                            .abs()
+                            .max()
+                            .item(),
+                            "debug_state_max_abs": (debug_state - reference_state)
+                            .abs()
+                            .max()
+                            .item(),
+                        }
+                        torch.save(
+                            {
+                                "conv_reference": conv_ref.cpu(),
+                                "conv_candidate": conv_debug.cpu(),
+                                "state_reference": state_a.cpu(),
+                                "state_candidate": state_b.cpu(),
+                                "state_eager_reference": reference_state.cpu(),
+                                "state_eager_debug": debug_state.cpu(),
+                                "initial_state": state_src.cpu(),
+                                "raw_gate": g1.cpu(),
+                                "beta": beta.cpu(),
+                                "a_log": banks[index]["a_log"].cpu(),
+                                "dt_bias": banks[index]["dt_bias"].cpu(),
+                            },
+                            args.output.with_suffix(".failure.pt"),
+                        )
+                        args.output.with_suffix(".ptx").write_text(
+                            debug_kernel.asm["ptx"]
+                        )
+                        raise
+                    checks.append(
+                        {
+                            "fixture": index,
+                            "changed_input_null": changed,
+                            "output_max_abs": (a.float() - b.float())
+                            .abs()
+                            .max()
+                            .item(),
+                            "state_max_abs": (state_a - state_b).abs().max().item(),
+                            "conv_exact": torch.equal(conv_a, conv_b),
+                        }
+                    )
+            # Null-slot checks must not turn the timing workload into no-ops.
+            indices.copy_(torch.arange(1, batch + 1, device="cuda", dtype=torch.int32))
+            samples = []
+            for _ in range(3):
+                sample = {}
+                for name, arm in (("before", 0), ("candidate", 1), ("after", 0)):
+                    reset_states(initial, states[arm])
+                    sample[name] = measure(graphs[arm], len(banks), 10)
+                samples.append(sample)
+            row = {
+                "batch": batch,
+                "checks": checks,
+                "samples_us": samples,
+                "median_us": {
+                    k: statistics.median(s[k] for s in samples) for k in samples[0]
+                },
+                "registers": kernel.n_regs,
+                "spills": kernel.n_spills,
+            }
+            result["cases"].append(row)
+            print({k: v for k, v in row.items() if k != "checks"}, flush=True)
+            save()
+            del graphs, outputs, states, initial, inputs
+        result["status"] = "complete"
+    except Exception as error:
+        result.update(status="failed", error=repr(error))
+        raise
+    finally:
+        save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_glm53_kda_core.py
+++ b/benchmarks/kernels/benchmark_glm53_kda_core.py
@@ -3,7 +3,7 @@
 """Phase 4.2: one full-head conv/KDA/norm fusion, complete-window comparison.
 
 Reuses the completed prefetch experiment's actual-weight windows, without any
-prefetch. 51 allocations exceed3xL2. Fixed eight-warps/full-head ownership;
+prefetch. 51 allocations exceed 3x L2. Fixed eight-warps/full-head ownership;
 no tile sweep. FP32 recurrent state, BF16 conv state, original projections.
 """
 
@@ -72,6 +72,8 @@ def main():
         "status": "running",
         "roadmap": "4.2",
         "diagnostic_only": True,
+        "method": __doc__,
+        "recipe": "glm53-redhatai-nvfp4-fp8-kda-tp4-v1",
         "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
         "source_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
         "kernel_sha256": hashlib.sha256(

--- a/benchmarks/kernels/benchmark_glm53_kda_fg_b.py
+++ b/benchmarks/kernels/benchmark_glm53_kda_fg_b.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 4.2 paired K128 projection, one fixed kernel versus serving strided bmm.
+
+Actual rank0 TP4 BF16 weights, original merged-input strides, synthetic inputs.
+Three checkpoint layers with 129 distinct copies each exceed three128MiB L2
+capacities. Three A/B/A rounds, ten replays; no geometry/configuration sweep.
+"""
+
+import argparse
+import hashlib
+import json
+import statistics
+import subprocess
+from functools import partial
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+from torch.utils.cpp_extension import load
+
+from benchmarks.kernels.benchmark_glm53_marlin_schedule import measure
+from benchmarks.kernels.benchmark_glm53_nvfp4_pipeline import capture
+from benchmarks.kernels.check_glm53_marlin_schedule import errors
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--build-dir", type=Path, required=True)
+    parser.add_argument("--model", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--build-only", action="store_true")
+    args = parser.parse_args()
+    if not args.build_only and (
+        not args.model or not args.output or args.output.exists()
+    ):
+        parser.error("model and NEW output required")
+    args.build_dir.mkdir(parents=True, exist_ok=True)
+    root = Path(__file__).resolve().parents[2]
+    ext = load(
+        name="glm53_kda_fg_b",
+        sources=[str(root / "benchmarks/kernels/kda_fg_b_decode.cu")],
+        extra_include_paths=[str(root / "csrc")],
+        extra_cflags=["-O3", "-std=c++20"],
+        extra_cuda_cflags=[
+            "-O3",
+            "-std=c++20",
+            "-lineinfo",
+            "-gencode=arch=compute_120f,code=sm_120f",
+            "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+        ],
+        build_directory=str(args.build_dir),
+        verbose=True,
+    )
+    if args.build_only:
+        return
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"], text=True
+    ).strip()
+    if active:
+        raise RuntimeError(f"GPUs busy: {active}")
+    if torch.cuda.get_device_capability() != (12, 0):
+        raise RuntimeError("SM120 required")
+    torch.set_num_threads(4)
+    torch.manual_seed(1142)
+    index = json.loads((args.model / "model.safetensors.index.json").read_text())[
+        "weight_map"
+    ]
+    weights = []
+    for layer in (0, 22, 44):
+        pair = []
+        for projection in ("f_b_proj", "g_b_proj"):
+            key = f"model.language_model.layers.{layer}.self_attn.{projection}.weight"
+            with safe_open(
+                args.model / index[key], framework="pt", device="cpu"
+            ) as source:
+                pair.append(source.get_tensor(key)[:2048].contiguous())
+        weight = torch.stack(pair)
+        if weight.shape != (2, 2048, 128) or weight.dtype != torch.bfloat16:
+            raise ValueError("unexpected fixed-recipe projection weight")
+        weights.append(weight)
+    result = {
+        "status": "running",
+        "roadmap": "4.2",
+        "diagnostic_only": True,
+        "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "method": __doc__,
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "gpu": torch.cuda.get_device_name(),
+        "cases": [],
+        "weight_sha256": [
+            hashlib.sha256(w.view(torch.uint8).numpy().tobytes()).hexdigest()
+            for w in weights
+        ],
+        "source_sha256": {
+            name: hashlib.sha256((root / name).read_bytes()).hexdigest()
+            for name in (
+                "benchmarks/kernels/benchmark_glm53_kda_fg_b.py",
+                "benchmarks/kernels/kda_fg_b_decode.cu",
+            "benchmarks/kernels/kda_fg_b_decode_sm120.cuh",
+            )
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    def save():
+        args.output.write_text(json.dumps(result, indent=2) + "\n")
+
+    save()
+    try:
+        banks = [weight.cuda() for _ in range(129) for weight in weights]
+        if len({w.data_ptr() for w in banks}) != 387:
+            raise RuntimeError("weight rotation must not alias")
+        for batch in (1, 8, 16):
+            base = torch.randn(batch, 6528, device="cuda", dtype=torch.bfloat16)
+            x = base[:, -256:].view(batch, 2, 128).transpose(0, 1)
+            row = {"batch": batch, "x_stride": list(x.stride()), "correctness": []}
+            for i, w in enumerate(banks[:3]):
+                a = torch.bmm(x, w.transpose(1, 2))
+                b = torch.empty_like(a)
+                ext.run(x, w, b)
+                expected = torch.bmm(
+                    x.cpu().double(), weights[i].double().transpose(1, 2)
+                ).bfloat16()
+                torch.testing.assert_close(b.cpu(), expected, rtol=0.01, atol=0.001)
+                torch.testing.assert_close(b, a, rtol=0.01, atol=0.001)
+                row["correctness"].append(
+                    {
+                        "versus_bmm": errors(b, a),
+                        "versus_fp64": errors(b.cpu(), expected),
+                    }
+                )
+            a_out = [
+                torch.empty(2, batch, 2048, device="cuda", dtype=torch.bfloat16)
+                for _ in banks
+            ]
+            b_out = [torch.empty_like(out) for out in a_out]
+            a = capture(
+                [
+                    partial(torch.bmm, x, w.transpose(1, 2), out=out)
+                    for w, out in zip(banks, a_out)
+                ]
+            )
+            b = capture([partial(ext.run, x, w, out) for w, out in zip(banks, b_out)])
+            # Changed input also exercises the captured strided read, not a baked value.
+            x.mul_(0.5)
+            a.replay()
+            b.replay()
+            for av, bv in zip(a_out, b_out):
+                torch.testing.assert_close(bv, av, rtol=0.01, atol=0.001)
+            samples = []
+            for _ in range(3):
+                samples.append(
+                    {
+                        "before_us": measure(a, len(banks), 10),
+                        "candidate_us": measure(b, len(banks), 10),
+                        "after_us": measure(a, len(banks), 10),
+                    }
+                )
+            row["samples"] = samples
+            row["median_us"] = {
+                k: statistics.median(s[k] for s in samples) for k in samples[0]
+            }
+            result["cases"].append(row)
+            print(row, flush=True)
+            save()
+            del a, b, a_out, b_out
+        result["status"] = "complete"
+    except BaseException as error:
+        result["status"] = "failed"
+        result["error"] = str(error)
+        raise
+    finally:
+        save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_glm53_kda_prefetch.py
+++ b/benchmarks/kernels/benchmark_glm53_kda_prefetch.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 2.3: one fixed output-weight prefetch, complete KDA decode window.
+
+Actual TP4 rank0 weights from layers 0/22/44, synthetic merged inputs/states.
+51 independent 8 MiB output weights exceed three SM120 L2 capacities. Original
+fg_b bmm -> conv -> state-updating KDA -> copy -> gated norm -> FP8 o_proj -> copy.
+One side-stream fork per window; one join per graph, not per layer. The input
+projection and TP output all-reduce are outside this component-window probe.
+Three A/B/A rounds, ten graph replays, M1/8/16; no geometry or budget sweep.
+No serving implementation, arithmetic change, installed binary or profile change.
+"""
+
+import argparse
+import hashlib
+import json
+import statistics
+import subprocess
+from pathlib import Path
+
+import torch
+import triton
+import triton.language as tl
+from safetensors import safe_open
+
+from benchmarks.kernels.benchmark_glm53_marlin_schedule import measure
+from vllm.model_executor.layers.mamba.mamba_utils import (
+    MambaStateDtypeCalculator,
+    get_conv_state_layout,
+)
+from vllm.model_executor.layers.mamba.ops.causal_conv1d import causal_conv1d_update
+from vllm.models.kimi_k3.nvidia.ops.third_party.kda import (
+    fused_recurrent_kda_packed_decode,
+)
+from vllm.quixicore.ops import quixicore_ops
+from vllm.third_party.flash_linear_attention.ops.kda import rms_norm_gated
+
+
+@triton.jit
+def prefetch_output_weight(weight):
+    # #576 mechanism: read-only cache hints, no value or synchronization output.
+    # 16 CTAs x 128 lanes x 4 KiB covers exactly the contiguous 8 MiB FP8 weight.
+    offset = (tl.program_id(0) * 128 + tl.arange(0, 128)) * 4096
+    tl.inline_asm_elementwise(
+        """{
+        .reg .b64 policy;
+        createpolicy.fractional.L2::evict_last.b64 policy, 1.0;
+        cp.async.bulk.prefetch.L2.global.L2::cache_hint [$1], 4096, policy;
+        mov.u32 $0, 0;
+        }""",
+        constraints="=r,l",
+        args=[weight + offset],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+def load_weights(model, layer):
+    index = json.loads((model / "model.safetensors.index.json").read_text())[
+        "weight_map"
+    ]
+    prefix = f"model.language_model.layers.{layer}.self_attn."
+
+    def get(name, artifact=None):
+        key = prefix + name
+        with safe_open(
+            model / (artifact or index[key]), framework="pt", device="cpu"
+        ) as f:
+            return f.get_tensor(key)
+
+    weight = get("o_proj.weight", "fp8-swapset.safetensors")[:, :2048].contiguous()
+    scale = get("o_proj.weight_scale", "fp8-swapset.safetensors")[:, :16].contiguous()
+    assert weight.shape == (4096, 2048) and weight.dtype == torch.float8_e4m3fn
+    assert scale.shape == (32, 16) and scale.dtype == torch.float32
+    return {
+        "weight": weight,
+        "scale": scale,
+        "fg": torch.stack([get(f"{p}_b_proj.weight")[:2048] for p in ("f", "g")]),
+        "conv": torch.cat(
+            [get(f"{p}_conv1d.weight")[:2048].reshape(2048, 4) for p in ("q", "k", "v")]
+        ),
+        "norm": get("o_norm.weight"),
+        "a_log": get("A_log", "f32-overrides.safetensors")[:16].contiguous(),
+        "dt_bias": get("dt_bias", "f32-overrides.safetensors")[:2048].contiguous(),
+    }
+
+
+def window(weights, inputs, state, indices, output):
+    batch = inputs.shape[0]
+    mixed, beta, fg_a = inputs.split([6144, 128, 256], dim=-1)
+    fg_a = fg_a.view(batch, 2, 128).transpose(0, 1)
+    fg_b = torch.bmm(fg_a, weights["fg"].transpose(1, 2))
+    g1, g2 = fg_b.unbind(0)
+    conv_state, recurrent_state = state
+    mixed = causal_conv1d_update(
+        mixed,
+        conv_state,
+        weights["conv"],
+        activation="silu",
+        conv_state_indices=indices,
+        validate_data=True,
+        out=torch.empty_like(mixed),
+    )
+    core, _ = fused_recurrent_kda_packed_decode(
+        mixed,
+        g1.view(1, batch, 16, 128),
+        beta[:, :16].unsqueeze(0),
+        weights["a_log"],
+        weights["dt_bias"],
+        -5.0,
+        recurrent_state,
+        indices,
+    )
+    # Match the opaque attention op's placement into the caller-owned buffer.
+    placed = torch.empty_like(core)
+    placed.copy_(core)
+    # FusedRMSNormGated defaults to 1e-5 in the actual KDA constructor.
+    placed.copy_(
+        rms_norm_gated(
+            placed,
+            g2.view(batch, 16, 128),
+            weights["norm"],
+            None,
+            activation="sigmoid",
+            eps=1e-5,
+        )
+    )
+    output.copy_(
+        quixicore_ops.decode_gemm_fp8(
+            placed.view(batch, 2048),
+            weights["weight"],
+            weights["scale"],
+        )
+    )
+
+
+def capture(banks, inputs, states, indices, outputs, prefetch):
+    compute, side = torch.cuda.Stream(), torch.cuda.Stream()
+    compute.wait_stream(torch.cuda.current_stream())
+
+    def run():
+        for weights, x, state, out in zip(banks, inputs, states, outputs):
+            if prefetch:
+                side.wait_stream(compute)
+                with torch.cuda.stream(side):
+                    prefetch_output_weight[(16,)](weights["weight"], num_warps=4)
+            window(weights, x, state, indices, out)
+        if prefetch:
+            compute.wait_stream(side)
+
+    with torch.cuda.stream(compute):
+        run()
+    torch.cuda.current_stream().wait_stream(compute)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=compute):
+        run()
+    return graph
+
+
+def reset_states(initial, states):
+    for src, dst in zip(initial, states):
+        for sv, dv in zip(src, dst):
+            dv.copy_(sv)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    if args.output.exists():
+        parser.error("a NEW output is required")
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"],
+        text=True,
+    ).strip()
+    if active:
+        raise RuntimeError(f"GPUs busy: {active}")
+    assert torch.cuda.get_device_capability() == (12, 0)
+    assert get_conv_state_layout() == "SD"
+    assert MambaStateDtypeCalculator.kda_state_dtype(torch.bfloat16, "auto") == (
+        torch.bfloat16,
+        torch.float32,
+    )
+    torch.set_num_threads(4)
+    torch.manual_seed(2301)
+    cpu = [load_weights(args.model, layer) for layer in (0, 22, 44)]
+    banks = [
+        {name: value.cuda() for name, value in w.items()}
+        for _ in range(17)
+        for w in cpu
+    ]
+    assert len({w["weight"].data_ptr() for w in banks}) == 51
+    result = {
+        "status": "running",
+        "roadmap": "2.3",
+        "method": __doc__,
+        "recipe": "glm53-redhatai-nvfp4-fp8-kda-tp4-v1",
+        "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "source_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        "weight_sha256": [
+            {
+                k: hashlib.sha256(v.view(torch.uint8).numpy().tobytes()).hexdigest()
+                for k, v in w.items()
+            }
+            for w in cpu
+        ],
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "gpu": torch.cuda.get_device_name(),
+        "state_dtype": "float32",
+        "output_weight_bytes": 51 * 8 * 1024 * 1024,
+        "cases": [],
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    def save():
+        args.output.write_text(json.dumps(result, indent=2) + "\n")
+
+    save()
+    try:
+        kernel = prefetch_output_weight[(16,)](banks[0]["weight"], num_warps=4)
+        assert "cp.async.bulk.prefetch.L2.global.L2::cache_hint" in kernel.asm["ptx"]
+        args.output.with_suffix(".prefetch.ptx").write_text(kernel.asm["ptx"])
+        for batch in (1, 8, 16):
+            indices = torch.arange(1, batch + 1, device="cuda", dtype=torch.int32)
+            inputs = [
+                torch.randn(batch, 6528, device="cuda", dtype=torch.bfloat16)
+                for _ in banks
+            ]
+            initial = [
+                (
+                    torch.randn(
+                        batch + 1, 3, 6144, device="cuda", dtype=torch.bfloat16
+                    ).transpose(-1, -2),
+                    torch.randn(batch + 1, 16, 128, 128, device="cuda") * 0.1,
+                )
+                for _ in banks
+            ]
+            states = [
+                [tuple(s.clone() for s in pair) for pair in initial] for _ in range(2)
+            ]
+            outputs = [
+                [
+                    torch.empty(batch, 4096, device="cuda", dtype=torch.bfloat16)
+                    for _ in banks
+                ]
+                for _ in range(2)
+            ]
+            graphs = [
+                capture(banks, inputs, states[i], indices, outputs[i], bool(i))
+                for i in range(2)
+            ]
+
+            # Both initial and changed-input replays must match every output/state bit.
+            for check in range(2):
+                if check:
+                    for x in inputs:
+                        x.mul_(0.5)
+                    indices.copy_(indices.flip(0))
+                for i in range(2):
+                    reset_states(initial, states[i])
+                    graphs[i].replay()
+                for a, b in zip(outputs[0], outputs[1]):
+                    assert torch.isfinite(a).all().item()
+                    torch.testing.assert_close(b, a, rtol=0, atol=0)
+                for a, b in zip(states[0], states[1]):
+                    for av, bv in zip(a, b):
+                        assert torch.isfinite(av).all().item()
+                        torch.testing.assert_close(bv, av, rtol=0, atol=0)
+            samples = []
+            for _ in range(3):
+                sample = {}
+                for name, i in (("before_us", 0), ("candidate_us", 1), ("after_us", 0)):
+                    reset_states(initial, states[i])
+                    sample[name] = measure(graphs[i], len(banks), 10)
+                samples.append(sample)
+            row = {
+                "batch": batch,
+                "exact_output_state_checks": 102,
+                "samples": samples,
+                "median_us": {
+                    k: statistics.median(s[k] for s in samples) for k in samples[0]
+                },
+                "conv_stride": list(initial[0][0].stride()),
+            }
+            result["cases"].append(row)
+            print(json.dumps(row), flush=True)
+            save()
+            del graphs, outputs, states, initial, inputs
+        result["status"] = "complete"
+    except BaseException as error:
+        result["status"] = "failed"
+        result["error"] = str(error)
+        raise
+    finally:
+        save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_glm53_marlin_prefill.py
+++ b/benchmarks/kernels/benchmark_glm53_marlin_prefill.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Large-prefill Marlin tile A/B/A, actual NVFP4 weights, synthetic inputs/routes.
+
+Reuses the decode probe's preparation, correctness and timing. This is a kernel
+screen, not serving performance. The full expert weight set exceeds SM120 L2.
+"""
+
+import argparse
+import gc
+import hashlib
+import json
+import os
+import statistics
+import subprocess
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.benchmark_glm53_marlin_schedule import (
+    capture,
+    correctness,
+    measure,
+    parse_config,
+    prepare_case,
+)
+from benchmarks.kernels.check_glm53_marlin_schedule import errors, oracle
+from benchmarks.kernels.profile_glm53_marlin import load_layer
+
+
+def parse_prefill_config(value):
+    if value == "64,512,1":
+        return 64, 512, 1
+    return parse_config(value)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--layers", type=int, nargs="+", default=[3])
+    parser.add_argument("--batch", type=int, nargs="+", default=[7616])
+    parser.add_argument("--rounds", type=int, default=3)
+    parser.add_argument("--replays", type=int, default=5)
+    parser.add_argument("--rank", type=int, default=0)
+    parser.add_argument("--block-sizes", type=int, nargs="+", default=[32, 48, 64])
+    parser.add_argument("--stages", type=int, choices=[2, 3, 4])
+    parser.add_argument("--build-dir", type=Path)
+    parser.add_argument("--build-only", action="store_true")
+    parser.add_argument("--pipeline", action="store_true")
+    parser.add_argument("--oracle", action="store_true")
+    parser.add_argument("--check-only", action="store_true")
+    parser.add_argument("--installed-wide", action="store_true")
+    parser.add_argument(
+        "--configs",
+        type=parse_prefill_config,
+        nargs="+",
+        default=[
+            (64, 256, 1),
+            (64, 128, 1),
+            (64, 128, 2),
+            (128, 64, 1),
+            (128, 128, 1),
+        ],
+    )
+    args = parser.parse_args()
+    if args.output.exists() or not 0 <= args.rank < 4:
+        parser.error("new output path and rank 0..3 required")
+    if min(args.rounds, args.replays, *args.batch) < 1 or max(args.batch) > 7616:
+        parser.error("positive counts and batches <=7616 required")
+    if any(not 3 <= layer <= 44 for layer in args.layers):
+        parser.error("target layers 3..44 required")
+    if any(b not in (8, 16, 32, 48, 64) for b in args.block_sizes):
+        parser.error("block sizes must be in 8/16/32/48/64")
+    if args.oracle and not args.pipeline:
+        parser.error("--oracle requires --pipeline")
+    if args.installed_wide and (
+        os.environ.get("VLLM_GLM53_MARLIN_PREFILL_WIDE") != "1"
+        or args.stages != 3
+        or not args.pipeline
+        or args.configs != [(64, 512, 1)]
+    ):
+        parser.error("installed-wide requires flag1, stages3, pipeline and K64/N512/1")
+    extension = None
+    if args.stages is not None:
+        if args.build_dir is None or args.block_sizes != [64]:
+            parser.error("stage experiment requires --build-dir and --block-sizes 64")
+        from torch.utils.cpp_extension import load
+
+        args.build_dir.mkdir(parents=True, exist_ok=True)
+        extension = load(
+            name="marlin_prefill_stages",
+            sources=[
+                str(Path(__file__).with_name("marlin_prefill_stages.cu").resolve())
+            ],
+            extra_include_paths=[str(Path(__file__).resolve().parents[2] / "csrc")],
+            extra_cflags=["-O3", "-std=c++20"],
+            extra_cuda_cflags=[
+                "-O3",
+                "-std=c++20",
+                "-lineinfo",
+                "--expt-relaxed-constexpr",
+                "--expt-extended-lambda",
+                "-static-global-template-stub=false",
+                "-gencode=arch=compute_120f,code=sm_120f",
+                "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+            ],
+            build_directory=str(args.build_dir),
+            verbose=True,
+        )
+        if args.build_only:
+            return
+    elif args.build_only:
+        parser.error("--build-only requires --stages")
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"], text=True
+    ).strip()
+    if active:
+        parser.error(f"GPUs busy: {active}")
+    torch.manual_seed(103)
+    from vllm import _custom_ops as ops
+
+    def gemm(*pos, **kw):
+        if args.installed_wide:
+            kw.update(thread_k=-1, thread_n=-1, blocks_per_sm=-1)
+            return ops.moe_wna16_marlin_gemm(*pos, **kw)
+        if extension is None or kw["thread_k"] == -1:
+            return ops.moe_wna16_marlin_gemm(*pos, **kw)
+        if kw["thread_k"] != 64 or kw["moe_block_size"] != 64:
+            raise ValueError("pipeline probe requires K64/M64 tiles")
+        return extension.run(
+            pos[0],
+            pos[1],
+            pos[2],
+            pos[4],
+            pos[6],
+            pos[10],
+            pos[11],
+            pos[12],
+            pos[13],
+            pos[14],
+            kw["top_k"],
+            kw["mul_topk_weights"],
+            kw["thread_n"],
+            kw["blocks_per_sm"],
+            args.stages,
+        )
+
+    def baseline_gemm(*pos, **kw):
+        if args.installed_wide and kw["moe_block_size"] == 64:
+            # Explicit schedules bypass the new dispatcher; this is the measured
+            # installed auto baseline for all tested M64 target shapes.
+            kw.update(thread_k=64, thread_n=256, blocks_per_sm=1)
+        return ops.moe_wna16_marlin_gemm(*pos, **kw)
+
+    result = {
+        "status": "running",
+        "diagnostic_only": True,
+        "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "source_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "gpu": torch.cuda.get_device_name(),
+        "native_sha256": hashlib.sha256(
+            (
+                Path(__file__).resolve().parents[2]
+                / "vllm/_moe_C_stable_libtorch.abi3.so"
+            ).read_bytes()
+        ).hexdigest(),
+        "probe_sha256": hashlib.sha256(
+            Path(extension.__file__).read_bytes()
+        ).hexdigest()
+        if extension is not None
+        else None,
+        "settings": {
+            k: str(v) if isinstance(v, Path) else v for k, v in vars(args).items()
+        },
+        "layers": {},
+        "measurements": [],
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    def save():
+        args.output.write_text(json.dumps(result, indent=2) + "\n")
+
+    save()
+    try:
+        for layer in args.layers:
+            weights, identity = load_layer(args.model, layer, args.rank)
+            result["layers"][layer] = identity
+            print(f"Loaded actual layer {layer} weights", flush=True)
+            for batch in args.batch:
+                block_size = next(
+                    (b for b in [8, 16, 32, 48, 64] if batch * 8 / 288 / b < 0.9), 64
+                )
+                for routing in ("uniform", "skewed"):
+                    generator = torch.Generator().manual_seed(7103 + batch)
+                    logits = torch.randn(batch, 288, generator=generator)
+                    if routing == "skewed":
+                        logits[:, :32] += 2
+                    ids = logits.topk(8, dim=-1).indices.tolist()
+                    record = {"routes": [[row] * 42 for row in ids], "step": 0}
+                    reference = prepare_case(
+                        weights,
+                        batch,
+                        record,
+                        layer,
+                        block_size=block_size,
+                        gemm=baseline_gemm,
+                    )
+                    for phase in ("moe",) if args.pipeline else ("gate_up", "down"):
+                        auto = ((-1, -1, -1),) * 2 if args.pipeline else (-1, -1, -1)
+                        baseline = (
+                            None
+                            if args.check_only
+                            else capture([reference], phase, auto)
+                        )
+                        for candidate_block, config in (
+                            (b, c) for b in args.block_sizes for c in args.configs
+                        ):
+                            if args.pipeline:
+                                config = (config, config)
+                            case = prepare_case(
+                                weights,
+                                batch,
+                                record,
+                                layer,
+                                block_size=candidate_block,
+                                gemm=gemm,
+                                alignment=reference["alignment"]
+                                if candidate_block == block_size
+                                else None,
+                            )
+                            case["input"].copy_(reference["input"])
+                            case["outputs"]["activation"].copy_(
+                                reference["outputs"]["activation"]
+                            )
+                            case["refs"] = reference["refs"]
+                            row = {
+                                "layer": layer,
+                                "batch": batch,
+                                "routing": routing,
+                                "baseline_block_size": block_size,
+                                "block_size": candidate_block,
+                                "phase": phase,
+                                "config": config,
+                                "samples": [],
+                            }
+                            result["measurements"].append(row)
+                            try:
+                                row["correctness"] = correctness([case], phase, config)
+                                if args.installed_wide:
+                                    w13, s13, g13, w2, s2, g2, workspace = weights
+                                    for name, a, w, s, g, topk in (
+                                        ("gate_up", case["input"], w13, s13, g13, 8),
+                                        (
+                                            "down",
+                                            case["outputs"]["activation"],
+                                            w2,
+                                            s2,
+                                            g2,
+                                            1,
+                                        ),
+                                    ):
+                                        actual = case["outputs"][name]
+                                        expected = extension.run(
+                                            a,
+                                            torch.empty_like(actual),
+                                            w,
+                                            s,
+                                            g,
+                                            workspace,
+                                            *case["alignment"],
+                                            case["routing_weights"],
+                                            topk,
+                                            topk == 1,
+                                            512,
+                                            1,
+                                            3,
+                                        )
+                                        if not torch.equal(actual, expected):
+                                            raise AssertionError(
+                                                f"native/probe mismatch: {name}"
+                                            )
+                                    row["native_probe_exact"] = True
+                                if args.oracle:
+                                    selected = [0, batch // 2, batch - 1]
+                                    expected = oracle(
+                                        args.model,
+                                        layer,
+                                        args.rank,
+                                        [ids[i] for i in selected],
+                                        case["input"][selected].cpu(),
+                                        case["routing_weights"][selected].cpu(),
+                                    )
+                                    row["oracle"] = {}
+                                    for name in ("gate_up", "activation", "moe"):
+                                        got = (
+                                            case["outputs"][name]
+                                            .view(batch, 8, -1)[selected]
+                                            .flatten(0, 1)
+                                            .cpu()
+                                        )
+                                        row["oracle"][name] = errors(
+                                            got, expected[name]
+                                        )
+                                        torch.testing.assert_close(
+                                            got, expected[name], rtol=0.01, atol=0.01
+                                        )
+                                if args.check_only:
+                                    row["status"] = "checked"
+                                    save()
+                                    print(json.dumps(row), flush=True)
+                                    del case
+                                    continue
+                                candidate = capture([case], phase, config)
+                            except RuntimeError as error:
+                                if not any(
+                                    s in str(error)
+                                    for s in (
+                                        "Invalid thread config",
+                                        "Unsupported shapes",
+                                    )
+                                ):
+                                    raise
+                                row.update(status="unsupported", error=str(error))
+                                save()
+                                del case
+                                continue
+                            for _ in range(args.rounds):
+                                row["samples"].append(
+                                    {
+                                        name: measure(graph, 1, args.replays)
+                                        for name, graph in (
+                                            ("a_before_us", baseline),
+                                            ("b_us", candidate),
+                                            ("a_after_us", baseline),
+                                        )
+                                    }
+                                )
+                            row["median_us"] = {
+                                k: statistics.median(s[k] for s in row["samples"])
+                                for k in row["samples"][0]
+                            }
+                            row["paired_speedup"] = statistics.median(
+                                (s["a_before_us"] + s["a_after_us"]) / (2 * s["b_us"])
+                                for s in row["samples"]
+                            )
+                            row["status"] = "complete"
+                            print(
+                                json.dumps(
+                                    {
+                                        k: v
+                                        for k, v in row.items()
+                                        if k not in ("correctness", "samples")
+                                    }
+                                ),
+                                flush=True,
+                            )
+                            save()
+                            del candidate
+                            del case
+                        del baseline
+                    del reference
+                    gc.collect()
+                    torch.cuda.empty_cache()
+            del weights
+        result["status"] = "complete"
+    except BaseException as error:
+        result.update(status="failed", error=repr(error))
+        raise
+    finally:
+        save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_glm53_marlin_schedule.py
+++ b/benchmarks/kernels/benchmark_glm53_marlin_schedule.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Isolated A/B/A of existing Marlin launch controls, never a serving benchmark.
+
+Uses actual TP4 quant bytes and predetermined captured routes. Activations are
+synthetic; down inputs come from the unchanged serving gate/up and activation.
+Rotates distinct layers/routes rather than timing one cache-hot expert matrix.
+No quantization, native binary, serving dispatcher or clock changes are made.
+"""
+
+import argparse
+import hashlib
+import json
+import statistics
+import subprocess
+from collections import defaultdict
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.profile_glm53_marlin import load_layer, route_cases
+
+
+def parse_config(value):
+    if value == "auto":
+        return (-1, -1, -1)
+    try:
+        k, n, blocks = map(int, value.split(","))
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("expected K,N,blocks or auto") from error
+    if (k, n) not in ((64, 128), (128, 64), (128, 128), (64, 256)):
+        raise argparse.ArgumentTypeError("tile is not in the generated kernel set")
+    if not 1 <= blocks <= 4:
+        raise argparse.ArgumentTypeError("blocks must be 1..4")
+    return k, n, blocks
+
+
+def footprint(cases, phase):
+    if phase == "moe":
+        return footprint(cases, "gate_up") + footprint(cases, "down")
+    if phase not in ("gate_up", "down"):
+        raise ValueError("unknown phase")
+    experts = defaultdict(set)
+    for case in cases:
+        experts[case["layer"]].update(e for row in case["expert_ids"] for e in row)
+    n, k = (1024, 4096) if phase == "gate_up" else (4096, 512)
+    return sum(map(len, experts.values())) * n * k * 9 // 16
+
+
+def prepare_case(
+    weights, batch, record, layer_id, gemm=None, block_size=8, alignment=None
+):
+    from vllm import _custom_ops as ops
+    from vllm.model_executor.layers.fused_moe.activation import (
+        MoEActivation,
+        apply_moe_activation,
+    )
+    from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
+        moe_align_block_size,
+    )
+    from vllm.scalar_type import scalar_types
+
+    if gemm is None:
+        gemm = ops.moe_wna16_marlin_gemm
+
+    ids_cpu = [r[layer_id - 3] for r in record["routes"]]
+    if len(ids_cpu) != batch or any(
+        len(row) != 8 or len(set(row)) != 8 or min(row) < 0 or max(row) >= 288
+        for row in ids_cpu
+    ):
+        raise ValueError("invalid captured expert IDs")
+    ids = torch.tensor(ids_cpu, device="cuda", dtype=torch.int32)
+    if alignment is None:
+        alignment = moe_align_block_size(ids, block_size, 288)
+    sorted_ids, expert_ids, padded = alignment
+    topk_weights = torch.full((batch, 8), 2.5 / 8, device="cuda")
+    x = torch.randn(batch, 4096, device="cuda", dtype=torch.bfloat16)
+    gate = torch.empty(batch * 8, 1024, device="cuda", dtype=torch.bfloat16)
+    down_input = torch.empty(batch * 8, 512, device="cuda", dtype=torch.bfloat16)
+    down = torch.empty(batch * 8, 4096, device="cuda", dtype=torch.bfloat16)
+    w13, s13, g13, w2, s2, g2, workspace = weights
+
+    def call(phase, config):
+        if phase == "moe":
+            call("gate_up", config[0])
+            apply_moe_activation(MoEActivation.SILU, down_input, gate, clamp_limit=10.0)
+            return call("down", config[1])
+        is_gate = phase == "gate_up"
+        return gemm(
+            x if is_gate else down_input,
+            gate if is_gate else down,
+            w13 if is_gate else w2,
+            None,
+            s13 if is_gate else s2,
+            None,
+            g13 if is_gate else g2,
+            None,
+            None,
+            None,
+            workspace,
+            sorted_ids,
+            expert_ids,
+            padded,
+            topk_weights,
+            moe_block_size=block_size,
+            top_k=8 if is_gate else 1,
+            mul_topk_weights=not is_gate,
+            b_q_type=scalar_types.float4_e2m1f,
+            size_m=batch if is_gate else batch * 8,
+            size_n=1024 if is_gate else 4096,
+            size_k=4096 if is_gate else 512,
+            is_k_full=True,
+            use_atomic_add=False,
+            use_fp32_reduce=True,
+            is_zp_float=False,
+            thread_k=config[0],
+            thread_n=config[1],
+            blocks_per_sm=config[2],
+        )
+
+    call("gate_up", (-1, -1, -1))
+    apply_moe_activation(MoEActivation.SILU, down_input, gate, clamp_limit=10.0)
+    refs = {phase: call(phase, (-1, -1, -1)).clone() for phase in ("gate_up", "down")}
+    refs["moe"] = refs["down"]
+    return {
+        "call": call,
+        "refs": refs,
+        "input": x,
+        "alignment": alignment,
+        "routing_weights": topk_weights,
+        "outputs": {
+            "gate_up": gate,
+            "activation": down_input,
+            "down": down,
+            "moe": down,
+        },
+        "identity": {
+            "layer": layer_id,
+            "batch": batch,
+            "block_size": block_size,
+            "step": record["step"],
+            "expert_ids": ids_cpu,
+            "padded_rows": padded.item(),
+        },
+    }
+
+
+def correctness(cases, phase, config):
+    rows = []
+    for case in cases:
+        value = case["call"](phase, config)
+        ref = case["refs"][phase]
+        error = value.float() - ref.float()
+        row = {
+            "layer": case["identity"]["layer"],
+            "step": case["identity"]["step"],
+            "max_abs": error.abs().max().item(),
+            "normalized_rms": (
+                error.square().mean().sqrt()
+                / ref.float().square().mean().sqrt().clamp_min(1e-12)
+            ).item(),
+            "changed_fraction": (value != ref).float().mean().item(),
+            "finite": bool(torch.isfinite(value).all()),
+        }
+        rows.append(row)
+        # This is a local comparison against installed auto scheduling, not
+        # an independent quant oracle or end-to-end quality qualification.
+        torch.testing.assert_close(value, ref, rtol=0.01, atol=0.01)
+    return rows
+
+
+def capture(cases, phase, config):
+    for case in cases:
+        case["call"](phase, config)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        for case in cases:
+            case["call"](phase, config)
+    graph.replay()
+    torch.cuda.synchronize()
+    return graph
+
+
+def measure(graph, count, replays):
+    for _ in range(3):
+        graph.replay()
+    start, end = (torch.cuda.Event(enable_timing=True) for _ in range(2))
+    start.record()
+    for _ in range(replays):
+        graph.replay()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) * 1000 / (replays * count)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--journal", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--layers", type=int, nargs="+", default=[3, 9, 15, 21, 27, 33, 39, 44]
+    )
+    parser.add_argument("--batch", type=int, nargs="+", default=[1, 8, 16])
+    parser.add_argument("--cases-per-batch", type=int, default=3)
+    parser.add_argument("--rounds", type=int, default=5)
+    parser.add_argument("--replays", type=int, default=20)
+    parser.add_argument("--rank", type=int, default=0)
+    parser.add_argument(
+        "--pipeline",
+        action="store_true",
+        help="Test the composed gate/up, activation and down path",
+    )
+    parser.add_argument("--gate-config", type=parse_config, default=(128, 64, 1))
+    parser.add_argument("--down-config", type=parse_config, default=(64, 128, 2))
+    parser.add_argument(
+        "--configs",
+        type=parse_config,
+        nargs="+",
+        default=[
+            (k, n, b)
+            for k, n in ((64, 128), (128, 64), (128, 128), (64, 256))
+            for b in (1, 2, 3, 4)
+        ],
+    )
+    args = parser.parse_args()
+    if args.output.exists() or not 0 <= args.rank < 4:
+        parser.error("output must be new and rank must be 0..3")
+    if (
+        min(args.cases_per_batch, args.rounds, args.replays) < 1
+        or any(not 3 <= layer <= 44 for layer in args.layers)
+        or any(not 1 <= b <= 16 for b in args.batch)
+    ):
+        parser.error("positive counts, target layers 3..44, batches 1..16 only")
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"], text=True
+    ).strip()
+    if active:
+        parser.error(f"GPUs already have compute processes: {active}")
+    selected = route_cases(args.journal, args.batch, args.cases_per_batch)
+    result = {
+        "status": "running",
+        "diagnostic_only": True,
+        "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "torch": torch.__version__,
+        "gpu": torch.cuda.get_device_name(),
+        "settings": {
+            k: str(v) if isinstance(v, Path) else v for k, v in vars(args).items()
+        },
+        "source_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        "journal_sha256": hashlib.sha256(args.journal.read_bytes()).hexdigest(),
+        "layers": {},
+        "cases": [],
+        "measurements": [],
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("x") as stream:
+        json.dump(result, stream, indent=2)
+
+    def save():
+        args.output.write_text(json.dumps(result, indent=2) + "\n")
+
+    try:
+        torch.manual_seed(103)
+        prepared = {}
+        for layer in args.layers:
+            weights, identity = load_layer(args.model, layer, args.rank)
+            result["layers"][layer] = identity
+            for batch, record in selected:
+                case = prepare_case(weights, batch, record, layer)
+                prepared[(batch, record["step"], layer)] = case
+                result["cases"].append(case["identity"])
+            save()
+            print(f"prepared layer {layer}", flush=True)
+        for batch in args.batch:
+            cases = [
+                prepared[(b, record["step"], layer)]
+                for b, record in selected
+                if b == batch
+                for layer in args.layers
+            ]
+            phase_configs = (
+                {"moe": [(args.gate_config, args.down_config)]}
+                if args.pipeline
+                else {"gate_up": args.configs, "down": args.configs}
+            )
+            for phase, configs in phase_configs.items():
+                auto = ((-1, -1, -1), (-1, -1, -1)) if phase == "moe" else (-1, -1, -1)
+                baseline = capture(cases, phase, auto)
+                for config in configs:
+                    row = {
+                        "batch": batch,
+                        "phase": phase,
+                        "config": config,
+                        "unique_weight_footprint_bytes": footprint(
+                            [c["identity"] for c in cases], phase
+                        ),
+                        "status": "running",
+                        "samples": [],
+                    }
+                    result["measurements"].append(row)
+                    save()
+                    try:
+                        row["correctness"] = correctness(cases, phase, config)
+                        candidate = capture(cases, phase, config)
+                    except RuntimeError as error:
+                        # Invalid shared-memory/tile configurations are explicit
+                        # rejections, not silently missing sweep points.
+                        if "Invalid thread config" not in str(
+                            error
+                        ) and "Unsupported shapes" not in str(error):
+                            raise
+                        row.update(status="unsupported", error=str(error))
+                        save()
+                        continue
+                    for _ in range(args.rounds):
+                        row["samples"].append(
+                            {
+                                name: measure(graph, len(cases), args.replays)
+                                for name, graph in (
+                                    ("a_before_us", baseline),
+                                    ("b_us", candidate),
+                                    ("a_after_us", baseline),
+                                )
+                            }
+                        )
+                        save()
+                    row["median_us"] = {
+                        key: statistics.median(s[key] for s in row["samples"])
+                        for key in ("a_before_us", "b_us", "a_after_us")
+                    }
+                    row["median_paired_speedup"] = statistics.median(
+                        (s["a_before_us"] + s["a_after_us"]) / (2 * s["b_us"])
+                        for s in row["samples"]
+                    )
+                    row["status"] = "complete"
+                    save()
+                    print(
+                        json.dumps(
+                            {
+                                k: v
+                                for k, v in row.items()
+                                if k not in ("correctness", "samples")
+                            }
+                        ),
+                        flush=True,
+                    )
+                    del candidate
+                del baseline
+        result["status"] = "complete"
+    except Exception as error:
+        result.update(status="failed", error=repr(error))
+        save()
+        raise
+    save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_glm53_marlin_swiglu.py
+++ b/benchmarks/kernels/benchmark_glm53_marlin_swiglu.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 4.1: fixed N64 gate/up pairing and fused clamped-SwiGLU epilogue.
+
+Actual TP4 checkpoint bytes and captured routes, synthetic BF16 inputs. Compare
+the COMPLETE gate/up, activation, weighted-down path to installed Marlin, not
+just a cache-hot activation kernel. One candidate, no launch-parameter sweep.
+"""
+
+import argparse
+import gc
+import hashlib
+import json
+import statistics
+import subprocess
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.benchmark_glm53_marlin_schedule import (
+    footprint,
+    measure,
+    prepare_case,
+)
+from benchmarks.kernels.profile_glm53_marlin import load_layer, route_cases
+from vllm import _custom_ops as ops
+from vllm.model_executor.layers.fused_moe.activation import (
+    MoEActivation,
+    apply_moe_activation,
+)
+from vllm.scalar_type import scalar_types
+
+
+def build(path):
+    from torch.utils.cpp_extension import load
+
+    path.mkdir(parents=True, exist_ok=True)
+    return load(
+        name="marlin_glm_swiglu",
+        sources=[str(Path(__file__).with_name("marlin_glm_swiglu.cu").resolve())],
+        extra_include_paths=[str(Path(__file__).resolve().parents[2] / "csrc")],
+        extra_cflags=["-O3", "-std=c++20"],
+        extra_cuda_cflags=[
+            "-O3",
+            "-std=c++20",
+            "-lineinfo",
+            "--expt-relaxed-constexpr",
+            "--expt-extended-lambda",
+            "-static-global-template-stub=false",
+            "-gencode=arch=compute_120f,code=sm_120f",
+            "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+        ],
+        build_directory=str(path),
+        verbose=True,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--build-dir", type=Path, required=True)
+    parser.add_argument("--build-only", action="store_true")
+    parser.add_argument(
+        "--diagnostic-timing",
+        action="store_true",
+        help="Record all comparison failures and timing; NEVER qualify a candidate",
+    )
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--journal", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    if args.output.exists():
+        parser.error("output must be new")
+    extension = build(args.build_dir)
+    if args.build_only:
+        return
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"], text=True
+    ).strip()
+    if active:
+        parser.error(f"GPUs busy: {active}")
+    torch.manual_seed(1053)
+    result = {
+        "status": "running",
+        "roadmap": "4.1",
+        "diagnostic_only": True,
+        "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "source_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        "probe_sha256": hashlib.sha256(
+            Path(extension.__file__).read_bytes()
+        ).hexdigest(),
+        "journal_sha256": hashlib.sha256(args.journal.read_bytes()).hexdigest(),
+        "weights": {},
+        "checks": [],
+        "measurements": [],
+        "comparison_failures": [],
+        "diagnostic_timing": args.diagnostic_timing,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    def save():
+        args.output.write_text(json.dumps(result, indent=2) + "\n")
+
+    save()
+    auto = (-1, -1, -1)
+    cases = {batch: [] for batch in (1, 8, 16)}
+    selected = route_cases(args.journal, [1], 15) + route_cases(
+        args.journal, [8, 16], 3
+    )
+    try:
+        for layer in (3, 23, 44):
+            original, identity = load_layer(args.model, layer, 0)
+            paired, paired_identity = load_layer(args.model, layer, 0, gate_up_tile=64)
+            assert identity == paired_identity
+            result["weights"][layer] = identity
+            w13, s13, g13 = paired[:3]
+            workspace = paired[-1]
+            temp = torch.empty(188 * 4 * 16 * 128, dtype=torch.float32, device="cuda")
+            for batch, record in selected:
+                case = prepare_case(original, batch, record, layer)
+
+                def candidate(
+                    case=case, w13=w13, s13=s13, g13=g13, workspace=workspace, temp=temp
+                ):
+                    extension.run(
+                        case["input"],
+                        case["outputs"]["activation"],
+                        w13,
+                        s13,
+                        g13,
+                        workspace,
+                        temp,
+                        *case["alignment"],
+                        case["routing_weights"],
+                    )
+                    return case["call"]("down", auto)
+
+                def control(case=case):
+                    return case["call"]("moe", (auto, auto))
+
+                case["candidate"] = candidate
+                case["control"] = control
+                for changed in (False, True):
+                    if changed:
+                        # Graph/reused workspace correctness must not depend on
+                        # the first input, including the actual clamp branches.
+                        case["input"].mul_(32)
+                    ref = control().clone()
+                    activation_ref = case["outputs"]["activation"].clone()
+                    value = candidate()
+                    activation = case["outputs"]["activation"]
+                    activation_passed = True
+                    try:
+                        torch.testing.assert_close(
+                            activation, activation_ref, rtol=0.01, atol=0.01
+                        )
+                    except AssertionError as comparison_error:
+                        activation_passed = False
+                        # Localize a failing element with the SAME paired
+                        # weights/schedule but the installed unfused epilogue.
+                        # This diagnostic neither relaxes nor replaces the gate.
+                        paired_gate = torch.empty_like(case["outputs"]["gate_up"])
+                        ops.moe_wna16_marlin_gemm(
+                            case["input"],
+                            paired_gate,
+                            w13,
+                            None,
+                            s13,
+                            None,
+                            g13,
+                            None,
+                            None,
+                            None,
+                            workspace,
+                            *case["alignment"],
+                            case["routing_weights"],
+                            moe_block_size=8,
+                            top_k=8,
+                            mul_topk_weights=False,
+                            b_q_type=scalar_types.float4_e2m1f,
+                            size_m=batch,
+                            size_n=1024,
+                            size_k=4096,
+                            is_k_full=True,
+                            use_atomic_add=False,
+                            use_fp32_reduce=True,
+                            is_zp_float=False,
+                            thread_k=128 if batch == 1 else 64,
+                            thread_n=64 if batch == 1 else 128,
+                            blocks_per_sm=2 if batch == 1 else 3,
+                        )
+                        restored = paired_gate.view(-1, 16, 2, 32).transpose(1, 2)
+                        restored = restored.reshape(-1, 1024).contiguous()
+                        paired_activation = torch.empty_like(activation)
+                        apply_moe_activation(
+                            MoEActivation.SILU,
+                            paired_activation,
+                            restored,
+                            clamp_limit=10.0,
+                        )
+                        result["failure_fixture"] = {
+                            **case["identity"],
+                            "changed_input": changed,
+                            "fused_vs_paired_activation_exact": torch.equal(
+                                activation, paired_activation
+                            ),
+                            "fused_vs_paired_max_abs": (
+                                activation.float() - paired_activation.float()
+                            )
+                            .abs()
+                            .max()
+                            .item(),
+                        }
+                        failure_id = len(result["comparison_failures"])
+                        result["comparison_failures"].append(
+                            {
+                                **result["failure_fixture"],
+                                "phase": "activation",
+                                "error": str(comparison_error),
+                            }
+                        )
+                        torch.save(
+                            {
+                                "input": case["input"].cpu(),
+                                "original_gate": case["outputs"]["gate_up"].cpu(),
+                                "paired_gate": restored.cpu(),
+                                "original_activation": activation_ref.cpu(),
+                                "paired_activation": paired_activation.cpu(),
+                                "fused_activation": activation.cpu(),
+                            },
+                            args.output.with_suffix(f".failure-{failure_id}.pt"),
+                        )
+                        if not args.diagnostic_timing:
+                            raise
+                    output_passed = True
+                    try:
+                        torch.testing.assert_close(value, ref, rtol=0.01, atol=0.01)
+                    except AssertionError as comparison_error:
+                        output_passed = False
+                        result["comparison_failures"].append(
+                            {
+                                **case["identity"],
+                                "changed_input": changed,
+                                "phase": "down",
+                                "error": str(comparison_error),
+                            }
+                        )
+                        if not args.diagnostic_timing:
+                            raise
+                    error = value.float() - ref.float()
+                    result["checks"].append(
+                        {
+                            **case["identity"],
+                            "changed_input": changed,
+                            "activation_passed": activation_passed,
+                            "output_passed": output_passed,
+                            "activation_exact": torch.equal(activation, activation_ref),
+                            "max_abs": error.abs().max().item(),
+                            "nrms": (
+                                error.square().mean().sqrt()
+                                / ref.float().square().mean().sqrt().clamp_min(1e-12)
+                            ).item(),
+                        }
+                    )
+                case["input"].div_(32)
+                cases[batch].append(case)
+            del original, paired
+            gc.collect()
+            save()
+            print(
+                f"layer {layer}: checks recorded; "
+                f"{len(result['comparison_failures'])} cumulative comparison failures",
+                flush=True,
+            )
+        for batch, fixtures in cases.items():
+            weight_bytes = footprint([c["identity"] for c in fixtures], "moe")
+            if weight_bytes <= 3 * 128 * 1024**2:
+                raise ValueError(f"insufficient weight footprint: {weight_bytes}")
+            graphs = {}
+            for arm in ("control", "candidate"):
+                for case in fixtures:
+                    case[arm]()
+                torch.cuda.synchronize()
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph):
+                    for case in fixtures:
+                        case[arm]()
+                graphs[arm] = graph
+            # Replay with changed contents, independently compare the complete
+            # captured outputs. Each graph sees the exact same live inputs.
+            for case in fixtures:
+                case["input"].neg_()
+            graphs["control"].replay()
+            expected = [c["outputs"]["down"].clone() for c in fixtures]
+            graphs["candidate"].replay()
+            torch.cuda.synchronize()
+            graph_passed = True
+            for case, ref in zip(fixtures, expected):
+                try:
+                    torch.testing.assert_close(
+                        case["outputs"]["down"], ref, rtol=0.01, atol=0.01
+                    )
+                except AssertionError as comparison_error:
+                    graph_passed = False
+                    result["comparison_failures"].append(
+                        {
+                            **case["identity"],
+                            "phase": "changed_graph",
+                            "error": str(comparison_error),
+                        }
+                    )
+                    if not args.diagnostic_timing:
+                        raise
+            samples = []
+            for round_id in range(3):
+                row = {"round": round_id}
+                for arm, label in (
+                    ("control", "before"),
+                    ("candidate", "candidate"),
+                    ("control", "after"),
+                ):
+                    row[label] = measure(graphs[arm], len(fixtures), 10)
+                samples.append(row)
+            medians = {
+                key: statistics.median(r[key] for r in samples)
+                for key in ("before", "candidate", "after")
+            }
+            result["measurements"].append(
+                {
+                    "batch": batch,
+                    "fixtures": len(fixtures),
+                    "weight_bytes": weight_bytes,
+                    "changed_input_graph_parity": graph_passed,
+                    "samples_us": samples,
+                    "median_us": medians,
+                }
+            )
+            print(f"batch {batch}: {medians}", flush=True)
+            save()
+        result["status"] = (
+            "diagnostic_timing_only" if args.diagnostic_timing else "complete"
+        )
+    except Exception as error:
+        result.update(status="failed", error=repr(error))
+        raise
+    finally:
+        save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_glm53_mhc_norm.py
+++ b/benchmarks/kernels/benchmark_glm53_mhc_norm.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Isolated mHC+RMS fusion probe; never changes serving operators or weights.
+
+The reference matches the generated GLM serving norm: FP32 normalization and
+weight multiply, then BF16 output. The Python eager IR has an extra cast that
+the cached serving Triton does not retain. Compare compiled behavior explicitly.
+Uses all 90 checkpoint mHC sites and their real BF16 norm weights, synthetic
+activations, three magnitudes, changed-input graphs, and fixed A/B/A timings.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import statistics
+import subprocess
+from contextlib import ExitStack
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.benchmark_mhc_output_parallel import (
+    checkpoint_parameters,
+    inputs,
+)
+
+
+def normalize_inplace(x, weight):
+    xf = x.float()
+    inv = torch.rsqrt(xf.square().mean(-1, keepdim=True) + 1e-5)
+    return x.copy_((xf * inv * weight.float()).to(x.dtype))
+
+
+def norm_oracle(x, weight):
+    xf = x.double()
+    inv = torch.rsqrt(xf.square().mean(-1, keepdim=True) + 1e-5)
+    return (xf * inv * weight.double()).bfloat16()
+
+
+def ulp_distance(a, b):
+    if a.dtype != torch.bfloat16 or b.dtype != torch.bfloat16 or a.shape != b.shape:
+        raise ValueError("matching BF16 tensors required")
+    if not torch.isfinite(a).all() or not torch.isfinite(b).all():
+        raise ValueError("finite BF16 tensors required")
+
+    def ordered(t):
+        bits = t.view(torch.int16).int() & 0xFFFF
+        magnitude = bits & 0x7FFF
+        return torch.where(bits >= 0x8000, 0x8000 - magnitude, 0x8000 + magnitude)
+
+    return (ordered(a) - ordered(b)).abs().max().item()
+
+
+def parameters(model):
+    from safetensors import safe_open
+
+    sites, identity = checkpoint_parameters(model)
+    index = json.loads((model / "model.safetensors.index.json").read_text())[
+        "weight_map"
+    ]
+    with ExitStack() as stack:
+        shards = {}
+        for i, site in enumerate(sites):
+            name = "input_layernorm" if i % 2 == 0 else "post_attention_layernorm"
+            key = f"model.language_model.layers.{i // 2}.{name}.weight"
+            filename = index[key]
+            if filename not in shards:
+                shards[filename] = stack.enter_context(
+                    safe_open(model / filename, framework="pt", device="cpu")
+                )
+            weight = shards[filename].get_tensor(key)
+            if weight.shape != (4096,) or weight.dtype != torch.bfloat16:
+                raise ValueError("expected the actual BF16 GLM norm weight")
+            identity[i]["norm"] = key
+            identity[i]["norm_sha256"] = hashlib.sha256(
+                weight.view(torch.uint8).numpy().tobytes()
+            ).hexdigest()
+            site.append(weight.cuda())
+    return sites, identity
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--batch", type=int, nargs="+", default=[1, 2, 4, 8])
+    parser.add_argument("--replays", type=int, default=20)
+    parser.add_argument("--rounds", type=int, default=5)
+    parser.add_argument("--check-only", action="store_true")
+    args = parser.parse_args()
+    if args.output.exists() or min(args.rounds, args.replays) < 1:
+        parser.error("new output and positive rounds/replays required")
+    if any(batch not in (1, 2, 4, 8) for batch in args.batch):
+        parser.error("only cooperative decode batches 1/2/4/8")
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"], text=True
+    ).strip()
+    if active:
+        parser.error(f"GPUs already have compute processes: {active}")
+    required_env = {
+        "VLLM_DSV4_MHC_MODE": "0",
+        "VLLM_DSV4_MHC_COOP_MAX_T": "8",
+        "VLLM_DSV4_MHC_SPLITS": "64",
+    }
+    for key, value in required_env.items():
+        if key in os.environ and os.environ[key] != value:
+            parser.error(f"this probe requires {key}={value}")
+        os.environ[key] = value
+    from vllm.quixicore.ops import quixicore_ops as qc
+
+    norm = torch.compile(normalize_inplace, fullgraph=True, dynamic=True)
+    root = Path(__file__).resolve().parents[2]
+    native = {
+        str(path): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in sorted((root / "vllm").glob("*.so"))
+    }
+    sites, identity = parameters(args.model)
+    result = {
+        "status": "running",
+        "diagnostic_only": True,
+        "method": __doc__,
+        "native_sha256": native,
+        "parameters": identity,
+        "source_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        "torch": torch.__version__,
+        "environment": required_env,
+        "settings": {
+            k: str(v) if isinstance(v, Path) else v for k, v in vars(args).items()
+        },
+        "checks": [],
+        "timings": [],
+    }
+    with args.output.open("x") as stream:
+        json.dump(result, stream, indent=2)
+
+    def save():
+        args.output.write_text(json.dumps(result, indent=2) + "\n")
+
+    def call(data, site_index, fused_norm):
+        x, residual, post, comb, fn, scale, base, weight = data
+        constants = [1e-5, 1e-6, 1e-6, 2.0, 20, weight if fused_norm else None, 1e-5]
+        if site_index == 0:
+            out = [residual, *qc.dsv4_mhc_pre(residual, fn, scale, base, *constants)]
+        else:
+            out = list(
+                qc.dsv4_mhc_fused_post_pre(
+                    x, residual, post, comb, fn, scale, base, *constants
+                )
+            )
+        return out
+
+    def compare(reference, candidate, oracle=None):
+        row = {
+            "mixes_exact": all(
+                torch.equal(a, b) for a, b in zip(reference[:3], candidate[:3])
+            ),
+            "candidate_reference_ulp": ulp_distance(candidate[-1], reference[-1]),
+        }
+        if oracle is not None:
+            row["reference_oracle_ulp"] = ulp_distance(reference[-1].cpu(), oracle)
+            row["candidate_oracle_ulp"] = ulp_distance(candidate[-1].cpu(), oracle)
+        row["passes"] = row["mixes_exact"] and all(
+            value <= 1 for key, value in row.items() if key.endswith("_ulp")
+        )
+        return row
+
+    try:
+        for batch in args.batch:
+            data = []
+            for i, site in enumerate(sites):
+                row = inputs(batch, 911 + i)
+                row[4:] = site
+                data.append(row)
+            for magnitude in (0.125, 1.0, 8.0):
+                for i, row in enumerate(data):
+                    fresh = inputs(batch, 1201 + i, magnitude)
+                    for target, value in zip(row[:4], fresh[:4]):
+                        target.copy_(value)
+                    reference = call(row, i, False)
+                    oracle = norm_oracle(reference[-1].cpu(), row[-1].cpu())
+                    norm(reference[-1], row[-1])
+                    candidate = call(row, i, True)
+                    result["checks"].append(
+                        {
+                            "batch": batch,
+                            "site": i,
+                            "magnitude": magnitude,
+                            **compare(reference, candidate, oracle),
+                        }
+                    )
+                save()
+
+            graphs, outputs = {}, {}
+            for candidate in (False, True):
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph):
+                    captured = []
+                    for i, row in enumerate(data):
+                        out = call(row, i, candidate)
+                        if not candidate:
+                            norm(out[-1], row[-1])
+                        captured.append(out)
+                graphs[candidate], outputs[candidate] = graph, captured
+            for replay in range(3):
+                for i, row in enumerate(data):
+                    fresh = inputs(batch, 1501 + 97 * replay + i)
+                    for target, value in zip(row[:4], fresh[:4]):
+                        target.copy_(value)
+                for graph in graphs.values():
+                    graph.replay()
+                torch.cuda.synchronize()
+                for i in range(len(data)):
+                    result["checks"].append(
+                        {
+                            "batch": batch,
+                            "site": i,
+                            "graph_replay": replay,
+                            **compare(outputs[False][i], outputs[True][i]),
+                        }
+                    )
+                save()
+
+            if not args.check_only and all(row["passes"] for row in result["checks"]):
+                for graph in graphs.values():
+                    for _ in range(3):
+                        graph.replay()
+                torch.cuda.synchronize()
+                samples = []
+                for repeat in range(args.rounds):
+                    sample = {"round": repeat}
+                    for name, candidate in (
+                        ("a_us", False),
+                        ("b_us", True),
+                        ("a2_us", False),
+                    ):
+                        start, end = (
+                            torch.cuda.Event(enable_timing=True),
+                            torch.cuda.Event(enable_timing=True),
+                        )
+                        start.record()
+                        for _ in range(args.replays):
+                            graphs[candidate].replay()
+                        end.record()
+                        end.synchronize()
+                        sample[name] = (
+                            start.elapsed_time(end) * 1000 / (args.replays * 90)
+                        )
+                    sample["paired_speedup"] = (sample["a_us"] + sample["a2_us"]) / (
+                        2 * sample["b_us"]
+                    ) - 1
+                    samples.append(sample)
+                result["timings"].append(
+                    {
+                        "batch": batch,
+                        "samples": samples,
+                        "median_paired_speedup": statistics.median(
+                            row["paired_speedup"] for row in samples
+                        ),
+                    }
+                )
+                print(json.dumps(result["timings"][-1]), flush=True)
+                save()
+            del graphs, outputs, captured, graph, data
+        result["status"] = (
+            "complete"
+            if all(row["passes"] for row in result["checks"])
+            else "failed_gates"
+        )
+        save()
+    except Exception as error:
+        result.update(status="failed", error=repr(error))
+        save()
+        raise
+    return int(result["status"] != "complete")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernels/benchmark_glm53_mhc_prefill_tc.py
+++ b/benchmarks/kernels/benchmark_glm53_mhc_prefill_tc.py
@@ -294,7 +294,12 @@ def main():
             # Same six distinct weight banks in both arms. No reference FP32
             # storage conversion is timed; baseline is installed paired BF16.
             rows = timing_rows(
-                sites, narrow, batch, shared_activations=True, weight_banks=6
+                sites,
+                narrow,
+                batch,
+                shared_activations=True,
+                weight_banks=6,
+                fp32_arm=False,
             )
             fn_bytes = sum(row[1][4].numel() * row[1][4].element_size() for row in rows)
             if fn_bytes <= 3 * 128 * 2**20:

--- a/benchmarks/kernels/benchmark_glm53_mhc_prefill_tc.py
+++ b/benchmarks/kernels/benchmark_glm53_mhc_prefill_tc.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Isolated SM120 mHC prefill tensor-core probe, not a serving operator.
+
+Same losslessly stored BF16 fn/activations, FP32 dot accumulation and existing
+20-iteration finalize/apply kernels. Dot summation order changes. Gate every
+actual site against installed BF16 serving and sampled independent FP64
+partials; require exact fused residual bits and changed-input graph/eager
+parity. Timing rotates six copies of all 90 fn matrices (>3x128MiB L2), with
+shared immutable activations per bank to bound memory. No serving gain follows
+from these isolated graphs; real-profile and sanitizer gates remain required.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.benchmark_glm53_mhc_storage import (
+    exact,
+    lossless_bf16,
+    selected_check_sites,
+    timing_rows,
+)
+from benchmarks.kernels.benchmark_mhc_output_parallel import (
+    build,
+    checkpoint_parameters,
+    compare,
+    inputs,
+)
+
+
+def oracle_rows(batch):
+    if batch < 64:
+        raise ValueError("prefill probe requires at least 64 rows")
+    return sorted({0, 1, 15, 16, 31, 32, 63, min(64, batch - 1), batch - 1})
+
+
+def partial_errors(residual, fn, partial):
+    """CPU FP64 oracle with the candidate's explicit 32 stream-slice splits.
+
+    Inputs are sampled *after* the fused residual has passed its bit gate;
+    that operation is independently checked against the installed kernel.
+    This oracle does not reuse tensor-core or native partial calculations.
+    """
+    if (
+        residual.ndim != 3
+        or tuple(residual.shape[1:]) != (4, 4096)
+        or tuple(fn.shape) != (24, 16384)
+        or tuple(partial.shape) != (residual.shape[0], 32, 25)
+    ):
+        raise ValueError("invalid mHC oracle shapes")
+    rows = oracle_rows(residual.shape[0])
+    r = residual[rows].cpu().double().reshape(len(rows), 4, 32, 128)
+    r = r.permute(0, 2, 1, 3).reshape(len(rows), 32, 512)
+    w = fn.cpu().double().reshape(24, 4, 32, 128)
+    w = w.permute(2, 0, 1, 3).reshape(32, 24, 512)
+    expected = torch.einsum("tsk,snk->tsn", r, w)
+    sq = r.square().sum(-1)
+    observed = partial[rows].cpu().double()
+    result = {
+        "rows": rows,
+        "finite": bool(
+            torch.isfinite(observed).all()
+            and torch.isfinite(r).all()
+            and torch.isfinite(w).all()
+        ),
+    }
+    if not result["finite"]:
+        return {**result, "passed": False}
+    delta = observed[:, :, :24] - expected
+    result["dot_normalized_rms"] = float(
+        delta.square().mean().sqrt() / expected.square().mean().sqrt().clamp_min(1e-30)
+    )
+    result["dot_row_peak_error"] = float(
+        (delta.abs() / expected.abs().amax(-1, keepdim=True).clamp_min(1e-30)).max()
+    )
+    result["square_relative_error"] = float(
+        ((observed[:, :, 24] - sq).abs() / sq.clamp_min(1e-30)).max()
+    )
+    result["passed"] = (
+        result["dot_normalized_rms"] <= 2e-6
+        and result["dot_row_peak_error"] <= 2e-5
+        and result["square_relative_error"] <= 1e-5
+    )
+    return result
+
+
+def installed(data, fused):
+    from vllm.quixicore.ops import quixicore_ops as qc
+
+    constants = [1e-5, 1e-6, 1e-6, 2.0, 20, None, 0.0]
+    if fused:
+        return qc.dsv4_mhc_fused_post_pre(*data, *constants)
+    _, residual, _, _, fn, scale, base = data
+    return [residual, *qc.dsv4_mhc_pre(residual, fn, scale, base, *constants)]
+
+
+def check_outputs(reference, candidate):
+    if len(reference) != 4 or len(candidate) != 4:
+        raise ValueError("unexpected operator output count")
+    for ref, got in zip(reference, candidate):
+        if ref.shape != got.shape or ref.dtype != got.dtype:
+            raise ValueError("operator output shape or dtype changed")
+    try:
+        exact(reference[:1], candidate[:1])
+        return compare(reference, candidate)
+    except AssertionError as error:
+        # Preserve the original gate and report the failed value, not only an
+        # empty AssertionError. Compute this extra diagnostic only on failure.
+        details = []
+        for index, (ref, got) in enumerate(zip(reference, candidate)):
+            finite = bool(torch.isfinite(ref).all() and torch.isfinite(got).all())
+            row = {"output": index, "dtype": str(ref.dtype), "finite": finite}
+            if finite and ref.numel():
+                delta = (got.float() - ref.float()).abs()
+                peak = ref.float().abs().amax(-1, keepdim=True).clamp_min(1e-6)
+                normalized = delta / peak
+                flat = int(normalized.argmax())
+                row.update(
+                    max_abs=float(delta.max()),
+                    row_peak_error=float(normalized.max()),
+                    max_flat_index=flat,
+                    reference=float(ref.flatten()[flat]),
+                    candidate=float(got.flatten()[flat]),
+                )
+            details.append(row)
+        raise AssertionError(
+            f"{error}; output diagnostics: {json.dumps(details)}"
+        ) from error
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--build-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--build-only", action="store_true")
+    parser.add_argument("--check-only", action="store_true")
+    parser.add_argument("--check-sites", type=int, nargs="+")
+    parser.add_argument(
+        "--batch", type=int, nargs="+", default=[64, 65, 128, 129, 7616]
+    )
+    parser.add_argument("--rounds", type=int, default=5)
+    parser.add_argument("--replays", type=int, default=4)
+    args = parser.parse_args()
+    try:
+        check_sites = selected_check_sites(args.check_sites)
+    except ValueError as error:
+        parser.error(str(error))
+    if args.check_sites is not None and not args.check_only:
+        parser.error("bounded site selection is for correctness/sanitizers only")
+    if min(args.rounds, args.replays) < 1 or any(
+        not 64 <= t <= 7616 for t in args.batch
+    ):
+        parser.error("positive rounds/replays, prefill batches 64..7616")
+    settings = {
+        "VLLM_DSV4_MHC_MODE": "0",
+        "VLLM_DSV4_MHC_COOP_MAX_T": "8",
+        "VLLM_DSV4_MHC_SPLITS": "64",
+        "VLLM_DSV4_MHC_PREFILL_MIN_T": "64",
+    }
+    for key, value in settings.items():
+        if key in os.environ and os.environ[key] != value:
+            parser.error(f"requires {key}={value}")
+        os.environ[key] = value
+    if not args.build_only:
+        if args.output is None or args.output.exists():
+            parser.error("a run requires a new output directory")
+        active = subprocess.check_output(
+            ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"],
+            text=True,
+        ).strip()
+        if active:
+            parser.error(f"GPU compute processes already active: {active}")
+    extension = build(args.build_dir, name="mhc_prefill_tc_probe")
+    if args.build_only:
+        return
+    args.output.mkdir(parents=True)
+    record = args.output / "summary.json"
+    root = Path(__file__).resolve().parents[2]
+    sources = [
+        Path(__file__),
+        Path(__file__).with_name("mhc_prefill_tc_probe.cu"),
+        Path(__file__).with_name("benchmark_glm53_mhc_storage.py"),
+        Path(__file__).with_name("benchmark_mhc_output_parallel.py"),
+        root / "csrc/quixicore/serving/mhc_ampere.cuh",
+        root / "csrc/quixicore/serving/bf16_decode_gemm.cuh",
+        root / "csrc/quixicore/tm_cuda/tm_cuda_serving.cu",
+    ]
+    result = {
+        "status": "running",
+        "diagnostic_only": True,
+        "method": __doc__,
+        "command": sys.argv,
+        "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "git_status": subprocess.check_output(
+            ["git", "status", "--short"], text=True
+        ).strip(),
+        "source_sha256": {
+            str(p.relative_to(root)): hashlib.sha256(p.read_bytes()).hexdigest()
+            for p in sources
+        },
+        "extension_sha256": hashlib.sha256(
+            Path(extension.__file__).read_bytes()
+        ).hexdigest(),
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "environment": settings,
+        "settings": {
+            k: str(v) if isinstance(v, Path) else v for k, v in vars(args).items()
+        },
+        "checks": [],
+        "timings": [],
+    }
+
+    def save():
+        record.write_text(json.dumps(result, indent=2) + "\n")
+
+    save()
+    try:
+        import vllm._quixicore_C as native
+
+        torch.set_num_threads(4)
+        if torch.cuda.get_device_capability() != (12, 0):
+            raise ValueError("requires the SM120 target")
+        result["gpu"] = torch.cuda.get_device_name()
+        result["resources"] = extension.resources()
+        with Path(native.__file__).open("rb") as stream:
+            result["native_sha256"] = hashlib.file_digest(stream, "sha256").hexdigest()
+        sites, result["parameters"] = checkpoint_parameters(args.model)
+        if len(sites) != 90:
+            raise ValueError("expected all 90 actual parameter sets")
+        narrow = [lossless_bf16(site[0]) for site in sites]
+        save()
+        for batch in args.batch:
+            for site in check_sites:
+                for magnitude in (0.01, 1.0, 100.0):
+                    data = inputs(batch, 301 + site, magnitude)[:7]
+                    data[4:] = [narrow[site], *sites[site][1:]]
+                    for fused in (False, True):
+                        row = {
+                            "batch": batch,
+                            "site": site,
+                            "magnitude": magnitude,
+                            "fused": fused,
+                            # The unfused graph checks mutate these same
+                            # buffers before the fused eager comparison.
+                            "eager_input_seed": (
+                                2001 + site * 3 + 2 if fused else 301 + site
+                            ),
+                            "graph_input_seeds": [
+                                2001 + site * 3 + replay for replay in range(3)
+                            ],
+                            "status": "checking",
+                        }
+                        result["checks"].append(row)
+                        save()
+                        ref = installed(data, fused)
+                        got = extension.run(*data, fused)
+                        row["eager"] = check_outputs(ref, got)
+                        ro, partial = extension.run(*data, fused, True)
+                        exact(ref[:1], [ro])
+                        row["partial_oracle"] = partial_errors(ro, data[4], partial)
+                        if not row["partial_oracle"]["passed"]:
+                            raise ValueError("independent FP64 partial oracle failed")
+                        del ro, partial, ref, got
+                        graph = torch.cuda.CUDAGraph()
+                        torch.cuda.synchronize()
+                        with torch.cuda.graph(graph):
+                            a = installed(data, fused)
+                            b = extension.run(*data, fused)
+                        row["graphs"] = []
+                        for replay in range(3):
+                            fresh = inputs(batch, 2001 + site * 3 + replay, magnitude)
+                            for target, source in zip(data[:4], fresh[:4]):
+                                target.copy_(source)
+                            graph.replay()
+                            row["graphs"].append(check_outputs(a, b))
+                            exact(b, extension.run(*data, fused))
+                        row["status"] = "complete"
+                        del graph, a, b, fresh
+                        save()
+                if site % 15 == 0:
+                    print(f"batch{batch}: checked site{site + 1}/90", flush=True)
+            if args.check_only:
+                continue
+            # Same six distinct weight banks in both arms. No reference FP32
+            # storage conversion is timed; baseline is installed paired BF16.
+            rows = timing_rows(
+                sites, narrow, batch, shared_activations=True, weight_banks=6
+            )
+            fn_bytes = sum(row[1][4].numel() * row[1][4].element_size() for row in rows)
+            if fn_bytes <= 3 * 128 * 2**20:
+                raise ValueError(
+                    "timing working set does not exceed three L2 capacities"
+                )
+            graphs = []
+            torch.cuda.reset_peak_memory_stats()
+            for call in (installed, lambda data, fused: extension.run(*data, fused)):
+                for row in rows:
+                    call(row[1], row[2])
+                torch.cuda.synchronize()
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph):
+                    for row in rows:
+                        call(row[1], row[2])
+                graphs.append(graph)
+            timing = {
+                "batch": batch,
+                "sites_per_graph": len(rows),
+                "fn_bytes": fn_bytes,
+                "fn_l2_ratio": fn_bytes / (128 * 2**20),
+                "activation_sets": 6,
+                "capture_peak_allocated_bytes": torch.cuda.max_memory_allocated(),
+                "rounds": [],
+            }
+            result["timings"].append(timing)
+            for repeat in range(args.rounds):
+                sample = {"repeat": repeat + 1}
+                timing["rounds"].append(sample)
+                for phase, variant in (("A", 0), ("B", 1), ("A2", 0)):
+                    graph = graphs[variant]
+                    for _ in range(3):
+                        graph.replay()
+                    start, end = (
+                        torch.cuda.Event(enable_timing=True) for _ in range(2)
+                    )
+                    start.record()
+                    for _ in range(args.replays):
+                        graph.replay()
+                    end.record()
+                    end.synchronize()
+                    sample[phase] = (
+                        start.elapsed_time(end) * 1000 / (args.replays * len(rows))
+                    )
+                    save()
+            timing["median_us"] = {
+                phase: statistics.median(r[phase] for r in timing["rounds"])
+                for phase in ("A", "B", "A2")
+            }
+            timing["median_paired_throughput_change_pct"] = statistics.median(
+                (0.5 * (r["A"] + r["A2"]) / r["B"] - 1) * 100 for r in timing["rounds"]
+            )
+            print(json.dumps(timing), flush=True)
+            del graphs, graph, rows, data
+            save()
+        result["status"] = "complete"
+    except BaseException as error:
+        result["status"], result["error"] = "failed", repr(error)
+        raise
+    finally:
+        save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_glm53_mhc_storage.py
+++ b/benchmarks/kernels/benchmark_glm53_mhc_storage.py
@@ -49,7 +49,9 @@ def exact(reference, candidate):
             )
 
 
-def timing_rows(sites, narrow, batch, shared_activations=False, weight_banks=2):
+def timing_rows(
+    sites, narrow, batch, shared_activations=False, weight_banks=2, *, fp32_arm=True
+):
     """Keep every fn allocation distinct; optionally share inputs within a bank."""
     if len(sites) != len(narrow):
         raise ValueError("parameter and narrow site counts differ")
@@ -66,7 +68,11 @@ def timing_rows(sites, narrow, batch, shared_activations=False, weight_banks=2):
                 if shared is not None
                 else inputs(batch, 5001 + site + bank * len(sites))[:4]
             )
-            data = [*activations, weights[0].clone(), *weights[1:]]
+            data = [
+                *activations,
+                weights[0].clone() if fp32_arm else None,
+                *weights[1:],
+            ]
             candidate = [*activations, narrow[site].clone(), *weights[1:]]
             rows.append((data, candidate, site != 0))
     return rows

--- a/benchmarks/kernels/benchmark_glm53_mhc_storage.py
+++ b/benchmarks/kernels/benchmark_glm53_mhc_storage.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Lossless BF16 storage for GLM's upcast mHC fn, with unchanged FP32 math.
+
+Isolated kernels only. Require bit-exact output to installed FP32 serving and
+changed-input graph parity over every actual checkpoint site. Fixed A/B/A
+timings default to two independent copies of all 90 parameter sets:
+even the narrower fn working set exceeds SM120's 128 MiB L2.
+Optional shared activation banks bound full-prefill timing memory; they are
+an isolated memory-layout control, not a simulation of model dependencies.
+Six banks increase the BF16 weight working set from 135 MiB to 405 MiB.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import statistics
+import subprocess
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.benchmark_mhc_output_parallel import (
+    build,
+    checkpoint_parameters,
+    inputs,
+)
+
+
+def lossless_bf16(value):
+    narrow = value.bfloat16()
+    if not torch.isfinite(value).all() or not torch.equal(value, narrow.float()):
+        raise ValueError("fn storage change would alter checkpoint values")
+    return narrow
+
+
+def exact(reference, candidate):
+    if len(reference) != len(candidate):
+        raise AssertionError("output arity changed")
+    for i, (a, b) in enumerate(zip(reference, candidate)):
+        if a.dtype != b.dtype or not torch.equal(a, b):
+            raise AssertionError(f"output {i} is not bit-exact")
+        if not torch.equal(
+            a.contiguous().view(torch.uint8), b.contiguous().view(torch.uint8)
+        ):
+            raise AssertionError(
+                f"output {i} has different bits (including signed zero)"
+            )
+
+
+def timing_rows(sites, narrow, batch, shared_activations=False, weight_banks=2):
+    """Keep every fn allocation distinct; optionally share inputs within a bank."""
+    if len(sites) != len(narrow):
+        raise ValueError("parameter and narrow site counts differ")
+    if weight_banks < 1:
+        raise ValueError("positive weight bank count required")
+    rows = []
+    for bank in range(weight_banks):
+        shared = (
+            inputs(batch, 5001 + bank * len(sites))[:4] if shared_activations else None
+        )
+        for site, weights in enumerate(sites):
+            activations = (
+                shared
+                if shared is not None
+                else inputs(batch, 5001 + site + bank * len(sites))[:4]
+            )
+            data = [*activations, weights[0].clone(), *weights[1:]]
+            candidate = [*activations, narrow[site].clone(), *weights[1:]]
+            rows.append((data, candidate, site != 0))
+    return rows
+
+
+def selected_check_sites(indices):
+    if indices is None:
+        return list(range(90))
+    if (
+        not indices
+        or len(set(indices)) != len(indices)
+        or any(index < 0 or index >= 90 for index in indices)
+    ):
+        raise ValueError("check sites must be distinct indices in 0..89")
+    return list(indices)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--build-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--batch", type=int, nargs="+", default=[1, 2, 4, 8, 16])
+    parser.add_argument("--rounds", type=int, default=5)
+    parser.add_argument("--replays", type=int, default=20)
+    parser.add_argument("--check-only", action="store_true")
+    parser.add_argument(
+        "--check-sites",
+        type=int,
+        nargs="+",
+        help="bounded sanitizer census only; timing runs require all 90 sites",
+    )
+    parser.add_argument("--check-installed-bf16", action="store_true")
+    parser.add_argument(
+        "--timing-baseline",
+        choices=("fp32", "installed-bf16"),
+        default="fp32",
+        help="compare probe BF16 to probe FP32 or the installed BF16 operator",
+    )
+    parser.add_argument("--build-only", action="store_true")
+    parser.add_argument(
+        "--paired-prefill-fn",
+        action="store_true",
+        help="isolated paired BF16 staging candidate; serving kernels stay unchanged",
+    )
+    parser.add_argument(
+        "--weight-banks",
+        type=int,
+        default=2,
+        help="distinct copies of all 90 fn matrices; six exceed three L2 capacities",
+    )
+    parser.add_argument(
+        "--shared-activations",
+        action="store_true",
+        help="reuse one activation set per timing bank to bound full-prefill memory",
+    )
+    args = parser.parse_args()
+    try:
+        check_sites = selected_check_sites(args.check_sites)
+    except ValueError as error:
+        parser.error(str(error))
+    if args.check_sites is not None and not args.check_only:
+        parser.error(
+            "--check-sites requires --check-only; timing gates stay exhaustive"
+        )
+    if args.timing_baseline == "installed-bf16":
+        args.check_installed_bf16 = True
+    if (
+        min(args.rounds, args.replays, args.weight_banks, *args.batch) < 1
+        or max(args.batch) > 7616
+    ):
+        parser.error("positive rounds/replays/batches, at most 7616 rows")
+    if (
+        not args.check_only
+        and not args.build_only
+        and max(args.batch) > 128
+        and not args.shared_activations
+    ):
+        parser.error(
+            "large prefill shapes require --check-only or --shared-activations"
+        )
+    if not args.build_only:
+        if args.output is None or args.output.exists():
+            parser.error("a run requires a new output path")
+        active = subprocess.check_output(
+            ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"],
+            text=True,
+        ).strip()
+        if active:
+            parser.error(f"GPUs already have compute processes: {active}")
+    settings = {
+        "VLLM_DSV4_MHC_MODE": "0",
+        "VLLM_DSV4_MHC_COOP_MAX_T": "8",
+        "VLLM_DSV4_MHC_SPLITS": "64",
+        "VLLM_DSV4_MHC_PREFILL_MIN_T": "64",
+    }
+    for key, value in settings.items():
+        if key in os.environ and os.environ[key] != value:
+            parser.error(f"requires {key}={value}")
+        os.environ[key] = value
+    extension = build(args.build_dir, name="mhc_storage_probe")
+    if args.build_only:
+        return
+    candidate_run = extension.run_paired if args.paired_prefill_fn else extension.run
+    from vllm.quixicore.ops import quixicore_ops as qc
+
+    root = Path(__file__).resolve().parents[2]
+    sources = [
+        Path(__file__),
+        Path(__file__).with_name("mhc_storage_probe.cu"),
+        Path(__file__).with_name("benchmark_mhc_output_parallel.py"),
+        root / "csrc/quixicore/serving/mhc_ampere.cuh",
+        root / "csrc/quixicore/tm_cuda/tm_cuda_serving.cu",
+    ]
+    result = {
+        "status": "running",
+        "diagnostic_only": True,
+        "method": __doc__,
+        "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "git_status": subprocess.check_output(
+            ["git", "status", "--short"], text=True
+        ).strip(),
+        "source_sha256": {
+            str(p.relative_to(root)): hashlib.sha256(p.read_bytes()).hexdigest()
+            for p in sources
+        },
+        "extension_sha256": hashlib.sha256(
+            Path(extension.__file__).read_bytes()
+        ).hexdigest(),
+        "serving_sha256": {
+            str(p.relative_to(root)): hashlib.sha256(p.read_bytes()).hexdigest()
+            for p in (root / "vllm").glob("_quixicore_C*.so")
+        },
+        "torch": torch.__version__,
+        "gpu": torch.cuda.get_device_name(),
+        "environment": settings,
+        "settings": {
+            k: str(v) if isinstance(v, Path) else v for k, v in vars(args).items()
+        },
+        "checks": [],
+        "checked_site_indices": check_sites,
+        "timings": [],
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("x") as stream:
+        json.dump(result, stream, indent=2)
+
+    def save():
+        args.output.write_text(json.dumps(result, indent=2) + "\n")
+
+    def installed(data, fused):
+        x, residual, post, comb, fn, scale, base = data
+        constants = [1e-5, 1e-6, 1e-6, 2.0, 20, None, 0.0]
+        if fused:
+            return qc.dsv4_mhc_fused_post_pre(*data, *constants)
+        return [residual, *qc.dsv4_mhc_pre(residual, fn, scale, base, *constants)]
+
+    try:
+        sites, result["parameters"] = checkpoint_parameters(args.model)
+        narrow = [lossless_bf16(site[0]) for site in sites]
+        result["site_count"] = len(sites)
+        if len(sites) != 90:
+            raise ValueError("expected all 90 GLM mHC sites")
+        save()
+        for batch in args.batch:
+            for site in check_sites:
+                weights = sites[site]
+                for magnitude in (0.01, 1.0, 100.0):
+                    data = inputs(batch, 301 + site, magnitude)[:7]
+                    data[4:7] = weights
+                    candidate = [*data[:4], narrow[site], *data[5:]]
+                    for fused in (False, True):
+                        row = {
+                            "batch": batch,
+                            "site": site,
+                            "magnitude": magnitude,
+                            "fused": fused,
+                            "status": "checking",
+                        }
+                        result["checks"].append(row)
+                        original = extension.run(*data, fused)
+                        exact(installed(data, fused), original)
+                        exact(original, candidate_run(*candidate, fused))
+                        if args.check_installed_bf16:
+                            exact(original, installed(candidate, fused))
+                        # Both storage forms share the same changing activations.
+                        graph = torch.cuda.CUDAGraph()
+                        torch.cuda.synchronize()
+                        with torch.cuda.graph(graph):
+                            a = extension.run(*data, fused)
+                            b = candidate_run(*candidate, fused)
+                            c = (
+                                installed(candidate, fused)
+                                if args.check_installed_bf16
+                                else None
+                            )
+                        for replay in range(3):
+                            fresh = inputs(batch, 2001 + site * 3 + replay, magnitude)
+                            for target, source in zip(data[:4], fresh[:4]):
+                                target.copy_(source)
+                            graph.replay()
+                            exact(a, b)
+                            if c is not None:
+                                exact(a, c)
+                        row["status"] = "bit_exact"
+                    save()
+                if site % 15 == 0:
+                    print(f"batch {batch}: checked site {site + 1}/90", flush=True)
+            if args.check_only:
+                continue
+            torch.cuda.reset_peak_memory_stats()
+            rows = timing_rows(
+                sites, narrow, batch, args.shared_activations, args.weight_banks
+            )
+            size = sum(row[1][4].numel() * row[1][4].element_size() for row in rows)
+            if size <= 128 * 2**20:
+                raise ValueError("narrow weight rotation does not exceed SM120 L2")
+            graphs = []
+
+            def timed_call(row, variant):
+                if variant == 0 and args.timing_baseline == "installed-bf16":
+                    return installed(row[1], row[2])
+                call = candidate_run if variant else extension.run
+                return call(*row[variant], row[2])
+
+            for variant in (0, 1):
+                for row in rows:
+                    timed_call(row, variant)
+                torch.cuda.synchronize()
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph):
+                    for row in rows:
+                        timed_call(row, variant)
+                graphs.append(graph)
+            timing = {
+                "batch": batch,
+                "sites_per_graph": len(rows),
+                "narrow_fn_bytes": size,
+                "activation_sets": args.weight_banks
+                if args.shared_activations
+                else len(rows),
+                "weight_banks": args.weight_banks,
+                "narrow_fn_l2_ratio": size / (128 * 2**20),
+                "shared_activations": args.shared_activations,
+                "baseline": args.timing_baseline,
+                "candidate": "probe-bf16-paired-prefill"
+                if args.paired_prefill_fn
+                else "probe-bf16",
+                "capture_peak_allocated_bytes": torch.cuda.max_memory_allocated(),
+                "rounds": [],
+            }
+            result["timings"].append(timing)
+            for _ in range(args.rounds):
+                sample = {}
+                for label, variant in (("A", 0), ("B", 1), ("A2", 0)):
+                    graph = graphs[variant]
+                    for _ in range(3):
+                        graph.replay()
+                    a, b = (
+                        torch.cuda.Event(enable_timing=True),
+                        torch.cuda.Event(enable_timing=True),
+                    )
+                    a.record()
+                    for _ in range(args.replays):
+                        graph.replay()
+                    b.record()
+                    b.synchronize()
+                    sample[label] = (
+                        a.elapsed_time(b) * 1000 / (args.replays * len(rows))
+                    )
+                timing["rounds"].append(sample)
+                save()
+            timing["median_paired_throughput_change_pct"] = statistics.median(
+                (0.5 * (r["A"] + r["A2"]) / r["B"] - 1) * 100 for r in timing["rounds"]
+            )
+            print(json.dumps(timing), flush=True)
+            del graphs, graph, rows, data, candidate
+            save()
+        result["status"] = "complete"
+    except BaseException as exc:
+        result["status"], result["error"] = "failed", repr(exc)
+        save()
+        raise
+    save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_glm53_mhc_tc_qualified.py
+++ b/benchmarks/kernels/benchmark_glm53_mhc_tc_qualified.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Cold isolated A/B/A timing, gated on the complete independent FP64 census.
+
+This does not satisfy sanitizer, real-profile or model-quality promotion gates.
+The original strict parity census remains failed. Five rounds/four replays,
+three warmups, six banks of all90 actual fn matrices, all five prescribed sizes.
+"""
+
+import argparse
+import importlib.util
+import json
+import math
+import os
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.benchmark_glm53_mhc_prefill_tc import installed, oracle_rows
+from benchmarks.kernels.benchmark_glm53_mhc_storage import lossless_bf16
+from benchmarks.kernels.benchmark_mhc_output_parallel import (
+    checkpoint_parameters,
+    inputs,
+)
+from benchmarks.kernels.check_glm53_mhc_tc_accuracy import PROBE_SHA, case_plan, sha
+
+BATCHES = [64, 65, 128, 129, 7616]
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def validate_accuracy(stats, rows):
+    require(stats["passed"] and stats["rows"] == rows, "accuracy rows/status mismatch")
+    for arm in ("reference", "candidate"):
+        data = stats[arm]
+        require(data["passed"], f"{arm} failed accuracy")
+        require(data["elements"] == rows * 4096, "hidden-coordinate coverage mismatch")
+        require(
+            not any(
+                data[k] for k in ("violations", "post_violations", "comb_violations")
+            ),
+            "pointwise accuracy violation",
+        )
+        for key, value in data.items():
+            require(
+                isinstance(value, (int, float)) and math.isfinite(value) and value >= 0,
+                f"invalid accuracy metric {arm}/{key}",
+            )
+        nrms = math.sqrt(data["squared_error"] / max(data["ideal_squared_sum"], 1e-60))
+        require(
+            math.isclose(nrms, data["normalized_rms"], rel_tol=1e-12, abs_tol=1e-30),
+            "inconsistent RMS calculation",
+        )
+    require(
+        stats["candidate_rms_noninferior"]
+        and stats["candidate"]["normalized_rms"]
+        <= 1.001 * stats["reference"]["normalized_rms"] + 1e-7,
+        "candidate RMS regression",
+    )
+
+
+def validate_partial(data, batch):
+    require(
+        data["passed"] and data["finite"] and data["rows"] == oracle_rows(batch),
+        "partial oracle status/rows mismatch",
+    )
+    for key, limit in (
+        ("dot_normalized_rms", 2e-6),
+        ("dot_row_peak_error", 2e-5),
+        ("square_relative_error", 1e-5),
+    ):
+        require(
+            math.isfinite(data[key]) and 0 <= data[key] <= limit,
+            f"partial oracle violation: {key}",
+        )
+
+
+def qualified_census(directory):
+    """Fail closed on bounded, interrupted, changed or internally invalid runs."""
+    summary = directory / "summary.json"
+    data = json.loads(summary.read_bytes())
+    plan = case_plan(BATCHES, list(range(90)))
+    require(
+        data["status"] == "complete" and data["contract"] == "glm53-mhc-tc-accuracy-v1",
+        "full independent accuracy census must be complete",
+    )
+    require(
+        data["planned_cases"] == data["completed_cases"] == len(plan)
+        and data["completed_graph_phases"] == 8100,
+        "full 2700-case/8100-phase census required",
+    )
+    require(
+        data["plan"] == plan and data["extension_sha256"] == PROBE_SHA,
+        "census plan or candidate changed",
+    )
+    journal = directory / "checks.jsonl"
+    require(sha(journal) == data["journal_sha256"], "census journal digest mismatch")
+    strict_failures, count = 0, 0
+    with journal.open() as stream:
+        for count, line in enumerate(stream, 1):
+            require(count <= len(plan), "extra census row")
+            row, item = json.loads(line), plan[count - 1]
+            require(
+                row["status"] == "complete"
+                and all(row[k] == v for k, v in item.items()),
+                "census row incomplete, reordered or changed",
+            )
+            validate_accuracy(row["eager_fp64_all_rows"], item["batch"])
+            validate_partial(row["partial_oracle"], item["batch"])
+            strict_failures += not row["strict_parity_diagnostic"]["passed"]
+            require(len(row["graphs"]) == 3, "missing graph phase")
+            for phase, seed in zip(row["graphs"], item["graph_seeds"]):
+                require(
+                    phase["status"] == "complete"
+                    and phase["seed"] == seed
+                    and phase["all_output_bits_match_eager"],
+                    "graph status/seed/bit gate failed",
+                )
+                require(
+                    phase["oracle_rows"] == oracle_rows(item["batch"]),
+                    "graph sampled rows changed",
+                )
+                validate_accuracy(phase["fp64_sampled_rows"], len(phase["oracle_rows"]))
+                validate_partial(phase["partial_oracle"], item["batch"])
+                strict_failures += not phase["strict_parity_diagnostic"]["passed"]
+    require(count == len(plan), "missing census rows")
+    require(
+        strict_failures == data["strict_parity_failed_comparisons"],
+        "strict parity failure count changed",
+    )
+    return data, {
+        "summary_sha256": sha(summary),
+        "journal_sha256": sha(journal),
+        "completed_cases": count,
+        "graph_phases": 8100,
+        "strict_parity_failed_comparisons": strict_failures,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--census", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    require(not args.output.exists(), "new output directory required")
+    census, receipt = qualified_census(args.census)
+    root = Path(__file__).resolve().parents[2]
+    source_hashes = {
+        **census["source_sha256"],
+        str(Path(__file__).relative_to(root)): sha(__file__),
+    }
+    for path, digest in source_hashes.items():
+        require(
+            sha(root / path) == digest, f"source changed since qualification: {path}"
+        )
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"], text=True
+    ).strip()
+    require(not active, f"GPU compute processes already active: {active}")
+    for key, value in census["environment"].items():
+        require(
+            key not in os.environ or os.environ[key] == value, f"requires {key}={value}"
+        )
+        os.environ[key] = value
+    extension_path = Path(census["settings"]["extension"])
+    require(sha(extension_path) == PROBE_SHA, "qualified candidate binary changed")
+    import vllm._quixicore_C as native
+
+    require(
+        sha(native.__file__) == census["native_sha256"],
+        "qualified baseline binary changed",
+    )
+    torch.set_num_threads(4)
+    require(torch.cuda.get_device_capability() == (12, 0), "SM120 target required")
+    spec = importlib.util.spec_from_file_location(
+        "mhc_prefill_tc_probe", extension_path
+    )
+    extension = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(extension)
+    args.output.mkdir(parents=True)
+    result = {
+        "status": "running",
+        "diagnostic_only": True,
+        "method": __doc__,
+        "command": sys.argv,
+        "accuracy_receipt": receipt,
+        "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "git_status": subprocess.check_output(
+            ["git", "status", "--short"], text=True
+        ).strip(),
+        "source_sha256": source_hashes,
+        "native_sha256": census["native_sha256"],
+        "extension_sha256": PROBE_SHA,
+        "environment": census["environment"],
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "gpu": torch.cuda.get_device_name(),
+        "resources": extension.resources(),
+        "timings": [],
+    }
+
+    def save():
+        temp = args.output / "summary.tmp"
+        temp.write_text(json.dumps(result, indent=2) + "\n")
+        temp.replace(args.output / "summary.json")
+
+    save()
+    try:
+        sites, result["parameters"] = checkpoint_parameters(
+            Path(census["settings"]["model"])
+        )
+        require(
+            result["parameters"] == census["parameters"],
+            "model parameters changed since census",
+        )
+        sites = [[lossless_bf16(s[0]), *s[1:]] for s in sites]
+        for batch in BATCHES:
+            # Same six activation seeds/90-site rotation as the original screen.
+            # Only used BF16 weights are allocated, no unused FP32 bank copies.
+            rows = []
+            for bank in range(6):
+                activations = inputs(batch, 5001 + bank * 90)[:4]
+                for site, weights in enumerate(sites):
+                    rows.append(
+                        ([*activations, weights[0].clone(), *weights[1:]], site != 0)
+                    )
+            fn_bytes = sum(data[4].numel() * data[4].element_size() for data, _ in rows)
+            require(
+                len(rows) == 540 and fn_bytes > 3 * 128 * 2**20,
+                "cold fn working set too small",
+            )
+            graphs = []
+            torch.cuda.reset_peak_memory_stats()
+            for call in (installed, lambda data, fused: extension.run(*data, fused)):
+                for data, fused in rows:
+                    call(data, fused)
+                torch.cuda.synchronize()
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph):
+                    for data, fused in rows:
+                        call(data, fused)
+                graphs.append(graph)
+            timing = {
+                "batch": batch,
+                "sites_per_graph": 540,
+                "fn_bytes": fn_bytes,
+                "fn_l2_ratio": fn_bytes / (128 * 2**20),
+                "activation_sets": 6,
+                "capture_peak_allocated_bytes": torch.cuda.max_memory_allocated(),
+                "rounds": [],
+            }
+            result["timings"].append(timing)
+            for repeat in range(5):
+                sample = {"repeat": repeat + 1}
+                timing["rounds"].append(sample)
+                for phase, variant in (("A", 0), ("B", 1), ("A2", 0)):
+                    graph = graphs[variant]
+                    for _ in range(3):
+                        graph.replay()
+                    start, end = (
+                        torch.cuda.Event(enable_timing=True) for _ in range(2)
+                    )
+                    start.record()
+                    for _ in range(4):
+                        graph.replay()
+                    end.record()
+                    end.synchronize()
+                    sample[phase] = start.elapsed_time(end) * 1000 / (4 * 540)
+                    save()
+            timing["median_us"] = {
+                phase: statistics.median(r[phase] for r in timing["rounds"])
+                for phase in ("A", "B", "A2")
+            }
+            timing["median_paired_throughput_change_pct"] = statistics.median(
+                (0.5 * (r["A"] + r["A2"]) / r["B"] - 1) * 100 for r in timing["rounds"]
+            )
+            print(json.dumps(timing), flush=True)
+            del graphs, graph, rows, data, activations
+            save()
+        for path, digest in source_hashes.items():
+            require(sha(root / path) == digest, f"source changed during timing: {path}")
+        require(
+            sha(native.__file__) == census["native_sha256"]
+            and sha(extension_path) == PROBE_SHA,
+            "binary changed during timing",
+        )
+        result["status"] = "complete"
+    except BaseException as error:
+        result["status"], result["error"] = "failed", repr(error)
+        raise
+    finally:
+        save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_glm53_nvfp4_pipeline.py
+++ b/benchmarks/kernels/benchmark_glm53_nvfp4_pipeline.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Rejected Phase 4.1 cross-item pipeline versus drain control and Marlin.
+
+Fixed batch1/TP4 shapes and NT16/K512/four-stage geometry; no parameter sweep.
+Actual checkpoint weights and captured routes, synthetic BF16 inputs. Both GEMMs
+are unweighted here to isolate staging; this is not a fused MoE or serving result.
+Forty-five independently allocated fixtures exceed three SM120 L2 capacities
+for each projection separately; these are data fixtures, not kernel variants.
+"""
+
+import argparse
+import gc
+import hashlib
+import json
+import statistics
+import subprocess
+from contextlib import ExitStack
+from functools import partial
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+from safetensors import safe_open
+
+from benchmarks.kernels.benchmark_glm53_marlin_schedule import measure
+from benchmarks.kernels.check_glm53_marlin_schedule import decode_fragments, errors
+from benchmarks.kernels.profile_glm53_marlin import route_cases
+
+
+def load_selected(model, index, layer, experts):
+    """Rank0 slices, actual global-scale convention, gate|up concatenation."""
+    result = {key: [] for key in ("w13", "s13", "g13", "w2", "s2", "g2")}
+    with ExitStack() as stack:
+        shards = {}
+
+        def get(key):
+            name = index[key]
+            if name not in shards:
+                shards[name] = stack.enter_context(
+                    safe_open(model / name, framework="pt", device="cpu")
+                )
+            return shards[name].get_tensor(key)
+
+        for expert in experts:
+            prefix = f"model.language_model.layers.{layer}.mlp.experts.{expert}."
+            gate, up, down = (
+                prefix + part + "." for part in ("gate_proj", "up_proj", "down_proj")
+            )
+            result["w13"].append(
+                torch.cat(
+                    [
+                        get(gate + "weight_packed")[:512],
+                        get(up + "weight_packed")[:512],
+                    ]
+                )
+            )
+            result["s13"].append(
+                torch.cat(
+                    [
+                        get(gate + "weight_scale")[:512],
+                        get(up + "weight_scale")[:512],
+                    ]
+                )
+            )
+            gg, gu = (get(p + "weight_global_scale") for p in (gate, up))
+            if not torch.equal(gg, gu):
+                raise ValueError("gate/up global scales differ")
+            result["g13"].append((1 / gg.float()).reshape(()))
+            result["w2"].append(get(down + "weight_packed")[:, :256].contiguous())
+            result["s2"].append(get(down + "weight_scale")[:, :32].contiguous())
+            result["g2"].append(
+                (1 / get(down + "weight_global_scale").float()).reshape(())
+            )
+    return {key: torch.stack(value) for key, value in result.items()}
+
+
+def repack(packed):
+    """Byte-neutral layout from the archived prototype, no quant conversion."""
+    e, n, kh = packed.shape
+    codes = (
+        torch.stack([packed & 15, packed >> 4], -1).reshape(e, n, kh // 16, 32).int()
+    )
+    words = torch.zeros(e, n, kh // 16, 4, dtype=torch.int32, device=packed.device)
+    for q in range(4):
+        for pos, k in (
+            (3, 0),
+            (7, 1),
+            (2, 8),
+            (6, 9),
+            (1, 16),
+            (5, 17),
+            (0, 24),
+            (4, 25),
+        ):
+            words[..., q] |= codes[..., k + 2 * q] << (4 * pos)
+    return words.view(torch.uint8).reshape(e, n, kh)
+
+
+def build(path):
+    from torch.utils.cpp_extension import load
+
+    path.mkdir(parents=True, exist_ok=True)
+    return load(
+        name="glm53_nvfp4_pipeline",
+        sources=[str(Path(__file__).with_name("nvfp4_decode_pipeline.cu").resolve())],
+        extra_include_paths=[str(Path(__file__).resolve().parents[2] / "csrc")],
+        extra_cflags=["-O3", "-std=c++20"],
+        extra_cuda_cflags=[
+            "-O3",
+            "-std=c++20",
+            "-lineinfo",
+            "-gencode=arch=compute_120f,code=sm_120f",
+            "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+        ],
+        build_directory=str(path),
+        verbose=True,
+    )
+
+
+def capture(calls):
+    for call in calls:
+        call()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        for call in calls:
+            call()
+    return graph
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path)
+    parser.add_argument("--journal", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--build-dir", type=Path, required=True)
+    parser.add_argument("--build-only", action="store_true")
+    args = parser.parse_args()
+    if not args.build_only and (not args.model or not args.journal or not args.output):
+        parser.error("model, journal and output required")
+    if args.output and args.output.exists():
+        parser.error("output must be new")
+    ext = build(args.build_dir)
+    if args.build_only:
+        return
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"], text=True
+    ).strip()
+    if active:
+        raise RuntimeError(f"GPUs busy: {active}")
+    torch.set_num_threads(4)
+    torch.manual_seed(105341)
+    from vllm import _custom_ops as ops
+    from vllm.model_executor.layers.fused_moe.activation import (
+        MoEActivation,
+        apply_moe_activation,
+    )
+    from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
+        moe_align_block_size,
+    )
+    from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
+        prepare_nvfp4_moe_layer_for_marlin,
+    )
+    from vllm.scalar_type import scalar_types
+
+    index = json.loads((args.model / "model.safetensors.index.json").read_text())[
+        "weight_map"
+    ]
+    result = {
+        "status": "running",
+        "roadmap": "4.1",
+        "diagnostic_only": True,
+        "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "method": __doc__,
+        "fixtures": [],
+        "timings": {},
+        "journal_sha256": hashlib.sha256(args.journal.read_bytes()).hexdigest(),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    def save():
+        args.output.write_text(json.dumps(result, indent=2) + "\n")
+
+    save()
+    try:
+        if torch.cuda.get_device_capability() != (12, 0):
+            raise ValueError("SM120 required")
+        result["gpu"] = torch.cuda.get_device_name()
+        root = Path(__file__).resolve().parents[2]
+        result["source_sha256"] = {
+            name: hashlib.sha256((root / name).read_bytes()).hexdigest()
+            for name in (
+                "benchmarks/kernels/benchmark_glm53_nvfp4_pipeline.py",
+                "benchmarks/kernels/nvfp4_decode_pipeline.cu",
+                "benchmarks/kernels/nvfp4_decode_sm120.cuh",
+            )
+        }
+        calls = {
+            phase: {kind: [] for kind in ("drain", "pipeline", "marlin")}
+            for phase in ("gate_up", "down")
+        }
+        keepalive = []
+        for layer in (3, 23, 44):
+            for _, record in route_cases(args.journal, [1], 15):
+                experts = record["routes"][0][layer - 3]
+                if len(experts) != 8 or len(set(experts)) != 8:
+                    raise ValueError("expected eight distinct captured experts")
+                raw = load_selected(args.model, index, layer, experts)
+                device = {key: value.cuda() for key, value in raw.items()}
+                layer_stub = SimpleNamespace(
+                    num_experts=8,
+                    hidden_size=4096,
+                    intermediate_size_per_partition=512,
+                    params_dtype=torch.bfloat16,
+                )
+                marlin = prepare_nvfp4_moe_layer_for_marlin(
+                    layer_stub,
+                    *[device[k] for k in ("w13", "s13", "g13", "w2", "s2", "g2")],
+                    True,
+                )
+                ids = torch.arange(8, dtype=torch.int32, device="cuda")
+                sorted_ids, expert_ids, padded = moe_align_block_size(ids[None], 8, 8)
+                topk_weights = torch.full((1, 8), 2.5 / 8, device="cuda")
+                counts = torch.ones(8, dtype=torch.int32, device="cuda")
+                x = torch.randn(1, 4096, device="cuda", dtype=torch.bfloat16)
+                gate_reference = None
+                for phase, prefix, mi in (("gate_up", "13", 0), ("down", "2", 3)):
+                    if phase == "down":
+                        x = torch.empty(8, 512, device="cuda", dtype=torch.bfloat16)
+                        apply_moe_activation(
+                            MoEActivation.SILU, x, gate_reference, clamp_limit=10.0
+                        )
+                    n, k = device["w" + prefix].shape[1], x.shape[1]
+                    rows = torch.full((8, 16), -1, dtype=torch.int32, device="cuda")
+                    rows[:, 0] = 0 if phase == "gate_up" else ids
+                    w = repack(device["w" + prefix])
+                    outputs = {
+                        kind: torch.empty(8, n, device="cuda", dtype=torch.bfloat16)
+                        for kind in calls[phase]
+                    }
+                    native_args = (
+                        x,
+                        w,
+                        device["s" + prefix],
+                        device["g" + prefix],
+                        ids,
+                        rows,
+                        counts,
+                        ids,
+                    )
+                    fns = {
+                        kind: partial(
+                            ext.run, *native_args, outputs[kind], kind == "pipeline"
+                        )
+                        for kind in ("drain", "pipeline")
+                    }
+                    fns["marlin"] = partial(
+                        ops.moe_wna16_marlin_gemm,
+                        x,
+                        outputs["marlin"],
+                        marlin[mi],
+                        None,
+                        marlin[mi + 1],
+                        None,
+                        marlin[mi + 2],
+                        None,
+                        None,
+                        None,
+                        layer_stub.workspace,
+                        sorted_ids,
+                        expert_ids,
+                        padded,
+                        topk_weights,
+                        moe_block_size=8,
+                        top_k=8 if phase == "gate_up" else 1,
+                        mul_topk_weights=False,
+                        b_q_type=scalar_types.float4_e2m1f,
+                        size_m=x.shape[0],
+                        size_n=n,
+                        size_k=k,
+                        is_k_full=True,
+                        use_atomic_add=False,
+                        use_fp32_reduce=True,
+                        is_zp_float=False,
+                    )
+                    for fn in fns.values():
+                        fn()
+                    torch.testing.assert_close(
+                        outputs["pipeline"], outputs["drain"], rtol=0, atol=0
+                    )
+                    torch.testing.assert_close(
+                        outputs["pipeline"], outputs["marlin"], rtol=0.01, atol=0.01
+                    )
+                    # Independent actual-byte FP64 oracle on fixed strided output rows.
+                    sample = torch.arange(0, n, n // 32)
+                    expected = []
+                    cpu_x = x.cpu()
+                    for slot in range(8):
+                        weight = decode_fragments(
+                            raw["w" + prefix][slot, sample],
+                            raw["s" + prefix][slot]
+                            .view(torch.uint8)[sample]
+                            .view(torch.float8_e4m3fn),
+                        )
+                        value = (
+                            weight @ cpu_x[0 if phase == "gate_up" else slot].double()
+                        )
+                        expected.append(value * raw["g" + prefix][slot].double())
+                    expected = torch.stack(expected).bfloat16()
+                    actual = outputs["pipeline"].cpu()[:, sample]
+                    torch.testing.assert_close(actual, expected, rtol=0.01, atol=0.01)
+                    result["fixtures"].append(
+                        {
+                            "layer": layer,
+                            "step": record["step"],
+                            "experts": experts,
+                            "phase": phase,
+                            "drain_bit_exact": True,
+                            "versus_marlin": errors(
+                                outputs["pipeline"], outputs["marlin"]
+                            ),
+                            "sampled_oracle": errors(actual, expected),
+                            "weight_sha256": hashlib.sha256(
+                                raw["w" + prefix].numpy().tobytes()
+                            ).hexdigest(),
+                        }
+                    )
+                    print(
+                        f"checked layer={layer} step={record['step']} phase={phase}",
+                        flush=True,
+                    )
+                    for kind, fn in fns.items():
+                        calls[phase][kind].append(fn)
+                    keepalive.append((native_args, outputs, marlin, layer_stub, fns))
+                    if phase == "gate_up":
+                        gate_reference = outputs["marlin"]
+                save()
+                del raw, device
+                gc.collect()
+        # A/B/A plus the retained production comparator: fixed counts, all retained.
+        for phase, implementations in calls.items():
+            graphs = {kind: capture(fns) for kind, fns in implementations.items()}
+            samples = []
+            for _ in range(3):
+                samples.append(
+                    {
+                        kind: measure(graphs[kind], len(implementations[kind]), 10)
+                        for kind in ("marlin", "drain", "pipeline")
+                    }
+                )
+                samples[-1]["return_drain"] = measure(
+                    graphs["drain"], len(implementations["drain"]), 10
+                )
+                samples[-1]["return_marlin"] = measure(
+                    graphs["marlin"], len(implementations["marlin"]), 10
+                )
+            result["timings"][phase] = {
+                "samples_us": samples,
+                "median_us": {
+                    kind: statistics.median(row[kind] for row in samples)
+                    for kind in samples[0]
+                },
+            }
+            print(phase, result["timings"][phase], flush=True)
+            save()
+        result["status"] = "complete"
+    except BaseException as error:
+        result["status"] = "failed"
+        result["error"] = str(error)
+        raise
+    finally:
+        save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_glm53_sparse_prefill_tiles.py
+++ b/benchmarks/kernels/benchmark_glm53_sparse_prefill_tiles.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Archived rejected SM120 sparse-prefill experiments; diagnostic only.
+
+BF16 Q/KV and the existing FP16 probability product are unchanged. Synthetic
+queries use 512 distinct pooled groups (four contiguous tokens per group) from
+a 32K/128K cache. All five experiment families completed on 2026-09-10 without
+a useful gain. Preserve this reproducer and its raw results; do not resume the
+sweep. See perf/optimization_status.md, "Close sparse-prefill local variants".
+No serving dispatcher imports the experimental kernels.
+"""
+
+import argparse
+import hashlib
+import json
+import math
+import statistics
+import subprocess
+from functools import partial
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.benchmark_glm53_marlin_schedule import measure
+from vllm.v1.attention.backends.mla import quixicore_mla_sparse_prefill as pf
+
+
+def capture(call):
+    call()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        call()
+    return graph
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--batch", type=int, nargs="+", default=[2048, 7616])
+    parser.add_argument("--context", type=int, nargs="+", default=[32768, 131072])
+    parser.add_argument("--rounds", type=int, default=3)
+    parser.add_argument("--replays", type=int, default=5)
+    parser.add_argument("--split-heads", action="store_true")
+    parser.add_argument("--fused-accumulator", action="store_true")
+    parser.add_argument("--reload-query", action="store_true")
+    parser.add_argument("--split-values", action="store_true")
+    args = parser.parse_args()
+    if args.output.exists() or min(args.rounds, args.replays, *args.batch) < 1:
+        parser.error("new output path and positive counts required")
+    if any(c not in (32768, 131072) for c in args.context):
+        parser.error("use the fixed 32K/128K cache cases")
+    if (
+        sum(
+            (
+                args.split_heads,
+                args.fused_accumulator,
+                args.reload_query,
+                args.split_values,
+            )
+        )
+        > 1
+    ):
+        parser.error("test one kernel hypothesis at a time")
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"], text=True
+    ).strip()
+    if active:
+        parser.error(f"GPUs busy: {active}")
+    if torch.cuda.get_device_capability() != (12, 0):
+        parser.error("SM120 required")
+    torch.manual_seed(91053)
+    result = {
+        "status": "running",
+        "diagnostic_only": True,
+        "gpu": torch.cuda.get_device_name(),
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "source_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "settings": {
+            k: str(v) if isinstance(v, Path) else v for k, v in vars(args).items()
+        },
+        "cases": [],
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    def save():
+        args.output.write_text(json.dumps(result, indent=2) + "\n")
+
+    try:
+        for batch in args.batch:
+            for context in args.context:
+                q = (torch.randn(batch, 32, 512, device="cuda") * 0.2).bfloat16()
+                kv = (
+                    torch.randn(context // 64, 64, 512, device="cuda") * 0.5
+                ).bfloat16()
+                bt = torch.arange(context // 64, device="cuda", dtype=torch.int32)
+                bt = bt[None].repeat(batch, 1)
+                # Odd strides permute a power-of-two pool domain, guaranteeing
+                # distinct groups without a giant random ranking matrix.
+                stride = torch.randint(context // 8, (batch, 1), device="cuda") * 2 + 1
+                offset = torch.randint(context // 4, (batch, 1), device="cuda")
+                group = (torch.arange(512, device="cuda")[None] * stride + offset) % (
+                    context // 4
+                )
+                indices = (
+                    (group[:, :, None] * 4 + torch.arange(4, device="cuda"))
+                    .reshape(batch, 2048)
+                    .int()
+                )
+                lengths = torch.full((batch,), 2048, device="cuda", dtype=torch.int32)
+                reference = pf.sparse_mla_prefill_nope(
+                    q, kv, bt, indices, lengths, 64, 1 / math.sqrt(512)
+                )
+                baseline_out = torch.empty_like(q)
+                candidate_out = torch.empty_like(q)
+
+                def call(
+                    out,
+                    n,
+                    warps,
+                    stages,
+                    batch=batch,
+                    q=q,
+                    kv=kv,
+                    bt=bt,
+                    indices=indices,
+                    lengths=lengths,
+                    implementation=pf._sparse_mla_prefill_kernel,
+                    kernel_kwargs=None,
+                ):
+                    value_tile = (kernel_kwargs or {}).get("VALUE_TILE", 512) or 512
+                    return implementation[(batch, 512 // value_tile)](
+                        q,
+                        kv,
+                        bt,
+                        indices,
+                        lengths,
+                        out,
+                        2048,
+                        bt.shape[1],
+                        kv.stride(0),
+                        64,
+                        1 / math.sqrt(512),
+                        H=32,
+                        D=512,
+                        BLOCK_N=n,
+                        num_warps=warps,
+                        num_stages=stages,
+                        **(kernel_kwargs or {}),
+                    )
+
+                baseline_kernel = call(baseline_out, 32, 4, 2)
+                torch.testing.assert_close(baseline_out, reference, rtol=0, atol=0)
+                baseline = capture(partial(call, baseline_out, 32, 4, 2))
+                if args.split_heads:
+                    # Each head is independent. This isolated view uses the
+                    # existing H16 kernel with duplicated request metadata;
+                    # a serving implementation would use a second grid axis.
+                    split_q = q.reshape(batch * 2, 16, 512)
+                    split_bt = bt.repeat_interleave(2, dim=0)
+                    split_indices = indices.repeat_interleave(2, dim=0)
+                    split_lengths = lengths.repeat_interleave(2, dim=0)
+
+                    def candidate_call(
+                        out,
+                        n,
+                        warps,
+                        stages,
+                        q=split_q,
+                        bt=split_bt,
+                        indices=split_indices,
+                        lengths=split_lengths,
+                        kv=kv,
+                    ):
+                        return pf._sparse_mla_prefill_kernel[(q.shape[0],)](
+                            q,
+                            kv,
+                            bt,
+                            indices,
+                            lengths,
+                            out,
+                            2048,
+                            bt.shape[1],
+                            kv.stride(0),
+                            64,
+                            1 / math.sqrt(512),
+                            H=16,
+                            D=512,
+                            BLOCK_N=n,
+                            num_warps=warps,
+                            num_stages=stages,
+                        )
+
+                    configs = [(32, 4, 2), (32, 4, 1), (64, 4, 1)]
+                elif args.fused_accumulator or args.reload_query or args.split_values:
+                    from benchmarks.kernels.glm53_sparse_prefill_fused import kernel
+
+                    candidate_call = partial(
+                        call,
+                        implementation=kernel,
+                        kernel_kwargs={
+                            "RELOAD_Q": args.reload_query,
+                            "FUSE_ACC": args.fused_accumulator,
+                            "VALUE_TILE": 256 if args.split_values else 0,
+                        },
+                    )
+                    configs = (
+                        [(32, 4, 1), (32, 4, 2)]
+                        if args.split_values
+                        else [(32, 4, 1), (32, 4, 2), (32, 4, 3)]
+                        if args.reload_query
+                        else [(32, 4, 2), (32, 8, 2), (64, 4, 1)]
+                    )
+                else:
+                    candidate_call = call
+                    configs = [(64, 4, 1), (64, 8, 1)]
+                for n, warps, stages in configs:
+                    row = {
+                        "batch": batch,
+                        "context": context,
+                        "tile": [n, warps, stages],
+                        "heads_per_block": 16 if args.split_heads else 32,
+                        "value_tile": 256 if args.split_values else 512,
+                        "baseline_resources": {
+                            "registers": baseline_kernel.n_regs,
+                            "spills": baseline_kernel.n_spills,
+                            "shared": baseline_kernel.metadata.shared,
+                        },
+                    }
+                    result["cases"].append(row)
+                    try:
+                        kernel = candidate_call(candidate_out, n, warps, stages)
+                    except torch.OutOfMemoryError:
+                        raise
+                    except Exception as error:
+                        if "out of resource" not in str(error).lower():
+                            raise
+                        row.update(status="unsupported", error=str(error))
+                        save()
+                        continue
+                    torch.testing.assert_close(
+                        candidate_out, reference, rtol=0.01, atol=0.016
+                    )
+                    delta = candidate_out.float() - reference.float()
+                    row.update(
+                        max_abs=delta.abs().max().item(),
+                        normalized_rms=(
+                            delta.square().mean().sqrt()
+                            / reference.float().square().mean().sqrt()
+                        ).item(),
+                        registers=kernel.n_regs,
+                        spills=kernel.n_spills,
+                        shared=kernel.metadata.shared,
+                    )
+                    candidate = capture(
+                        partial(candidate_call, candidate_out, n, warps, stages)
+                    )
+                    row["samples"] = [
+                        {
+                            name: measure(graph, 1, args.replays)
+                            for name, graph in (
+                                ("a_before_us", baseline),
+                                ("b_us", candidate),
+                                ("a_after_us", baseline),
+                            )
+                        }
+                        for _ in range(args.rounds)
+                    ]
+                    row["paired_speedup"] = statistics.median(
+                        (s["a_before_us"] + s["a_after_us"]) / (2 * s["b_us"])
+                        for s in row["samples"]
+                    )
+                    row["status"] = "complete"
+                    print(json.dumps(row), flush=True)
+                    save()
+                    del candidate
+                del baseline
+        result["status"] = "complete"
+    except BaseException as error:
+        result.update(status="failed", error=repr(error))
+        raise
+    finally:
+        save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_glm53_sparse_prefill_tiles.py
+++ b/benchmarks/kernels/benchmark_glm53_sparse_prefill_tiles.py
@@ -195,11 +195,13 @@ def main():
 
                     configs = [(32, 4, 2), (32, 4, 1), (64, 4, 1)]
                 elif args.fused_accumulator or args.reload_query or args.split_values:
-                    from benchmarks.kernels.glm53_sparse_prefill_fused import kernel
+                    from benchmarks.kernels.glm53_sparse_prefill_fused import (
+                        kernel as fused_kernel,
+                    )
 
                     candidate_call = partial(
                         call,
-                        implementation=kernel,
+                        implementation=fused_kernel,
                         kernel_kwargs={
                             "RELOAD_Q": args.reload_query,
                             "FUSE_ACC": args.fused_accumulator,
@@ -231,7 +233,7 @@ def main():
                     }
                     result["cases"].append(row)
                     try:
-                        kernel = candidate_call(candidate_out, n, warps, stages)
+                        compiled = candidate_call(candidate_out, n, warps, stages)
                     except torch.OutOfMemoryError:
                         raise
                     except Exception as error:
@@ -250,9 +252,9 @@ def main():
                             delta.square().mean().sqrt()
                             / reference.float().square().mean().sqrt()
                         ).item(),
-                        registers=kernel.n_regs,
-                        spills=kernel.n_spills,
-                        shared=kernel.metadata.shared,
+                        registers=compiled.n_regs,
+                        spills=compiled.n_spills,
+                        shared=compiled.metadata.shared,
                     )
                     candidate = capture(
                         partial(candidate_call, candidate_out, n, warps, stages)

--- a/benchmarks/kernels/benchmark_glm53_sparse_swapab.py
+++ b/benchmarks/kernels/benchmark_glm53_sparse_swapab.py
@@ -84,7 +84,8 @@ def main():
     ).strip()
     if active:
         parser.error(f"GPUs busy: {active}")
-    assert torch.cuda.get_device_capability() == (12, 0)
+    if torch.cuda.get_device_capability() != (12, 0):
+        parser.error("SM120 required")
     torch.manual_seed(4311)
     result = {
         "status": "running",
@@ -223,7 +224,8 @@ def main():
                 graph.replay()
             torch.cuda.synchronize()
             torch.testing.assert_close(outs[1], outs[0], rtol=0.01, atol=0.016)
-            assert torch.count_nonzero(outs[1][0]).item() == 0
+            if torch.count_nonzero(outs[1][0]).item() != 0:
+                raise ValueError("empty selection must produce a zero row")
             lengths.fill_(2048)
             indices[2, :64] = indices[3, :64]
             samples = []

--- a/benchmarks/kernels/benchmark_glm53_sparse_swapab.py
+++ b/benchmarks/kernels/benchmark_glm53_sparse_swapab.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""One source-led swapAB candidate on fixed SM120 prefill shapes. No sweep."""
+
+import argparse
+import hashlib
+import json
+import statistics
+import subprocess
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.benchmark_glm53_marlin_schedule import measure
+from benchmarks.kernels.benchmark_glm53_sparse_prefill_tiles import capture
+from benchmarks.kernels.glm53_sparse_swapab import sparse_swapab
+from vllm.v1.attention.backends.mla import quixicore_mla_sparse_prefill as pf
+
+
+def build_native(path):
+    from torch.utils.cpp_extension import load
+
+    path.mkdir(parents=True, exist_ok=True)
+    return load(
+        name="glm53_sparse_swapab",
+        sources=[str(Path(__file__).with_name("glm53_sparse_swapab.cu").resolve())],
+        extra_include_paths=[str(Path(__file__).resolve().parents[2] / "csrc")],
+        extra_cflags=["-O3", "-std=c++20"],
+        extra_cuda_cflags=[
+            "-O3",
+            "-std=c++20",
+            "-lineinfo",
+            "--expt-relaxed-constexpr",
+            "-gencode=arch=compute_120f,code=sm_120f",
+            "-Xptxas=-v",
+            "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+        ],
+        build_directory=str(path),
+        verbose=True,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--model",
+        type=Path,
+        required=True,
+        help="selected recipe checkpoint; supplies TP4 heads and scale",
+    )
+    implementation = parser.add_mutually_exclusive_group()
+    implementation.add_argument("--build-dir", type=Path)
+    implementation.add_argument("--installed", action="store_true")
+    parser.add_argument("--build-only", action="store_true")
+    parser.add_argument(
+        "--profile-only",
+        action="store_true",
+        help="one candidate launch; no timing or correctness claim",
+    )
+    args = parser.parse_args()
+    config = json.loads((args.model / "config.json").read_text())
+    config = config.get("text_config", config)
+    heads = config["num_attention_heads"] // 4
+    scale = config["qk_nope_head_dim"] ** -0.5
+    if heads != 16 or config["qk_rope_head_dim"] != 0:
+        parser.error("native specialization requires the selected TP4 H16 NoPE recipe")
+    if args.output.exists():
+        parser.error("output must be new")
+    if args.build_only and args.build_dir is None:
+        parser.error("--build-only requires --build-dir")
+    native = build_native(args.build_dir) if args.build_dir else None
+    if args.installed:
+        from vllm.quixicore.ops import _qc
+
+        native = _qc()
+    if args.build_only:
+        if native is None:
+            parser.error("--build-only requires --build-dir")
+        return
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"],
+        text=True,
+    ).strip()
+    if active:
+        parser.error(f"GPUs busy: {active}")
+    assert torch.cuda.get_device_capability() == (12, 0)
+    torch.manual_seed(4311)
+    result = {
+        "status": "running",
+        "roadmap": "4.3/4.5",
+        "diagnostic_only": True,
+        "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "source_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        "kernel_sha256": hashlib.sha256(
+            Path(__file__).with_name("glm53_sparse_swapab.py").read_bytes()
+        ).hexdigest(),
+        "cases": [],
+        "native": native is not None,
+        "model": str(args.model),
+        "heads_per_rank": heads,
+        "tp_size": 4,
+        "softmax_scale": scale,
+        "config_sha256": hashlib.sha256(
+            (args.model / "config.json").read_bytes()
+        ).hexdigest(),
+    }
+    if native is not None:
+        result["native_binary_sha256"] = hashlib.sha256(
+            Path(native.__file__).read_bytes()
+        ).hexdigest()
+        result["native_source_sha256"] = {
+            str(path): hashlib.sha256(path.read_bytes()).hexdigest()
+            for path in (
+                Path(__file__).with_name("glm53_sparse_swapab.cu"),
+                Path(__file__).resolve().parents[2]
+                / "csrc/quixicore/serving/glm53_sparse_swapab.cuh",
+                Path(__file__).resolve().parents[2]
+                / "csrc/quixicore/tm_cuda/tm_cuda_glm53_sparse.cu",
+            )
+        }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    def save():
+        args.output.write_text(json.dumps(result, indent=2) + "\n")
+
+    save()
+    try:
+        for batch, context in (
+            (2048, 32768),
+            (7616, 32768),
+            (2048, 131072),
+            (7616, 131072),
+        ):
+            q = (torch.randn(batch, heads, 512, device="cuda") * 0.2).bfloat16()
+            kv = (torch.randn(context // 64, 64, 512, device="cuda") * 0.5).bfloat16()
+            bt = torch.arange(context // 64, device="cuda", dtype=torch.int32)[
+                None
+            ].repeat(batch, 1)
+            stride = torch.randint(context // 8, (batch, 1), device="cuda") * 2 + 1
+            offset = torch.randint(context // 4, (batch, 1), device="cuda")
+            group = (torch.arange(512, device="cuda")[None] * stride + offset) % (
+                context // 4
+            )
+            indices = (
+                (group[:, :, None] * 4 + torch.arange(4, device="cuda"))
+                .reshape(batch, 2048)
+                .int()
+            )
+            lengths = torch.full((batch,), 2048, device="cuda", dtype=torch.int32)
+            outs = [torch.empty_like(q) for _ in range(2)]
+
+            def launch(
+                arm,
+                batch=batch,
+                q=q,
+                kv=kv,
+                bt=bt,
+                indices=indices,
+                lengths=lengths,
+                outs=outs,
+            ):
+                if arm == 1 and native is not None:
+                    if args.installed:
+                        outs[arm] = native.mla_prefill_bf16_sparse_nope_sm120(
+                            q,
+                            kv,
+                            bt,
+                            indices,
+                            lengths,
+                            64,
+                            scale,
+                            kv.stride(0) * 2,
+                        )
+                        return None
+                    native.run(q, kv, bt, indices, lengths, outs[arm], 64, scale)
+                    return None
+                implementation = (pf._sparse_mla_prefill_kernel, sparse_swapab)[arm]
+                return implementation[(batch,)](
+                    q,
+                    kv,
+                    bt,
+                    indices,
+                    lengths,
+                    outs[arm],
+                    indices.shape[1],
+                    bt.shape[1],
+                    kv.stride(0),
+                    64,
+                    scale,
+                    H=heads,
+                    D=512,
+                    BLOCK_N=32,
+                    num_warps=4,
+                    num_stages=2,
+                )
+
+            if args.profile_only:
+                launch(1)
+                torch.cuda.synchronize()
+                result.update(status="profile_only", batch=batch, context=context)
+                return
+            kernels = [launch(arm) for arm in range(2)]
+            torch.testing.assert_close(outs[1], outs[0], rtol=0.01, atol=0.016)
+            # Small independent FP64 attention oracle, actual gathered BF16
+            # values, not another implementation sharing the candidate layout.
+            for row in (0, batch // 2, batch - 1):
+                selected = kv.view(context, 512)[indices[row].long()].double()
+                scores = (q[row].double() @ selected.T) * scale
+                expected = scores.softmax(-1) @ selected
+                torch.testing.assert_close(
+                    outs[1][row].double(), expected, rtol=0.01, atol=0.016
+                )
+            max_abs = (outs[0].float() - outs[1].float()).abs().max().item()
+            graphs = [capture(lambda arm=arm: launch(arm)) for arm in range(2)]
+            # Mixed empty, short and changed selections in the same captured
+            # shape. Restore full useful rows before timing.
+            lengths[0] = 0
+            lengths[1] = 37
+            indices[2, :64] = -1
+            q.mul_(2)
+            for graph in graphs:
+                graph.replay()
+            torch.cuda.synchronize()
+            torch.testing.assert_close(outs[1], outs[0], rtol=0.01, atol=0.016)
+            assert torch.count_nonzero(outs[1][0]).item() == 0
+            lengths.fill_(2048)
+            indices[2, :64] = indices[3, :64]
+            samples = []
+            for _ in range(3):
+                samples.append(
+                    {
+                        name: measure(graphs[arm], 1, 5)
+                        for name, arm in (("before", 0), ("candidate", 1), ("after", 0))
+                    }
+                )
+            row = {
+                "batch": batch,
+                "context": context,
+                "max_abs": max_abs,
+                "oracle_rows": 3,
+                "changed_input_graph_parity": True,
+                "samples_us": samples,
+                "median_us": {
+                    k: statistics.median(s[k] for s in samples) for k in samples[0]
+                },
+                "resources": [
+                    {
+                        "registers": k.n_regs,
+                        "spills": k.n_spills,
+                        "shared": k.metadata.shared,
+                    }
+                    if k is not None
+                    else {"installed": True}
+                    if args.installed
+                    else dict(native.info())
+                    for k in kernels
+                ],
+            }
+            result["cases"].append(row)
+            print(row, flush=True)
+            save()
+            del graphs, outs, q, kv, bt, indices, lengths
+        result["status"] = "complete"
+    except Exception as error:
+        result.update(status="failed", error=repr(error))
+        raise
+    finally:
+        save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_mhc_output_parallel.py
+++ b/benchmarks/kernels/benchmark_mhc_output_parallel.py
@@ -125,9 +125,12 @@ def installed_baseline_checks(extension, batch):
                     *quixicore_ops.dsv4_mhc_pre(residual, fn, scale, base, *constants),
                 ]
             isolated = extension.run(*data, fused, with_norm, False)
-            assert all(torch.equal(a, b) for a, b in zip(reference, isolated)), (
-                "isolated baseline differs from the installed serving operator"
-            )
+            if len(reference) != len(isolated):
+                raise ValueError("isolated baseline output count differs from serving")
+            if not all(torch.equal(a, b) for a, b in zip(reference, isolated)):
+                raise ValueError(
+                    "isolated baseline differs from the installed serving operator"
+                )
             checks.append({"fused": fused, "norm": with_norm, "bit_exact": True})
     return checks
 

--- a/benchmarks/kernels/benchmark_mhc_output_parallel.py
+++ b/benchmarks/kernels/benchmark_mhc_output_parallel.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Isolated mHC arithmetic-layout A/B at the pinned GLM-5.3 settings.
+
+Both variants compile from this tree in one extension; serving stays untouched.
+Graph timings rotate over 90 distinct FP32 parameter sets, like the model's
+90 sites, so a single hot weight matrix is not the performance baseline.
+"""
+
+import argparse
+import hashlib
+import json
+import statistics
+import subprocess
+from pathlib import Path
+
+import torch
+
+
+def build(directory, name="mhc_output_parallel_probe"):
+    from torch.utils.cpp_extension import CUDA_HOME, load
+
+    if CUDA_HOME is None:
+        raise RuntimeError("CUDA_HOME must select the installed serving toolkit")
+    version = subprocess.check_output(
+        [str(Path(CUDA_HOME) / "bin/nvcc"), "--version"], text=True
+    )
+    if f"release {torch.version.cuda}," not in version:
+        raise RuntimeError(
+            f"probe toolkit must match Torch CUDA {torch.version.cuda}: {version}"
+        )
+
+    root = Path(__file__).resolve().parents[2]
+    directory.mkdir(parents=True, exist_ok=True)
+    return load(
+        name=name,
+        sources=[str(Path(__file__).with_name(name + ".cu"))],
+        extra_include_paths=[str(root / "csrc/quixicore/serving")],
+        extra_cflags=["-O3"],
+        extra_cuda_cflags=[
+            "-O3",
+            "-lineinfo",
+            "-std=c++20",
+            "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+            "-gencode=arch=compute_120f,code=sm_120f",
+        ],
+        build_directory=str(directory),
+        verbose=True,
+    )
+
+
+def inputs(batch, seed, magnitude=1.0):
+    g = torch.Generator(device="cuda").manual_seed(seed)
+
+    def rand(*shape):
+        return torch.randn(shape, device="cuda", generator=g)
+
+    return [
+        (rand(batch, 4096) * magnitude).bfloat16(),
+        (rand(batch, 4, 4096) * magnitude).bfloat16(),
+        torch.sigmoid(rand(batch, 4)) * 2,
+        rand(batch, 4, 4).softmax(-1),
+        rand(24, 16384) * 0.02,
+        torch.tensor([0.3, 0.2, 0.1], device="cuda"),
+        rand(24) * 0.1,
+        (1 + rand(4096) * 0.1).bfloat16(),
+    ]
+
+
+def compare(reference, candidate):
+    stats = []
+    for index, (ref, got) in enumerate(zip(reference, candidate)):
+        delta = (got.float() - ref.float()).abs()
+        row = {
+            "max_abs": delta.max().item(),
+            "rms_abs": delta.square().mean().sqrt().item(),
+            "different_fraction": (got != ref).float().mean().item(),
+        }
+        stats.append(row)
+        if index == 0:
+            assert torch.equal(got, ref), "post-mixed BF16 residual changed"
+        elif got.dtype == torch.float32:
+            torch.testing.assert_close(got, ref, rtol=2e-5, atol=2e-6)
+        else:
+            scale = ref.float().abs().amax(-1, keepdim=True).clamp_min(1e-6)
+            assert (delta / scale).max().item() < 2**-7
+    return stats
+
+
+def graph_checks(extension, batch):
+    data = inputs(batch, 501)
+    # Prime both paths outside capture; retain outputs from the captured calls.
+    extension.run(*data, True, False, False)
+    extension.run(*data, True, False, True)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        reference = extension.run(*data, True, False, False)
+        candidate = extension.run(*data, True, False, True)
+    checks = []
+    for seed in range(3):
+        for target, fresh in zip(data, inputs(batch, seed + 601)):
+            target.copy_(fresh)
+        graph.replay()
+        checks.append(compare(reference, candidate))
+    return checks
+
+
+def installed_baseline_checks(extension, batch):
+    from vllm.quixicore.ops import quixicore_ops
+
+    data = inputs(batch, 701)
+    x, residual, post, comb, fn, scale, base, norm = data
+    checks = []
+    for fused in (False, True):
+        for with_norm in (False, True):
+            constants = [1e-5, 1e-6, 1e-6, 2.0, 20, norm if with_norm else None, 1e-5]
+            if fused:
+                reference = quixicore_ops.dsv4_mhc_fused_post_pre(
+                    x, residual, post, comb, fn, scale, base, *constants
+                )
+            else:
+                reference = [
+                    residual,
+                    *quixicore_ops.dsv4_mhc_pre(residual, fn, scale, base, *constants),
+                ]
+            isolated = extension.run(*data, fused, with_norm, False)
+            assert all(torch.equal(a, b) for a, b in zip(reference, isolated)), (
+                "isolated baseline differs from the installed serving operator"
+            )
+            checks.append({"fused": fused, "norm": with_norm, "bit_exact": True})
+    return checks
+
+
+def checkpoint_parameters(model):
+    """Load only the 90 actual mHC sites, not the model's large linear weights."""
+    from contextlib import ExitStack
+
+    from safetensors import safe_open
+
+    index = json.loads((model / "model.safetensors.index.json").read_text())[
+        "weight_map"
+    ]
+    sites, identity = [], []
+    with ExitStack() as stack:
+        overrides = stack.enter_context(
+            safe_open(model / "f32-overrides.safetensors", framework="pt", device="cpu")
+        )
+        shards = {}
+        for layer in range(45):
+            for kind in ("attn", "ffn"):
+                prefix = f"model.language_model.layers.{layer}.hc_{kind}"
+                filename = index[prefix + "_fn"]
+                if filename not in shards:
+                    shards[filename] = stack.enter_context(
+                        safe_open(model / filename, framework="pt", device="cpu")
+                    )
+                # Serving upcasts the checkpoint's BF16 fn; only base/scale
+                # are restored from the native FP32 sidecar.
+                tensors = [
+                    shards[filename].get_tensor(prefix + "_fn").float(),
+                    overrides.get_tensor(prefix + "_scale"),
+                    overrides.get_tensor(prefix + "_base"),
+                ]
+                identity.append(
+                    {
+                        "site": prefix,
+                        "sha256": [
+                            hashlib.sha256(t.numpy().tobytes()).hexdigest()
+                            for t in tensors
+                        ],
+                    }
+                )
+                sites.append([t.cuda() for t in tensors])
+    return sites, identity
+
+
+def measure(extension, data, candidate, repeats):
+    # Same work sequence and buffers for each variant. Every parameter set is
+    # distinct; graph allocators retain its output storage until replay ends.
+    for row in data:
+        extension.run(*row, True, False, candidate)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        for row in data:
+            extension.run(*row, True, False, candidate)
+    for _ in range(3):
+        graph.replay()
+    torch.cuda.synchronize()
+    samples = []
+    for _ in range(5):
+        a = torch.cuda.Event(enable_timing=True)
+        b = torch.cuda.Event(enable_timing=True)
+        a.record()
+        for _ in range(repeats):
+            graph.replay()
+        b.record()
+        b.synchronize()
+        samples.append(a.elapsed_time(b) * 1000 / (repeats * len(data)))
+    return {"graph_us": samples, "median_us": statistics.median(samples)}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--build-dir", type=Path, required=True)
+    parser.add_argument("--build-only", action="store_true")
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--batch", type=int, nargs="+", default=[1, 2, 4, 8])
+    parser.add_argument("--seeds", type=int, default=4)
+    parser.add_argument("--repeats", type=int, default=20)
+    parser.add_argument("--check-only", action="store_true")
+    parser.add_argument(
+        "--model",
+        type=Path,
+        help="also check and time all 90 actual mHC parameter sets",
+    )
+    args = parser.parse_args()
+    if not args.batch or min(args.seeds, args.repeats, *args.batch) < 1:
+        parser.error("batch sizes, seeds and repeats must be positive")
+    if max(args.batch) > 8:
+        parser.error("this probe covers only the cooperative decode range <= 8")
+    if not args.build_only:
+        if args.output is None or args.output.exists():
+            parser.error("a run requires a new --output path")
+        active = subprocess.check_output(
+            ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"],
+            text=True,
+        ).strip()
+        if active:
+            parser.error(f"GPUs already have compute processes: {active}")
+    extension = build(args.build_dir)
+    if args.build_only:
+        return
+    root = Path(__file__).resolve().parents[2]
+    sources = [
+        root / "csrc/quixicore/serving/mhc_ampere.cuh",
+        Path(__file__).with_name("mhc_output_parallel.cuh"),
+        Path(__file__).with_suffix(".py"),
+        Path(__file__).with_name("mhc_output_parallel_probe.cu"),
+    ]
+    result = {
+        "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "source_sha256": {
+            str(p.relative_to(root)): hashlib.sha256(p.read_bytes()).hexdigest()
+            for p in sources
+        },
+        "torch": torch.__version__,
+        "isolated_binary_sha256": hashlib.sha256(
+            Path(extension.__file__).read_bytes()
+        ).hexdigest(),
+        "serving_binary_sha256": {
+            str(p.relative_to(root)): hashlib.sha256(p.read_bytes()).hexdigest()
+            for p in (root / "vllm").glob("_quixicore_C*.so")
+        },
+        "gpu": torch.cuda.get_device_name(),
+        "sinkhorn_iterations": 20,
+        "settings": {
+            k: str(v) if isinstance(v, Path) else v for k, v in vars(args).items()
+        },
+        "checks": [],
+        "graph_checks": [],
+        "checkpoint_checks": [],
+        "installed_baseline_checks": [],
+        "timings": [],
+        "status": "running",
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("x") as stream:
+        json.dump(result, stream, indent=2)
+
+    def save():
+        args.output.write_text(json.dumps(result, indent=2) + "\n")
+
+    try:
+        parameters = None
+        if args.model:
+            parameters, result["checkpoint_parameters"] = checkpoint_parameters(
+                args.model
+            )
+            save()
+        for batch in args.batch:
+            result["installed_baseline_checks"].append(
+                {
+                    "batch": batch,
+                    "checks": installed_baseline_checks(extension, batch),
+                }
+            )
+            save()
+            for seed in range(args.seeds):
+                for magnitude in [0.01, 1.0, 100.0]:
+                    data = inputs(batch, seed, magnitude)
+                    for fused in [False, True]:
+                        for norm in [False, True]:
+                            baseline = extension.run(*data, fused, norm, False)
+                            candidate = extension.run(*data, fused, norm, True)
+                            row = {
+                                "batch": batch,
+                                "seed": seed,
+                                "magnitude": magnitude,
+                                "fused": fused,
+                                "norm": norm,
+                            }
+                            result["checks"].append(row)
+                            save()
+                            row["errors"] = compare(baseline, candidate)
+                    save()
+            print(f"batch {batch}: arithmetic checks passed", flush=True)
+            result["graph_checks"].append(
+                {"batch": batch, "errors": graph_checks(extension, batch)}
+            )
+            if parameters:
+                for site, weights in enumerate(parameters):
+                    for magnitude in (0.01, 1.0, 100.0):
+                        data = inputs(batch, site + 100, magnitude)
+                        data[4:7] = weights
+                        row = {"batch": batch, "site": site, "magnitude": magnitude}
+                        result["checkpoint_checks"].append(row)
+                        save()
+                        row["errors"] = compare(
+                            extension.run(*data, True, False, False),
+                            extension.run(*data, True, False, True),
+                        )
+                save()
+            if not args.check_only:
+                data = [inputs(batch, seed + 100) for seed in range(90)]
+                if parameters:
+                    for inputs_row, weights in zip(data, parameters):
+                        inputs_row[4:7] = weights
+                row = {"batch": batch, "sites": len(data)}
+                # A/B/A identifies drift instead of selecting a favorable run.
+                for label, candidate in [("A", False), ("B", True), ("A2", False)]:
+                    row[label] = measure(extension, data, candidate, args.repeats)
+                result["timings"].append(row)
+                print(json.dumps(row), flush=True)
+                save()
+        result["status"] = "complete"
+    except Exception as error:
+        result["status"] = "failed"
+        result["error"] = repr(error)
+        save()
+        raise
+    save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/check_glm53_marlin_boundary.py
+++ b/benchmarks/kernels/check_glm53_marlin_boundary.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Record/check installed Marlin outputs across decode and prefill tile sizes.
+
+Uses actual layer3 TP4 rank0 checkpoint bytes and the serving auto dispatcher.
+Inputs/routes are deliberately synthetic. This is a changed-input graph
+regression, not an independent numerical oracle or a serving benchmark.
+"""
+
+import argparse
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.profile_glm53_marlin import load_layer
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--reference-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--mode", choices=["record", "check"], required=True)
+    args = parser.parse_args()
+    if args.output.exists():
+        parser.error("output must be new")
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"], text=True
+    ).strip()
+    if active:
+        parser.error(f"GPUs already have compute processes: {active}")
+    root = Path(__file__).resolve().parents[2]
+    identity = {
+        "native_sha256": digest(root / "vllm/_moe_C_stable_libtorch.abi3.so"),
+        "checkpoint_index_sha256": digest(args.model / "model.safetensors.index.json"),
+        "source_sha256": digest(Path(__file__)),
+        "torch": torch.__version__,
+        "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+    }
+    manifest = args.reference_dir / "manifest.json"
+    if args.mode == "record":
+        args.reference_dir.mkdir(parents=True, exist_ok=False)
+        manifest.write_text(json.dumps(identity, indent=2) + "\n")
+    else:
+        previous = json.loads(manifest.read_text())
+        for key in ("checkpoint_index_sha256", "source_sha256", "torch"):
+            if previous[key] != identity[key]:
+                raise ValueError(f"reference mismatch: {key}")
+        if previous["native_sha256"] == identity["native_sha256"]:
+            raise ValueError("check requires a different native library")
+
+    from vllm.model_executor.layers.fused_moe.experts.marlin_moe import fused_marlin_moe
+    from vllm.scalar_type import scalar_types
+
+    torch.set_num_threads(8)
+    torch.manual_seed(131)
+    weights, weight_identity = load_layer(args.model, 3, 0)
+    w13, s13, g13, w2, s2, g2, workspace = weights
+    result = {
+        "status": "running",
+        "mode": args.mode,
+        "identity": identity,
+        "weights": weight_identity,
+        "cases": [],
+    }
+    with args.output.open("x") as stream:
+        json.dump(result, stream, indent=2)
+
+    def save():
+        args.output.write_text(json.dumps(result, indent=2) + "\n")
+
+    try:
+        # These exercise all five auto-selected M tile sizes: 8/16/32/48/64.
+        for batch in (1, 8, 16, 256, 512, 1024, 1536, 2048):
+            x = torch.empty(batch, 4096, device="cuda", dtype=torch.bfloat16)
+            # Eight distinct experts per row, balanced across all 288 experts.
+            ids = ((torch.arange(batch * 8) * 37) % 288).reshape(batch, 8)
+            ids = ids.to(device="cuda", dtype=torch.int32)
+            routing_weights = torch.full(
+                (batch, 8), 2.5 / 8, device="cuda", dtype=torch.float32
+            )
+
+            def call(x=x, routing_weights=routing_weights, ids=ids):
+                return fused_marlin_moe(
+                    x,
+                    w13,
+                    w2,
+                    None,
+                    None,
+                    s13,
+                    s2,
+                    routing_weights,
+                    ids,
+                    scalar_types.float4_e2m1f.id,
+                    global_scale1=g13,
+                    global_scale2=g2,
+                    workspace=workspace,
+                    clamp_limit=10.0,
+                )
+
+            x.normal_()
+            call()
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                captured = call()
+            for replay in range(3):
+                reference_path = args.reference_dir / f"batch{batch}-replay{replay}.pt"
+                if args.mode == "record":
+                    x.normal_()
+                    reference = None
+                else:
+                    reference = torch.load(reference_path, weights_only=True)
+                    x.copy_(reference["input"])
+                eager = call()
+                graph.replay()
+                torch.cuda.synchronize()
+                if not torch.isfinite(captured).all():
+                    raise ValueError("nonfinite output")
+                output = captured.cpu()
+                row = {
+                    "batch": batch,
+                    "replay": replay,
+                    "graph_eager_exact": torch.equal(captured, eager),
+                }
+                if reference is None:
+                    torch.save({"input": x.cpu(), "output": output}, reference_path)
+                else:
+                    row.update(
+                        reference_exact=torch.equal(output, reference["output"]),
+                        max_abs=(output.float() - reference["output"].float())
+                        .abs()
+                        .max()
+                        .item(),
+                    )
+                result["cases"].append(row)
+                save()
+                print(json.dumps(row), flush=True)
+            del graph, captured, eager
+        failed = [
+            row
+            for row in result["cases"]
+            if not row["graph_eager_exact"] or not row.get("reference_exact", True)
+        ]
+        result["status"] = "failed_gates" if failed else "complete"
+        save()
+        if failed:
+            raise SystemExit(1)
+    except Exception as error:
+        result.update(status="failed", error=repr(error))
+        save()
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/check_glm53_marlin_schedule.py
+++ b/benchmarks/kernels/check_glm53_marlin_schedule.py
@@ -162,6 +162,7 @@ def main():
         },
         "cases": [],
     }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
     with args.output.open("x") as stream:
         json.dump(result, stream, indent=2)
 

--- a/benchmarks/kernels/check_glm53_marlin_schedule.py
+++ b/benchmarks/kernels/check_glm53_marlin_schedule.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Check a Marlin schedule against an independent checkpoint-byte CPU oracle.
+
+The oracle decodes planar nibbles/scales directly, uses BF16 weight fragments
+and FP64 dot products, then the serving BF16 boundaries and GLM clamp/SILU.
+It does not use Marlin's repack or dequant helpers. This is not model quality.
+"""
+
+import argparse
+import hashlib
+import json
+import subprocess
+from contextlib import ExitStack
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+
+from benchmarks.kernels.benchmark_glm53_marlin_schedule import prepare_case
+from benchmarks.kernels.profile_glm53_marlin import load_layer, route_cases
+
+AUTO = ((-1, -1, -1), (-1, -1, -1))
+CANDIDATE = ((128, 64, 1), (64, 128, 2))
+
+
+def decode_fragments(packed, scales):
+    table = torch.tensor(
+        [0, 0.5, 1, 1.5, 2, 3, 4, 6, 0, -0.5, -1, -1.5, -2, -3, -4, -6],
+        dtype=torch.float64,
+    )
+    codes = torch.stack((packed & 15, packed >> 4), dim=-1).flatten(-2).long()
+    if scales.shape != (packed.shape[0], codes.shape[1] // 16):
+        raise ValueError("unexpected planar group-16 shape")
+    values = table[codes] * scales.double().repeat_interleave(16, dim=-1)
+    return values.to(torch.bfloat16).double()
+
+
+def oracle(model, layer, rank, expert_ids, x, routing_weights):
+    index = json.loads((model / "model.safetensors.index.json").read_text())[
+        "weight_map"
+    ]
+    output = torch.empty(len(expert_ids), 8, 4096, dtype=torch.bfloat16)
+    gate_up = torch.empty(len(expert_ids), 8, 1024, dtype=torch.bfloat16)
+    activations = torch.empty(len(expert_ids), 8, 512, dtype=torch.bfloat16)
+    gate_up_exact = torch.empty_like(gate_up, dtype=torch.float64)
+    with ExitStack() as stack:
+        shards = {}
+
+        def tensor(key):
+            filename = index[key]
+            if filename not in shards:
+                shards[filename] = stack.enter_context(
+                    safe_open(model / filename, framework="pt", device="cpu")
+                )
+            return shards[filename].get_tensor(key)
+
+        def projection(prefix, token, down=False):
+            w, s = tensor(prefix + "weight_packed"), tensor(prefix + "weight_scale")
+            if down:
+                w, s = (
+                    w[:, rank * 256 : (rank + 1) * 256],
+                    s[:, rank * 32 : (rank + 1) * 32],
+                )
+            else:
+                w, s = (
+                    w[rank * 512 : (rank + 1) * 512],
+                    s[rank * 512 : (rank + 1) * 512],
+                )
+            scale = (1.0 / tensor(prefix + "weight_global_scale").float()).item()
+            values = decode_fragments(w, s) @ token.double()
+            return values, scale
+
+        for token, row in enumerate(expert_ids):
+            for route, expert in enumerate(row):
+                prefix = f"model.language_model.layers.{layer}.mlp.experts.{expert}."
+                gate, gg = projection(prefix + "gate_proj.", x[token])
+                up, gu = projection(prefix + "up_proj.", x[token])
+                gate_up_exact[token, route] = torch.cat([gate * gg, up * gu])
+                gate_up[token, route] = gate_up_exact[token, route].to(torch.bfloat16)
+                gate = (gate * gg).to(torch.bfloat16).double().clamp(max=10)
+                up = (up * gu).to(torch.bfloat16).double().clamp(-10, 10)
+                # The installed activation kernel returns BF16 SiLU before the
+                # separate up multiply, even in its vectorized clamp path.
+                silu = torch.nn.functional.silu(gate).to(torch.bfloat16).double()
+                activated = (silu * up).to(torch.bfloat16)
+                activations[token, route] = activated
+                down, gd = projection(prefix + "down_proj.", activated, down=True)
+                # The existing weighted Marlin epilogue rounds the dot product
+                # and (global scale * routing weight) separately to BF16, then
+                # multiplies BF16 values. Its power-of-two dequant bias cancels
+                # and does not change normal-range BF16 rounding. Do not replace
+                # those two boundaries with one high-precision final multiply.
+                final_scale = (
+                    (routing_weights[token, route].float() * gd)
+                    .to(torch.bfloat16)
+                    .double()
+                )
+                output[token, route] = (
+                    down.to(torch.bfloat16).double() * final_scale
+                ).to(torch.bfloat16)
+    return {
+        "moe": output.flatten(0, 1),
+        "gate_up": gate_up.flatten(0, 1),
+        "activation": activations.flatten(0, 1),
+        "gate_up_exact": gate_up_exact.flatten(0, 1),
+    }
+
+
+def errors(value, ref):
+    diff = value.double() - ref.double()
+    if not torch.isfinite(diff).all():
+        raise ValueError("nonfinite comparison")
+    return {
+        "max_abs": diff.abs().max().item(),
+        "normalized_rms": (
+            diff.square().mean().sqrt()
+            / ref.double().square().mean().sqrt().clamp_min(1e-12)
+        ).item(),
+        "changed_fraction": (value != ref).float().mean().item(),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--journal", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--layers", type=int, nargs="+", default=[3, 23, 44])
+    parser.add_argument("--ranks", type=int, nargs="+", default=[0, 1, 2, 3])
+    parser.add_argument("--replays", type=int, default=3)
+    args = parser.parse_args()
+    if (
+        args.output.exists()
+        or args.replays < 1
+        or any(not 0 <= r < 4 for r in args.ranks)
+        or any(not 3 <= layer <= 44 for layer in args.layers)
+    ):
+        parser.error(
+            "new output, positive replays, ranks 0..3 and layers 3..44 required"
+        )
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"], text=True
+    ).strip()
+    if active:
+        parser.error(f"GPUs already have compute processes: {active}")
+    torch.set_num_threads(8)
+    torch.manual_seed(713)
+    _, record = route_cases(args.journal, [1], 1)[0]
+    result = {
+        "status": "running",
+        "diagnostic_only": True,
+        "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "torch": torch.__version__,
+        "journal_sha256": hashlib.sha256(args.journal.read_bytes()).hexdigest(),
+        "checkpoint_index_sha256": hashlib.sha256(
+            (args.model / "model.safetensors.index.json").read_bytes()
+        ).hexdigest(),
+        "source_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        "settings": {
+            k: str(v) if isinstance(v, Path) else v for k, v in vars(args).items()
+        },
+        "cases": [],
+    }
+    with args.output.open("x") as stream:
+        json.dump(result, stream, indent=2)
+
+    def save():
+        args.output.write_text(json.dumps(result, indent=2) + "\n")
+
+    try:
+        for rank in args.ranks:
+            for layer in args.layers:
+                weights, _ = load_layer(args.model, layer, rank)
+                case = prepare_case(weights, 1, record, layer)
+                graphs = {}
+                for name, config in (("auto", AUTO), ("candidate", CANDIDATE)):
+                    graph = torch.cuda.CUDAGraph()
+                    with torch.cuda.graph(graph):
+                        case["call"]("moe", config)
+                    graphs[name] = graph
+                for replay in range(args.replays):
+                    case["input"].normal_()
+                    reference = oracle(
+                        args.model,
+                        layer,
+                        rank,
+                        case["identity"]["expert_ids"],
+                        case["input"].cpu(),
+                        case["routing_weights"].cpu(),
+                    )
+                    row = {
+                        "rank": rank,
+                        "layer": layer,
+                        "replay": replay,
+                        "expert_ids": case["identity"]["expert_ids"],
+                    }
+                    result["cases"].append(row)
+                    outputs, intermediates = {}, {}
+                    for name, graph in graphs.items():
+                        graph.replay()
+                        torch.cuda.synchronize()
+                        outputs[name] = case["outputs"]["moe"].cpu()
+                        row[name] = errors(outputs[name], reference["moe"])
+                        intermediates[name] = {
+                            phase: case["outputs"][phase].cpu()
+                            for phase in ("gate_up", "activation")
+                        }
+                        row[name]["intermediates"] = {
+                            phase: errors(value, reference[phase])
+                            for phase, value in intermediates[name].items()
+                        }
+                    row["candidate_vs_auto"] = errors(
+                        outputs["candidate"], outputs["auto"]
+                    )
+                    save()
+                    # A high-precision oracle changes accumulation order. Require
+                    # both implementations to be close, and no material increase
+                    # relative to the measured auto-scheduler arithmetic error.
+                    row["auto_oracle_pass"] = row["auto"]["normalized_rms"] < 0.002
+                    row["candidate_relative_oracle_pass"] = row["candidate"][
+                        "normalized_rms"
+                    ] < max(0.0005, row["auto"]["normalized_rms"] * 1.25)
+                    try:
+                        torch.testing.assert_close(
+                            outputs["candidate"], outputs["auto"], rtol=0.01, atol=0.01
+                        )
+                        row["candidate_auto_close"] = True
+                    except AssertionError as error:
+                        row["candidate_auto_close"] = False
+                        row["close_error"] = str(error)
+                    row["passes"] = all(
+                        row[k]
+                        for k in (
+                            "auto_oracle_pass",
+                            "candidate_relative_oracle_pass",
+                            "candidate_auto_close",
+                        )
+                    )
+                    if not row["passes"]:
+                        artifact = args.output.with_name(
+                            f"{args.output.stem}-rank{rank}-layer{layer}-replay{replay}.pt"
+                        )
+                        torch.save(
+                            {
+                                "input": case["input"].cpu(),
+                                "reference": reference,
+                                "outputs": outputs,
+                                "intermediates": intermediates,
+                            },
+                            artifact,
+                        )
+                        row["failure_tensors"] = str(artifact)
+                    save()
+                    print(json.dumps(row), flush=True)
+                del graphs, case, weights
+        result["status"] = (
+            "complete"
+            if all(row["passes"] for row in result["cases"])
+            else "failed_gates"
+        )
+    except Exception as error:
+        result.update(status="failed", error=repr(error))
+        save()
+        raise
+    save()
+    return int(result["status"] != "complete")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernels/check_glm53_mhc_tc_accuracy.py
+++ b/benchmarks/kernels/check_glm53_mhc_tc_accuracy.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Separate FP64 accuracy census; does not modify or rename strict parity.
+
+See perf/glm53-mhc-tc-accuracy-contract.md. No timings or serving integration.
+Every eager row is checked; graph oracle rows are explicitly sampled, while
+graph/eager bit checks cover all outputs. The original failed seed is included.
+"""
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.benchmark_glm53_mhc_prefill_tc import (
+    check_outputs,
+    installed,
+    oracle_rows,
+    partial_errors,
+)
+from benchmarks.kernels.benchmark_glm53_mhc_storage import exact, lossless_bf16
+from benchmarks.kernels.benchmark_mhc_output_parallel import (
+    checkpoint_parameters,
+    inputs,
+)
+from benchmarks.kernels.mhc_fp64_oracle import accuracy_pair
+
+PROBE_SHA = "45d5e817520a56bbc818e3e237d54b1feea3cb11385540aaabb1fec8fb7980e3"
+
+
+def sha(path):
+    with Path(path).open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def case_plan(batches, sites):
+    if (
+        not batches
+        or not sites
+        or len(set(batches)) != len(batches)
+        or len(set(sites)) != len(sites)
+        or any(t not in (64, 65, 128, 129, 7616) for t in batches)
+        or any(not 0 <= site < 90 for site in sites)
+    ):
+        raise ValueError("unique prescribed batches and sites0..89 required")
+    return [
+        {
+            "batch": t,
+            "site": site,
+            "magnitude": mag,
+            "fused": fused,
+            "eager_seed": 2003 + site * 3 if fused else 301 + site,
+            "graph_seeds": [12001 + site * 3 + replay for replay in range(3)],
+        }
+        for t in batches
+        for site in sites
+        for mag in (0.01, 1.0, 100.0)
+        for fused in (False, True)
+    ]
+
+
+def strict_diagnostic(reference, candidate):
+    try:
+        return {"passed": True, "outputs": check_outputs(reference, candidate)}
+    except AssertionError as error:
+        return {"passed": False, "error": str(error)}
+
+
+def check_case(plan, site, extension, row):
+    t, fused, magnitude = plan["batch"], plan["fused"], plan["magnitude"]
+    data = inputs(t, plan["eager_seed"], magnitude)[:7]
+    data[4:] = site
+    ref, got = installed(data, fused), extension.run(*data, fused)
+    exact(ref[:1], got[:1])
+    row["strict_parity_diagnostic"] = strict_diagnostic(ref, got)
+    row["eager_fp64_all_rows"] = accuracy_pair(ref[0], *data[4:], ref[1:], got[1:])
+    if not row["eager_fp64_all_rows"]["passed"]:
+        raise AssertionError("independent all-row eager accuracy failed")
+    ro, partial = extension.run(*data, fused, True)
+    exact(ref[:1], [ro])
+    row["partial_oracle"] = partial_errors(ro, data[4], partial)
+    if not row["partial_oracle"]["passed"]:
+        raise AssertionError("unchanged partial oracle failed")
+    del ref, got, ro, partial
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        a, b = installed(data, fused), extension.run(*data, fused)
+    selected = oracle_rows(t)
+    row["graphs"] = []
+    for seed in plan["graph_seeds"]:
+        phase = {"seed": seed, "oracle_rows": selected, "status": "checking"}
+        row["graphs"].append(phase)
+        fresh = inputs(t, seed, magnitude)
+        for target, source in zip(data[:4], fresh[:4]):
+            target.copy_(source)
+        graph.replay()
+        exact(a[:1], b[:1])
+        exact(a, installed(data, fused))
+        exact(b, extension.run(*data, fused))
+        # Finiteness of all graph outputs is checked by strict diagnostic;
+        # its output mismatch can be recorded without becoming an accuracy pass.
+        for tensor in (*a, *b):
+            if not torch.isfinite(tensor).all():
+                raise AssertionError("nonfinite graph output")
+        phase["all_output_bits_match_eager"] = True
+        phase["strict_parity_diagnostic"] = strict_diagnostic(a, b)
+        phase["fp64_sampled_rows"] = accuracy_pair(
+            a[0][selected],
+            *data[4:],
+            [v[selected] for v in a[1:]],
+            [v[selected] for v in b[1:]],
+        )
+        if not phase["fp64_sampled_rows"]["passed"]:
+            raise AssertionError("independent sampled graph accuracy failed")
+        ro, partial = extension.run(*data, fused, True)
+        exact(a[:1], [ro])
+        phase["partial_oracle"] = partial_errors(ro, data[4], partial)
+        if not phase["partial_oracle"]["passed"]:
+            raise AssertionError("changed-input partial oracle failed")
+        phase["status"] = "complete"
+        del ro, partial, fresh
+    torch.cuda.synchronize()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--extension", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--batch", type=int, nargs="+", default=[64, 65, 128, 129, 7616]
+    )
+    parser.add_argument("--sites", type=int, nargs="+", default=list(range(90)))
+    args = parser.parse_args()
+    try:
+        plan = case_plan(args.batch, args.sites)
+    except ValueError as error:
+        parser.error(str(error))
+    if args.output.exists():
+        parser.error("output directory must be new; no overwrite or silent resume")
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"], text=True
+    ).strip()
+    if active:
+        parser.error(f"GPU compute processes already active: {active}")
+    if sha(args.extension) != PROBE_SHA:
+        parser.error("extension differs from the frozen original tensor-core candidate")
+    settings = {
+        "VLLM_DSV4_MHC_MODE": "0",
+        "VLLM_DSV4_MHC_COOP_MAX_T": "8",
+        "VLLM_DSV4_MHC_SPLITS": "64",
+        "VLLM_DSV4_MHC_PREFILL_MIN_T": "64",
+    }
+    for key, value in settings.items():
+        if key in os.environ and os.environ[key] != value:
+            parser.error(f"requires {key}={value}")
+        os.environ[key] = value
+    root = Path(__file__).resolve().parents[2]
+    paths = [
+        Path(__file__),
+        Path(__file__).with_name("mhc_fp64_oracle.py"),
+        Path(__file__).with_name("benchmark_glm53_mhc_prefill_tc.py"),
+        Path(__file__).with_name("benchmark_glm53_mhc_storage.py"),
+        Path(__file__).with_name("benchmark_mhc_output_parallel.py"),
+        Path(__file__).with_name("mhc_prefill_tc_probe.cu"),
+        root / "perf/glm53-mhc-tc-accuracy-contract.md",
+        root / "csrc/quixicore/serving/mhc_ampere.cuh",
+        root / "csrc/quixicore/serving/bf16_decode_gemm.cuh",
+        root / "csrc/quixicore/tm_cuda/tm_cuda_serving.cu",
+    ]
+    hashes = {str(p.relative_to(root)): sha(p) for p in paths}
+    result = {
+        "status": "running",
+        "diagnostic_only": True,
+        "contract": "glm53-mhc-tc-accuracy-v1",
+        "method": __doc__,
+        "command": sys.argv,
+        "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "git_status": subprocess.check_output(
+            ["git", "status", "--short"], text=True
+        ).strip(),
+        "source_sha256": hashes,
+        "extension_sha256": PROBE_SHA,
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "environment": settings,
+        "planned_cases": len(plan),
+        "plan": plan,
+        "completed_cases": 0,
+        "completed_graph_phases": 0,
+        "strict_parity_failed_comparisons": 0,
+        "settings": {
+            k: str(v) if isinstance(v, Path) else v for k, v in vars(args).items()
+        },
+    }
+    args.output.mkdir(parents=True)
+    journal = args.output / "checks.jsonl"
+    summary = args.output / "summary.json"
+
+    def save():
+        temp = summary.with_suffix(".tmp")
+        temp.write_text(json.dumps(result, indent=2) + "\n")
+        temp.replace(summary)
+
+    save()
+    started = time.monotonic()
+    try:
+        import vllm._quixicore_C as native
+
+        torch.set_num_threads(4)
+        if torch.cuda.get_device_capability() != (12, 0):
+            raise ValueError("SM120 target required")
+        spec = importlib.util.spec_from_file_location(
+            "mhc_prefill_tc_probe", args.extension
+        )
+        extension = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(extension)
+        result["native_sha256"] = sha(native.__file__)
+        result["gpu"] = torch.cuda.get_device_name()
+        result["resources"] = extension.resources()
+        sites, result["parameters"] = checkpoint_parameters(args.model)
+        if len(sites) != 90:
+            raise ValueError("all90 parameter sets required")
+        sites = [[lossless_bf16(s[0]), *s[1:]] for s in sites]
+        with journal.open("x") as stream:
+            for item in plan:
+                row = {**item, "status": "checking"}
+                result["current_case"] = item
+                save()
+                case_started = time.monotonic()
+                try:
+                    check_case(item, sites[item["site"]], extension, row)
+                    row["status"] = "complete"
+                    result["completed_cases"] += 1
+                    result["completed_graph_phases"] += len(row["graphs"])
+                    result["strict_parity_failed_comparisons"] += sum(
+                        not d["passed"]
+                        for d in [
+                            row["strict_parity_diagnostic"],
+                            *(g["strict_parity_diagnostic"] for g in row["graphs"]),
+                        ]
+                    )
+                except BaseException as error:
+                    row["status"], row["error"] = "failed", repr(error)
+                    raise
+                finally:
+                    row["elapsed_seconds"] = time.monotonic() - case_started
+                    stream.write(json.dumps(row) + "\n")
+                    stream.flush()
+                    save()
+                if result["completed_cases"] % 6 == 0:
+                    print(
+                        json.dumps(
+                            {
+                                k: result[k]
+                                for k in (
+                                    "completed_cases",
+                                    "planned_cases",
+                                    "strict_parity_failed_comparisons",
+                                )
+                            }
+                        ),
+                        flush=True,
+                    )
+        if hashes != {str(p.relative_to(root)): sha(p) for p in paths}:
+            raise ValueError("source changed during census")
+        if (
+            sha(native.__file__) != result["native_sha256"]
+            or sha(args.extension) != PROBE_SHA
+        ):
+            raise ValueError("native library changed during census")
+        result["status"] = "complete"
+        result.pop("current_case", None)
+    except BaseException as error:
+        result["status"], result["error"] = "failed", repr(error)
+        raise
+    finally:
+        result["elapsed_seconds"] = time.monotonic() - started
+        result["journal_sha256"] = sha(journal) if journal.exists() else None
+        save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/check_glm53_mhc_tc_native.py
+++ b/benchmarks/kernels/check_glm53_mhc_tc_native.py
@@ -82,12 +82,18 @@ def main():
     # qualified GPU dependencies, oracle, input and gate sources stay frozen.
     changed_host = "csrc/quixicore/tm_cuda/tm_cuda_serving.cu"
     for path, digest in census["source_sha256"].items():
+        require((root / path).is_file(), f"qualified source missing: {path}")
         if path != changed_host:
             require(sha(root / path) == digest, f"qualified source changed: {path}")
     probe = root / "benchmarks/kernels/mhc_prefill_tc_probe.cu"
     header = root / "csrc/quixicore/serving/glm53_mhc_prefill_tc.cuh"
+    for path in (probe, header):
+        require(path.is_file(), f"qualified source missing: {path}")
     qualified_kernel_body(probe.read_text(), header.read_text())
     extension_path = Path(census["settings"]["extension"])
+    require(
+        extension_path.is_file(), f"qualified probe binary missing: {extension_path}"
+    )
     require(sha(extension_path) == PROBE_SHA, "qualified probe binary changed")
     active = subprocess.check_output(
         ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"], text=True
@@ -107,6 +113,8 @@ def main():
         "vllm/model_executor/layers/glm5_next_mhc_ops.py",
         "vllm/model_executor/models/glm5_next.py",
     }
+    for path in sorted(paths):
+        require((root / path).is_file(), f"qualified source missing: {path}")
     hashes = {p: sha(root / p) for p in sorted(paths)}
     plan = case_plan(BATCHES, list(range(90)))
     result = {

--- a/benchmarks/kernels/check_glm53_mhc_tc_native.py
+++ b/benchmarks/kernels/check_glm53_mhc_tc_native.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Prove native integration is bit-exact to the independently qualified probe.
+
+This is not a new FP64 census or a serving-performance qualification. It uses
+the full prescribed 2700-case/8100-phase plan and verifies the original receipt,
+probe binary, kernel source, dependencies and actual model parameter identities.
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.benchmark_glm53_mhc_prefill_tc import installed
+from benchmarks.kernels.benchmark_glm53_mhc_storage import exact, lossless_bf16
+from benchmarks.kernels.benchmark_glm53_mhc_tc_qualified import (
+    BATCHES,
+    qualified_census,
+    require,
+)
+from benchmarks.kernels.benchmark_mhc_output_parallel import (
+    checkpoint_parameters,
+    inputs,
+)
+from benchmarks.kernels.check_glm53_mhc_tc_accuracy import PROBE_SHA, case_plan, sha
+
+
+def qualified_kernel_body(probe, native):
+    """Only the containing namespace and host wrapper may differ."""
+    original = probe.split("constexpr int H =", 1)[1].split(
+        "\ntemplate <bool FUSED>\nstatic std::vector<Tensor> run_typed", 1
+    )[0]
+    copied = native.split("constexpr int H =", 1)[1].rsplit("}", 1)[0]
+    require(original.strip() == copied.strip(), "qualified kernel body changed")
+
+
+def check_case(item, site, extension, row):
+    batch, fused, magnitude = item["batch"], item["fused"], item["magnitude"]
+    data = inputs(batch, item["eager_seed"], magnitude)[:7]
+    data[4:] = site
+    exact(extension.run(*data, fused), installed(data, fused))
+    row["eager_all_output_bits_match_probe"] = True
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        reference, candidate = extension.run(*data, fused), installed(data, fused)
+    row["graphs"] = []
+    for seed in item["graph_seeds"]:
+        phase = {"seed": seed, "status": "checking"}
+        row["graphs"].append(phase)
+        fresh = inputs(batch, seed, magnitude)
+        for target, value in zip(data[:4], fresh[:4]):
+            target.copy_(value)
+        graph.replay()
+        exact(reference, candidate)
+        exact(reference, extension.run(*data, fused))
+        exact(candidate, installed(data, fused))
+        phase.update(
+            all_output_bits_match_probe=True,
+            both_graphs_match_eager=True,
+            status="complete",
+        )
+    torch.cuda.synchronize()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--census", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    require(not args.output.exists(), "new output directory required")
+    census, receipt = qualified_census(args.census)
+    root = Path(__file__).resolve().parents[2]
+    # Host dispatch is the intentional integration change. All originally
+    # qualified GPU dependencies, oracle, input and gate sources stay frozen.
+    changed_host = "csrc/quixicore/tm_cuda/tm_cuda_serving.cu"
+    for path, digest in census["source_sha256"].items():
+        if path != changed_host:
+            require(sha(root / path) == digest, f"qualified source changed: {path}")
+    probe = root / "benchmarks/kernels/mhc_prefill_tc_probe.cu"
+    header = root / "csrc/quixicore/serving/glm53_mhc_prefill_tc.cuh"
+    qualified_kernel_body(probe.read_text(), header.read_text())
+    extension_path = Path(census["settings"]["extension"])
+    require(sha(extension_path) == PROBE_SHA, "qualified probe binary changed")
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"], text=True
+    ).strip()
+    require(not active, f"GPU compute processes already active: {active}")
+    settings = {**census["environment"], "VLLM_GLM5_MHC_PREFILL_TC": "1"}
+    for key, value in settings.items():
+        require(
+            key not in os.environ or os.environ[key] == value, f"requires {key}={value}"
+        )
+        os.environ[key] = value
+    paths = set(census["source_sha256"]) | {
+        str(Path(__file__).relative_to(root)),
+        str(header.relative_to(root)),
+        "benchmarks/kernels/benchmark_glm53_mhc_tc_qualified.py",
+        "vllm/quixicore/ops.py",
+        "vllm/model_executor/layers/glm5_next_mhc_ops.py",
+        "vllm/model_executor/models/glm5_next.py",
+    }
+    hashes = {p: sha(root / p) for p in sorted(paths)}
+    plan = case_plan(BATCHES, list(range(90)))
+    result = {
+        "status": "running",
+        "method": __doc__,
+        "command": sys.argv,
+        "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "git_status": subprocess.check_output(
+            ["git", "status", "--short"], text=True
+        ).strip(),
+        "source_sha256": hashes,
+        "qualified_accuracy": receipt,
+        "extension_sha256": PROBE_SHA,
+        "environment": settings,
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "plan": plan,
+        "planned_cases": len(plan),
+        "completed_cases": 0,
+        "completed_graph_phases": 0,
+    }
+    args.output.mkdir(parents=True)
+    journal, summary = args.output / "checks.jsonl", args.output / "summary.json"
+
+    def save():
+        temp = summary.with_suffix(".tmp")
+        temp.write_text(json.dumps(result, indent=2) + "\n")
+        temp.replace(summary)
+
+    save()
+    started = time.monotonic()
+    try:
+        import vllm._quixicore_C as native
+
+        from vllm.quixicore.ops import quixicore_ops as qc
+
+        torch.set_num_threads(4)
+        require(torch.cuda.get_device_capability() == (12, 0), "SM120 required")
+        require(qc.get_glm53_mhc_prefill_tc() == 1, "native candidate not enabled")
+        require(qc.get_dsv4_mhc_prefill_min_t() == 64, "prefill selector changed")
+        result["native_sha256"] = sha(native.__file__)
+        result["gpu"] = torch.cuda.get_device_name()
+        spec = importlib.util.spec_from_file_location(
+            "mhc_prefill_tc_probe", extension_path
+        )
+        extension = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(extension)
+        sites, result["parameters"] = checkpoint_parameters(
+            Path(census["settings"]["model"])
+        )
+        require(
+            result["parameters"] == census["parameters"], "model parameters changed"
+        )
+        require(len(sites) == 90, "all 90 parameter sites required")
+        sites = [[lossless_bf16(s[0]), *s[1:]] for s in sites]
+        with journal.open("x") as stream:
+            for item in plan:
+                row = {**item, "status": "checking"}
+                result["current_case"] = item
+                try:
+                    check_case(item, sites[item["site"]], extension, row)
+                    row["status"] = "complete"
+                    result["completed_cases"] += 1
+                    result["completed_graph_phases"] += len(row["graphs"])
+                except BaseException as error:
+                    row.update(status="failed", error=repr(error))
+                    raise
+                finally:
+                    stream.write(json.dumps(row) + "\n")
+                    stream.flush()
+                    save()
+                if result["completed_cases"] % 90 == 0:
+                    print(
+                        json.dumps(
+                            {
+                                k: result[k]
+                                for k in (
+                                    "completed_cases",
+                                    "planned_cases",
+                                    "completed_graph_phases",
+                                )
+                            }
+                        ),
+                        flush=True,
+                    )
+        require(
+            hashes == {p: sha(root / p) for p in paths}, "source changed during census"
+        )
+        require(
+            sha(native.__file__) == result["native_sha256"],
+            "native changed during census",
+        )
+        require(sha(extension_path) == PROBE_SHA, "probe changed during census")
+        _, final_receipt = qualified_census(args.census)
+        require(final_receipt == receipt, "qualification receipt changed during census")
+        result["status"] = "complete"
+        result.pop("current_case", None)
+    except BaseException as error:
+        result.update(status="failed", error=repr(error))
+        raise
+    finally:
+        result["elapsed_seconds"] = time.monotonic() - started
+        result["journal_sha256"] = sha(journal) if journal.exists() else None
+        save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/fp8_launch_probe.cu
+++ b/benchmarks/kernels/fp8_launch_probe.cu
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Isolated launch-geometry sweep of unchanged serving math. No registered op.
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include "fp8_decode_gemm.cuh"
+
+namespace fp8 = tms::decode_gemm_fp8;
+using torch::Tensor;
+
+// NT, WARPS, STAGES; KCHUNK remains the checkpoint's 128-column scale block.
+#define CONFIGS(X) \
+    X(8,4,4) X(8,4,8) X(8,8,4) X(8,8,8) \
+    X(16,4,4) X(16,4,8) X(16,8,4) X(16,8,8) \
+    X(32,4,4) X(32,4,8) X(32,8,4) X(32,8,8)
+
+Tensor run(Tensor x, Tensor weight, Tensor scale, int nt, int warps, int stages) {
+    TORCH_CHECK(x.is_cuda(), "CUDA activations required");
+    const c10::cuda::CUDAGuard guard(x.device());
+    for (const auto& t : {x, weight, scale})
+        TORCH_CHECK(t.device() == x.device() && t.is_contiguous(),
+                    "contiguous inputs on the same CUDA device required");
+    TORCH_CHECK(x.scalar_type() == torch::kBFloat16 &&
+                weight.scalar_type() == torch::kFloat8_e4m3fn &&
+                scale.scalar_type() == torch::kFloat32,
+                "BF16 activations, E4M3 weights, FP32 scales required");
+    TORCH_CHECK(x.dim() == 2 && weight.dim() == 2 && scale.dim() == 2 &&
+                x.size(1) == weight.size(1), "unexpected ranks or K dimension");
+    const int m = x.size(0), n = weight.size(0), k = x.size(1);
+    TORCH_CHECK(m >= 1 && m <= 16 &&
+                ((n == 1024 && k == 4096) || (n == 4096 && k == 512)),
+                "only TP4 shared-expert serving shapes are in this probe");
+    TORCH_CHECK(scale.sizes() == at::IntArrayRef({n / 128, k / 128}),
+                "unexpected block-scale shape");
+    TORCH_CHECK(reinterpret_cast<uintptr_t>(x.data_ptr()) % 16 == 0 &&
+                reinterpret_cast<uintptr_t>(weight.data_ptr()) % 16 == 0,
+                "16-byte-aligned activation and weight allocations required");
+    auto out = torch::empty({m, n}, x.options());
+    const auto* xp = reinterpret_cast<const __nv_bfloat16*>(x.data_ptr());
+    const auto* wp = reinterpret_cast<const uint8_t*>(weight.data_ptr());
+    const auto* sp = scale.data_ptr<float>();
+    auto* op = reinterpret_cast<__nv_bfloat16*>(out.data_ptr());
+    auto stream = at::cuda::getCurrentCUDAStream();
+    if (nt == 0 && warps == 0 && stages == 0) {
+        fp8::launch_auto(xp, wp, sp, nullptr, op, m, n, k, stream);
+    } else {
+        bool matched = false;
+#define LAUNCH(N, W, S) \
+        if (nt == N && warps == W && stages == S) { \
+            fp8::launch<N, W, 128, S>(xp, wp, sp, nullptr, op, m, n, k, stream); \
+            matched = true; \
+        }
+        CONFIGS(LAUNCH)
+#undef LAUNCH
+        TORCH_CHECK(matched, "unsupported launch configuration");
+    }
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return out;
+}
+
+pybind11::list resources() {
+    pybind11::list rows;
+#define RESOURCE(N, W, S) { \
+    cudaFuncAttributes attr{}; \
+    C10_CUDA_CHECK(cudaFuncGetAttributes( \
+        &attr, fp8::fp8_decode_gemm_kernel<N, W, 128, S, __nv_bfloat16>)); \
+    pybind11::dict row; \
+    row["config"] = pybind11::make_tuple(N, W, S); \
+    row["registers"] = attr.numRegs; \
+    row["local_bytes"] = attr.localSizeBytes; \
+    row["dynamic_shared_bytes"] = fp8::Cfg<N, W, 128, S>::SMEM_BYTES; \
+    row["binary_version"] = attr.binaryVersion; \
+    rows.append(row); \
+}
+    CONFIGS(RESOURCE)
+#undef RESOURCE
+    return rows;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("run", &run);
+    m.def("resources", &resources);
+}

--- a/benchmarks/kernels/glm53_kda_core.py
+++ b/benchmarks/kernels/glm53_kda_core.py
@@ -15,7 +15,7 @@ from vllm.triton_utils import tl, triton
 
 
 @triton.jit
-def _conv_head(x, weight, state, features, slot, X_STRIDE: tl.constexpr):
+def _conv_head(x, weight, state, features, slot):
     offsets = slot * 18432 + features
     c0 = tl.load(state + offsets)
     c1 = tl.load(state + offsets + 6144)
@@ -73,9 +73,9 @@ def _core(
         return
     x = mixed + token * MIXED_STRIDE
     features = head * 128 + k
-    q = _conv_head(x, conv_weight, conv_state, features, slot, MIXED_STRIDE)
-    key = _conv_head(x, conv_weight, conv_state, 2048 + features, slot, MIXED_STRIDE)
-    value = _conv_head(x, conv_weight, conv_state, 4096 + features, slot, MIXED_STRIDE)
+    q = _conv_head(x, conv_weight, conv_state, features, slot)
+    key = _conv_head(x, conv_weight, conv_state, 2048 + features, slot)
+    value = _conv_head(x, conv_weight, conv_state, 4096 + features, slot)
     if debug_conv is not None:
         tl.store(debug_conv + token * 6144 + features, q)
         tl.store(debug_conv + token * 6144 + 2048 + features, key)
@@ -109,10 +109,24 @@ def _core(
 
 def core(mixed, g1, g2, beta, weights, conv_state, state, indices, output, debug=None):
     batch = mixed.shape[0]
+    if weights["conv"].shape != (6144, 4) or not weights["conv"].is_contiguous():
+        raise ValueError("conv weights must be contiguous [6144, 4]")
+    if (
+        output.shape != (batch, 2048)
+        or output.dtype != torch.bfloat16
+        or not output.is_contiguous()
+    ):
+        raise ValueError("output must be contiguous BF16 [batch, 2048]")
+    if (
+        indices.shape != (batch,)
+        or indices.dtype not in (torch.int32, torch.int64)
+        or not indices.is_contiguous()
+    ):
+        raise ValueError("indices must be contiguous integer [batch]")
     assert mixed.shape == (batch, 6144) and mixed.dtype == torch.bfloat16
     assert conv_state.stride() == (18432, 1, 6144)
     assert state.dtype == torch.float32 and state.shape[1:] == (16, 128, 128)
-    assert state.is_contiguous() and output.is_contiguous()
+    assert state.is_contiguous()
     assert g1.stride() == g2.stride() == (2048, 1)
     assert weights["norm"].numel() == 128
     return _core[(batch * 16,)](

--- a/benchmarks/kernels/glm53_kda_core.py
+++ b/benchmarks/kernels/glm53_kda_core.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+"""Phase 4.2 full-head conv/state/norm prototype; no serving dispatch.
+
+Adapts the owned GDN whole-head fusion boundary to GLM53's KDA equations.
+The arithmetic follows causal_conv1d_update, fused_recurrent_kda_packed_decode
+and the FLA gated RMSNorm. Projections remain on their existing kernels.
+"""
+
+import torch
+
+from vllm.third_party.flash_linear_attention.ops.op import exp
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _conv_head(x, weight, state, features, slot, X_STRIDE: tl.constexpr):
+    offsets = slot * 18432 + features
+    c0 = tl.load(state + offsets)
+    c1 = tl.load(state + offsets + 6144)
+    c2 = tl.load(state + offsets + 12288)
+    current = tl.load(x + features)
+    w0 = tl.load(weight + features * 4)
+    w1 = tl.load(weight + features * 4 + 1)
+    w2 = tl.load(weight + features * 4 + 2)
+    w3 = tl.load(weight + features * 4 + 3)
+    # Match the original expression's BF16 operands and FP32 accumulator,
+    # including the explicit post-convolution BF16 materialization boundary.
+    acc = tl.full((128,), 0, tl.float32)
+    acc += c0 * w0
+    acc += c1 * w1
+    acc += c2 * w2
+    acc += current * w3
+    value = acc / (1 + tl.exp(-acc))
+    # Whole-head recurrence broadcasts these vectors across multiple warps.
+    # All duplicated readers must finish before the canonical writer shifts
+    # the in-place conv history. Shared-memory racecheck cannot detect this
+    # global-memory read/write dependency within the CTA.
+    tl.debug_barrier()
+    tl.store(state + offsets, c1)
+    tl.store(state + offsets + 6144, c2)
+    tl.store(state + offsets + 12288, current)
+    return value.to(tl.bfloat16).to(tl.float32)
+
+
+@triton.jit
+def _core(
+    mixed,
+    raw_g,
+    output_gate,
+    raw_beta,
+    conv_weight,
+    conv_state,
+    a_log,
+    dt_bias,
+    state,
+    indices,
+    norm_weight,
+    output,
+    debug_conv,
+    MIXED_STRIDE: tl.constexpr,
+    G_STRIDE: tl.constexpr,
+    BETA_STRIDE: tl.constexpr,
+):
+    nh = tl.program_id(0)
+    token, head = nh // 16, nh % 16
+    slot = tl.load(indices + token).to(tl.int64)
+    k = tl.arange(0, 128)
+    v = tl.arange(0, 128)
+    if slot <= 0:
+        tl.store(output + nh * 128 + v, 0.0)
+        return
+    x = mixed + token * MIXED_STRIDE
+    features = head * 128 + k
+    q = _conv_head(x, conv_weight, conv_state, features, slot, MIXED_STRIDE)
+    key = _conv_head(x, conv_weight, conv_state, 2048 + features, slot, MIXED_STRIDE)
+    value = _conv_head(x, conv_weight, conv_state, 4096 + features, slot, MIXED_STRIDE)
+    if debug_conv is not None:
+        tl.store(debug_conv + token * 6144 + features, q)
+        tl.store(debug_conv + token * 6144 + 2048 + features, key)
+        tl.store(debug_conv + token * 6144 + 4096 + features, value)
+    q /= tl.sqrt(tl.sum(q * q) + 1e-6)
+    key /= tl.sqrt(tl.sum(key * key) + 1e-6)
+    q *= 128**-0.5
+    g = tl.load(raw_g + token * G_STRIDE + features).to(tl.float32)
+    bias = tl.load(dt_bias + features).to(tl.float32)
+    decay = exp(tl.load(a_log + head).to(tl.float32))
+    g += bias
+    gate = -5.0 * tl.sigmoid(decay * g)
+    p_state = state + slot * 16 * 128 * 128 + head * 128 * 128
+    p_state += v[:, None] * 128 + k[None, :]
+    h = tl.load(p_state).to(tl.float32)
+    h *= exp(gate[None, :])
+    value -= tl.sum(h * key[None, :], axis=1)
+    beta = tl.sigmoid(tl.load(raw_beta + token * BETA_STRIDE + head).to(tl.float32))
+    value *= beta
+    h += value[:, None] * key[None, :]
+    result = tl.sum(h * q[None, :], axis=1)
+    tl.store(p_state, h)
+    # The existing recurrent op writes BF16 before gated normalization.
+    result = result.to(tl.bfloat16).to(tl.float32)
+    rstd = 1 / tl.sqrt(tl.sum(result * result) / 128 + 1e-5)
+    weight = tl.load(norm_weight + v).to(tl.float32)
+    out_gate = tl.load(output_gate + token * G_STRIDE + features).to(tl.float32)
+    result = ((result * rstd) * weight) * tl.sigmoid(out_gate)
+    tl.store(output + nh * 128 + v, result.to(tl.bfloat16))
+
+
+def core(mixed, g1, g2, beta, weights, conv_state, state, indices, output, debug=None):
+    batch = mixed.shape[0]
+    assert mixed.shape == (batch, 6144) and mixed.dtype == torch.bfloat16
+    assert conv_state.stride() == (18432, 1, 6144)
+    assert state.dtype == torch.float32 and state.shape[1:] == (16, 128, 128)
+    assert state.is_contiguous() and output.is_contiguous()
+    assert g1.stride() == g2.stride() == (2048, 1)
+    assert weights["norm"].numel() == 128
+    return _core[(batch * 16,)](
+        mixed,
+        g1,
+        g2,
+        beta,
+        weights["conv"],
+        conv_state,
+        weights["a_log"],
+        weights["dt_bias"],
+        state,
+        indices,
+        weights["norm"],
+        output,
+        debug,
+        MIXED_STRIDE=mixed.stride(0),
+        G_STRIDE=g1.stride(0),
+        BETA_STRIDE=beta.stride(0),
+        num_warps=8,
+        num_stages=2,
+    )

--- a/benchmarks/kernels/glm53_sparse_prefill_fused.py
+++ b/benchmarks/kernels/glm53_sparse_prefill_fused.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Rejected sparse-prefill diagnostics; never imported by serving.
+
+Accumulator fusion, query reload, and value splitting were closed on 2026-09-10
+without a useful speed gain. Kept solely to reproduce the recorded experiments.
+See perf/optimization_status.md, "Close sparse-prefill local variants".
+"""
+
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit(do_not_specialize=["bt_stride", "max_topk"])
+def kernel(
+    q_ptr,
+    cache_ptr,
+    bt_ptr,
+    idx_ptr,
+    tlen_ptr,
+    out_ptr,
+    max_topk,
+    bt_stride,
+    page_stride,
+    block_size,
+    scale,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    RELOAD_Q: tl.constexpr = False,
+    FUSE_ACC: tl.constexpr = True,
+    VALUE_TILE: tl.constexpr = 0,
+):
+    b = tl.program_id(0)
+    h = tl.arange(0, H)
+    d = tl.arange(0, D)
+    DV: tl.constexpr = VALUE_TILE if VALUE_TILE else D
+    dv = tl.program_id(1) * DV + tl.arange(0, DV)
+    if not RELOAD_Q:
+        q = tl.load(q_ptr + (b.to(tl.int64) * H + h)[:, None] * D + d[None, :])
+    tlen = tl.minimum(tl.maximum(tl.load(tlen_ptr + b), 0), max_topk)
+    m_i = tl.full((H,), -1.0e30, tl.float32)
+    l_i = tl.zeros((H,), tl.float32)
+    acc = tl.zeros((H, DV), tl.float32)
+    for j0 in range(0, tlen, BLOCK_N):
+        j = j0 + tl.arange(0, BLOCK_N)
+        t = tl.load(idx_ptr + b.to(tl.int64) * max_topk + j, mask=j < tlen, other=-1)
+        col = t // block_size
+        ok = (t >= 0) & (col < bt_stride)
+        blk = tl.load(bt_ptr + b.to(tl.int64) * bt_stride + col, mask=ok, other=-1)
+        ok = ok & (blk >= 0)
+        slot = t - col * block_size
+        rows = blk.to(tl.int64) * page_stride + slot.to(tl.int64) * D
+        k = tl.load(cache_ptr + rows[:, None] + d[None, :], mask=ok[:, None], other=0.0)
+        if RELOAD_Q:
+            # Cacheable reload shortens Q's live range across the value product.
+            # Volatile prevents loop hoisting.
+            q = tl.load(
+                q_ptr + (b.to(tl.int64) * H + h)[:, None] * D + d[None, :],
+                volatile=True,
+            )
+        s = tl.dot(q, tl.trans(k)) * scale
+        s = tl.where(ok[None, :], s, float("-inf"))
+        m_new = tl.maximum(m_i, tl.max(s, axis=1))
+        alpha = tl.exp(m_i - m_new)
+        p = tl.exp(s - m_new[:, None])
+        l_i = l_i * alpha + tl.sum(p, axis=1)
+        if VALUE_TILE:
+            v = tl.load(
+                cache_ptr + rows[:, None] + dv[None, :], mask=ok[:, None], other=0.0
+            ).to(tl.float16)
+        else:
+            v = k.to(tl.float16)
+        # Keep the running output in the tensor-core accumulator instead of
+        # materializing a second HxD FP32 product and adding it afterwards.
+        # This changes FP32 summation order, not operand/accumulator precision.
+        if FUSE_ACC:
+            acc = tl.dot(p.to(tl.float16), v, acc * alpha[:, None])
+        else:
+            acc = acc * alpha[:, None] + tl.dot(p.to(tl.float16), v)
+        m_i = m_new
+    out = tl.where(l_i[:, None] > 0.0, acc / l_i[:, None], 0.0)
+    tl.store(
+        out_ptr + (b.to(tl.int64) * H + h)[:, None] * D + dv[None, :],
+        out.to(tl.bfloat16),
+    )

--- a/benchmarks/kernels/glm53_sparse_swapab.cu
+++ b/benchmarks/kernels/glm53_sparse_swapab.cu
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include "quixicore/serving/glm53_sparse_swapab.cuh"
+
+void run(at::Tensor q, at::Tensor cache, at::Tensor bt, at::Tensor ids,
+         at::Tensor lengths, at::Tensor out, int block_size, double scale) {
+  TORCH_CHECK(q.is_cuda() && q.scalar_type() == at::kBFloat16);
+  const c10::cuda::CUDAGuard guard(q.device());
+  for (const auto& t : {q, cache, bt, ids, lengths, out})
+    TORCH_CHECK(t.device() == q.device());
+  TORCH_CHECK(q.is_contiguous() && out.is_contiguous() && bt.is_contiguous() &&
+              ids.is_contiguous() && lengths.is_contiguous());
+  TORCH_CHECK(q.dim() == 3 && q.size(1) == slimserve::glm53_swapab::HEADS && q.size(2) == 512);
+  TORCH_CHECK(cache.scalar_type() == q.scalar_type() && out.scalar_type() == q.scalar_type());
+  TORCH_CHECK(out.sizes() == q.sizes() && cache.dim() == 3 && cache.size(0) > 0 &&
+              cache.size(1) == block_size && cache.size(2) == 512 &&
+              cache.stride(1) == 512 && cache.stride(2) == 1);
+  TORCH_CHECK(bt.scalar_type() == at::kInt && ids.scalar_type() == at::kInt &&
+              lengths.scalar_type() == at::kInt && bt.dim() == 2 && ids.dim() == 2 &&
+              bt.size(0) == q.size(0) && ids.size(0) == q.size(0) &&
+              lengths.numel() == q.size(0));
+  if (q.size(0) == 0) return;
+  namespace impl = slimserve::glm53_swapab;
+  auto kernel = impl::sparse_nope;
+  C10_CUDA_CHECK(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                     sizeof(impl::Shared)));
+  kernel<<<q.size(0), impl::THREADS, sizeof(impl::Shared), at::cuda::getCurrentCUDAStream()>>>(
+      (const impl::BF*)q.data_ptr(), (const impl::BF*)cache.data_ptr(),
+      bt.data_ptr<int>(), ids.data_ptr<int>(), lengths.data_ptr<int>(),
+      (impl::BF*)out.data_ptr(), ids.size(1), bt.size(1), block_size,
+      cache.stride(0), float(scale));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+pybind11::dict info() {
+  cudaFuncAttributes attr;
+  C10_CUDA_CHECK(cudaFuncGetAttributes(&attr, slimserve::glm53_swapab::sparse_nope));
+  pybind11::dict d;
+  d["registers"] = attr.numRegs; d["local_bytes"] = attr.localSizeBytes;
+  d["shared"] = sizeof(slimserve::glm53_swapab::Shared);
+  return d;
+}
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) { m.def("run", &run); m.def("info", &info); }

--- a/benchmarks/kernels/glm53_sparse_swapab.py
+++ b/benchmarks/kernels/glm53_sparse_swapab.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Phase 4.3/4.5 diagnostic: candidate-major scores and transposed PV.
+
+Mechanism reference: FlashInfer #4751, merged through #4802. This adapts ONLY
+operand ownership, not that implementation's FP8 quantization or dispatch.
+Uses SlimServe's original BF16 Q/KV and FP16 P/V arithmetic and tile extents.
+"""
+
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit(do_not_specialize=["bt_stride", "max_topk"])
+def sparse_swapab(
+    q_ptr,
+    cache_ptr,
+    bt_ptr,
+    idx_ptr,
+    tlen_ptr,
+    out_ptr,
+    max_topk,
+    bt_stride,
+    page_stride,
+    block_size,
+    scale,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    b = tl.program_id(0)
+    h = tl.arange(0, H)
+    d = tl.arange(0, D)
+    # Q stays the reusable B operand; candidates own M. O is [D,H], so
+    # normalization runs over candidates within each head, not across heads.
+    q = tl.load(q_ptr + (b.to(tl.int64) * H + h)[None, :] * D + d[:, None])
+    tlen = tl.minimum(tl.maximum(tl.load(tlen_ptr + b), 0), max_topk)
+    m_i = tl.full((H,), -1.0e30, tl.float32)
+    l_i = tl.zeros((H,), tl.float32)
+    acc = tl.zeros((D, H), tl.float32)
+    for j0 in range(0, tlen, BLOCK_N):
+        j = j0 + tl.arange(0, BLOCK_N)
+        t = tl.load(idx_ptr + b.to(tl.int64) * max_topk + j, mask=j < tlen, other=-1)
+        col = t // block_size
+        ok = (t >= 0) & (col < bt_stride)
+        blk = tl.load(bt_ptr + b.to(tl.int64) * bt_stride + col, mask=ok, other=-1)
+        ok = ok & (blk >= 0)
+        slot = t - col * block_size
+        rows = blk.to(tl.int64) * page_stride + slot.to(tl.int64) * D
+        k = tl.load(cache_ptr + rows[:, None] + d[None, :], mask=ok[:, None], other=0.0)
+        s = tl.dot(k, q) * scale
+        s = tl.where(ok[:, None], s, float("-inf"))
+        m_new = tl.maximum(m_i, tl.max(s, axis=0))
+        alpha = tl.exp(m_i - m_new)
+        p = tl.exp(s - m_new[None, :])
+        l_i = l_i * alpha + tl.sum(p, axis=0)
+        acc = acc * alpha[None, :] + tl.dot(
+            tl.trans(k.to(tl.float16)), p.to(tl.float16)
+        )
+        m_i = m_new
+    out = tl.where(l_i[None, :] > 0.0, acc / l_i[None, :], 0.0)
+    tl.store(
+        out_ptr + (b.to(tl.int64) * H + h)[None, :] * D + d[:, None],
+        out.to(tl.bfloat16),
+    )

--- a/benchmarks/kernels/kda_fg_b_decode.cu
+++ b/benchmarks/kernels/kda_fg_b_decode.cu
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include "kda_fg_b_decode_sm120.cuh"
+
+void run(torch::Tensor x, torch::Tensor w, torch::Tensor out) {
+    TORCH_CHECK(x.is_cuda() && w.device() == x.device() && out.device() == x.device());
+    TORCH_CHECK(x.scalar_type() == torch::kBFloat16 && w.scalar_type() == x.scalar_type()
+                && out.scalar_type() == x.scalar_type());
+    TORCH_CHECK(x.dim() == 3 && x.size(0) == 2 && x.size(2) == 128);
+    const int m = x.size(1);
+    TORCH_CHECK(m >= 1 && m <= 16 && x.stride(0) == 128 && x.stride(2) == 1);
+    TORCH_CHECK(x.stride(1) >= 256 && x.stride(1) % 8 == 0);
+    TORCH_CHECK(w.is_contiguous() && w.sizes() == torch::IntArrayRef({2, 2048, 128}));
+    TORCH_CHECK(out.is_contiguous() && out.sizes() == torch::IntArrayRef({2, m, 2048}));
+    const c10::cuda::CUDAGuard guard(x.device());
+    using C = tms::decode_gemm::Cfg<16, 8, 128, 2>;
+    tms::kda_fg_b_decode::kda_fg_b_decode_kernel
+        <<<dim3(128, 2), 256, C::SMEM_BYTES, at::cuda::getCurrentCUDAStream()>>>(
+            reinterpret_cast<const __nv_bfloat16*>(x.data_ptr()),
+            reinterpret_cast<const __nv_bfloat16*>(w.data_ptr()),
+            reinterpret_cast<__nv_bfloat16*>(out.data_ptr()), m, x.stride(1));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) { m.def("run", &run); }

--- a/benchmarks/kernels/kda_fg_b_decode_sm120.cuh
+++ b/benchmarks/kernels/kda_fg_b_decode_sm120.cuh
@@ -1,0 +1,132 @@
+#pragma once
+// SPDX-License-Identifier: Apache-2.0
+// Phase 4.2 candidate: paired K128 BF16 projections from the strided merged
+// KDA input, producing [2, M, 2048] without input copies. Same cp.async,
+// ldmatrix, FP32 MMA accumulation and reduction as bf16_decode_gemm.cuh.
+// Parked after a 23-25% isolated win: only ~20 us across 34 layers, not yet
+// worth a serving qualification. No serving dispatcher selects this candidate.
+#include "quixicore/serving/bf16_decode_gemm.cuh"
+
+namespace tms::kda_fg_b_decode {
+using namespace tms::decode_gemm;
+__global__ void __launch_bounds__(256) kda_fg_b_decode_kernel(
+        const __nv_bfloat16* __restrict__ x,     // [M, K]
+        const __nv_bfloat16* __restrict__ w,     // [N, K]
+        __nv_bfloat16* __restrict__ out,                  // [M, N]
+        int M, int x_stride) {
+    constexpr int NT = 16, WARPS = 8, KCHUNK = 128, STAGES = 2;
+    constexpr int N = 2048, K = 128;
+    const int projection = blockIdx.y;
+    x += projection * K;
+    w += projection * N * K;
+    out += projection * M * N;
+    using C = Cfg<NT, WARPS, KCHUNK, STAGES>;
+    extern __shared__ __align__(16) unsigned char smem_raw[];
+    __nv_bfloat16* smem = reinterpret_cast<__nv_bfloat16*>(smem_raw);
+
+    const int tid = threadIdx.x, lane = tid & 31, warp = tid >> 5;
+    const int n0 = blockIdx.x * NT;
+    const int nchunks = K / KCHUNK;
+
+    auto stage_x = [&](int s) { return smem + s * C::STAGE; };
+    auto stage_w = [&](int s) { return smem + s * C::STAGE + C::X_TILE; };
+
+    // Issue the cp.async loads of chunk c into stage s.
+    auto load_chunk = [&](int c, int s) {
+        const int k0 = c * KCHUNK;
+        __nv_bfloat16* xs = stage_x(s);
+        __nv_bfloat16* ws = stage_w(s);
+        for (int i = tid; i < MT * C::KVEC; i += C::THREADS) {
+            const int m = i / C::KVEC, v = i - m * C::KVEC;
+            const bool valid = m < M;
+            const __nv_bfloat16* src = x + size_t(valid ? m : 0) * x_stride + k0 + v * 8;
+            cp_async16(smem_u32(xs + m * C::ROW + v * 8), src, valid);
+        }
+        for (int i = tid; i < NT * C::KVEC; i += C::THREADS) {
+            const int r = i / C::KVEC, v = i - r * C::KVEC;
+            const int n = min(n0 + r, N - 1);
+            cp_async16(smem_u32(ws + r * C::ROW + v * 8), w + size_t(n) * K + k0 + v * 8, true);
+        }
+    };
+
+    float acc[C::NTILES][4];
+#pragma unroll
+    for (int j = 0; j < C::NTILES; ++j)
+#pragma unroll
+        for (int e = 0; e < 4; ++e) acc[j][e] = 0.0f;
+
+    // ldmatrix addressing: lane supplies the row address of matrix (lane / 8).
+    const int mat = lane >> 3, mrow = lane & 7;
+    // A (x) tile: a0 = rows 0-7 / k 0-7, a1 = rows 8-15 / k 0-7, a2 = rows 0-7 / k 8-15, a3 = rows 8-15 / k 8-15.
+    const int a_row = mrow + 8 * (mat & 1), a_col = 8 * (mat >> 1);
+    // B (w) tile pair: r0 = tile 2p k 0-7, r1 = tile 2p k 8-15, r2 = tile 2p+1 k 0-7, r3 = tile 2p+1 k 8-15.
+    const int b_row = mrow + 8 * (mat >> 1), b_col = 8 * (mat & 1);
+
+    // Prologue: STAGES-1 chunks in flight.
+#pragma unroll
+    for (int c = 0; c < STAGES - 1; ++c) {
+        if (c < nchunks) load_chunk(c, c);
+        cp_async_commit();
+    }
+
+    for (int c = 0; c < nchunks; ++c) {
+        cp_async_wait<STAGES - 2>();
+        __syncthreads();   // chunk c landed for everyone; stage (c-1)%STAGES is free
+        {
+            const int cn = c + STAGES - 1;
+            if (cn < nchunks) load_chunk(cn, cn % STAGES);
+            cp_async_commit();
+        }
+        const int s = c % STAGES;
+        const uint32_t xs = smem_u32(stage_x(s));
+        const uint32_t ws = smem_u32(stage_w(s));
+#pragma unroll
+        for (int step = warp; step < C::KSTEPS; step += WARPS) {
+            const int k0 = step * 16;
+            uint32_t a[4];
+            ldmatrix_x4(a, xs + (a_row * C::ROW + k0 + a_col) * 2);
+#pragma unroll
+            for (int p = 0; p < C::NTILES / 2; ++p) {
+                uint32_t b[4];
+                ldmatrix_x4(b, ws + ((16 * p + b_row) * C::ROW + k0 + b_col) * 2);
+                mma_bf16_16816(acc[2 * p], a, b[0], b[1]);
+                mma_bf16_16816(acc[2 * p + 1], a, b[2], b[3]);
+            }
+            if constexpr (C::NTILES % 2 == 1) {
+                // Last single n8 tile: x2 with lanes 0-15 addressing (k 0-7, k 8-15).
+                uint32_t b[2];
+                const int r = mrow, col = 8 * (mat & 1);
+                ldmatrix_x2(b, ws + ((16 * (C::NTILES / 2) + r) * C::ROW + k0 + col) * 2);
+                mma_bf16_16816(acc[C::NTILES - 1], a, b[0], b[1]);
+            }
+        }
+    }
+
+    // Cross-warp reduction of the K partials through shared memory.
+    cp_async_wait<0>();
+    __syncthreads();
+    float* red = reinterpret_cast<float*>(smem_raw);   // [WARPS][MT][NT]
+    {
+        float* mine = red + warp * (MT * NT);
+        const int r0 = lane >> 2, cc = (lane & 3) * 2;
+#pragma unroll
+        for (int j = 0; j < C::NTILES; ++j) {
+            const int n = 8 * j + cc;
+            mine[r0 * NT + n] = acc[j][0];
+            mine[r0 * NT + n + 1] = acc[j][1];
+            mine[(r0 + 8) * NT + n] = acc[j][2];
+            mine[(r0 + 8) * NT + n + 1] = acc[j][3];
+        }
+    }
+    __syncthreads();
+    for (int i = tid; i < MT * NT; i += C::THREADS) {
+        const int m = i / NT, n = i - m * NT;
+        if (m >= M || n0 + n >= N) continue;
+        float v = 0.0f;
+#pragma unroll
+        for (int wv = 0; wv < WARPS; ++wv) v += red[wv * (MT * NT) + i];
+        out[size_t(m) * N + n0 + n] = __float2bfloat16_rn(v);
+    }
+}
+
+}  // namespace tms::kda_fg_b_decode

--- a/benchmarks/kernels/marlin_glm_swiglu.cu
+++ b/benchmarks/kernels/marlin_glm_swiglu.cu
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Isolated Phase 4.1 probe. No registered op or serving dispatch.
+// Parked fusion decision and measurements: marlin_glm_swiglu_template.h header;
+// perf/optimization_status.md, 2026-09-11 "Phase 4.1 paired Marlin SwiGLU".
 #include <torch/extension.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>

--- a/benchmarks/kernels/marlin_glm_swiglu.cu
+++ b/benchmarks/kernels/marlin_glm_swiglu.cu
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Isolated Phase 4.1 probe. No registered op or serving dispatch.
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#define MARLIN_NAMESPACE_NAME marlin_glm_swiglu
+#include "marlin_glm_swiglu_template.h"
+
+template <int K, int N, int BLOCKS>
+at::Tensor launch(at::Tensor a, at::Tensor out, at::Tensor weight,
+               at::Tensor scales, at::Tensor global_scale, at::Tensor workspace,
+               at::Tensor temp, at::Tensor sorted_ids, at::Tensor experts,
+               at::Tensor padded, at::Tensor routing_weights) {
+  TORCH_CHECK(a.is_cuda() && a.scalar_type() == at::kBFloat16);
+  const c10::cuda::CUDAGuard guard(a.device());
+  for (const auto& t : {a, out, weight, scales, global_scale, workspace, temp,
+                       sorted_ids, experts, padded, routing_weights})
+    TORCH_CHECK(t.device() == a.device() && t.is_contiguous());
+  TORCH_CHECK(out.scalar_type() == at::kBFloat16 &&
+              weight.scalar_type() == at::kInt &&
+              scales.scalar_type() == at::kFloat8_e4m3fn &&
+              global_scale.scalar_type() == at::kFloat &&
+              routing_weights.scalar_type() == at::kFloat &&
+              temp.scalar_type() == at::kFloat);
+  TORCH_CHECK(workspace.scalar_type() == at::kInt && sorted_ids.scalar_type() == at::kInt &&
+              experts.scalar_type() == at::kInt && padded.scalar_type() == at::kInt);
+  TORCH_CHECK(a.dim() == 2 && a.size(1) == 4096 && a.size(0) >= 1 && a.size(0) <= 16);
+  TORCH_CHECK(out.sizes() == at::IntArrayRef({a.size(0) * 8, 512}));
+  TORCH_CHECK(weight.sizes() == at::IntArrayRef({288, 256, 2048}));
+  TORCH_CHECK(scales.sizes() == at::IntArrayRef({288, 256, 1024}));
+  TORCH_CHECK(global_scale.numel() == 288 && padded.numel() == 1 &&
+              routing_weights.numel() == a.size(0) * 8 &&
+              experts.numel() * 8 >= sorted_ids.numel());
+  // Retained decode schedules from actual-weight counter traces: c1
+  // K128/N64/two-CTAs-per-SM; c8/c16 K64/N128/three-CTAs-per-SM.
+  // No schedule search. Only column ownership and the epilogue change.
+  constexpr int THREADS = 128, SMEM = 16 * 16 + 4 * 16 * K * 2 +
+                                     4 * K * N / 2 + 4 * (K / 16) * N;
+  auto kernel = MARLIN_NAMESPACE_NAME::Marlin<
+      vllm::kBFloat16.id(), vllm::kFE2M1f.id(), vllm::kBFloat16.id(),
+      vllm::kFE4M3fn.id(), THREADS, 1, N / 16, K / 16, true, 4, 1, false, true>;
+  int sms;
+  C10_CUDA_CHECK(cudaDeviceGetAttribute(
+      &sms, cudaDevAttrMultiProcessorCount, a.get_device()));
+  TORCH_CHECK(workspace.numel() >= sms * 4 && temp.numel() >= sms * BLOCKS * 16 * N);
+  C10_CUDA_CHECK(cudaFuncSetAttribute(
+      kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM));
+  kernel<<<sms * BLOCKS, THREADS, SMEM, at::cuda::getCurrentCUDAStream()>>>(
+      (const int4*)a.data_ptr(), (const int4*)weight.data_ptr(),
+      (int4*)out.data_ptr(), (int4*)temp.data_ptr(), nullptr, nullptr,
+      (const int4*)scales.data_ptr(), global_scale.data_ptr<float>(), nullptr,
+      nullptr, sorted_ids.data_ptr<int>(), experts.data_ptr<int>(),
+      padded.data_ptr<int>(), routing_weights.data_ptr<float>(), 8, false,
+      256, int(a.size(0)), 1024, 4096, workspace.data_ptr<int>(), false, false, true);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return out;
+}
+
+at::Tensor run(at::Tensor a, at::Tensor out, at::Tensor weight,
+               at::Tensor scales, at::Tensor global_scale, at::Tensor workspace,
+               at::Tensor temp, at::Tensor sorted_ids, at::Tensor experts,
+               at::Tensor padded, at::Tensor routing_weights) {
+  if (a.size(0) == 1)
+    return launch<128, 64, 2>(a, out, weight, scales, global_scale, workspace,
+                             temp, sorted_ids, experts, padded, routing_weights);
+  return launch<64, 128, 3>(a, out, weight, scales, global_scale, workspace,
+                            temp, sorted_ids, experts, padded, routing_weights);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) { m.def("run", &run); }

--- a/benchmarks/kernels/marlin_glm_swiglu_template.h
+++ b/benchmarks/kernels/marlin_glm_swiglu_template.h
@@ -1,5 +1,9 @@
 // Archived Phase 4.1 experiment; NOT used by serving builds.
 // Marlin baseline: 6cba6fdee. Only the paired SwiGLU epilogue was added.
+// Decision: perf/optimization_status.md, 2026-09-11 "Phase 4.1 paired Marlin
+// SwiGLU: park for small serving budget". Complete expert c1 24.98 -> 23.69 us
+// (~54 us/model step), c8 neutral; seven stress comparisons fail tolerance.
+// Raw: perf/results/2026-09-11/marlin-swiglu/. No serving promotion.
 /*
  * Modified by Neural Magic
  * Copyright (C) Marlin.2024 Elias Frantar

--- a/benchmarks/kernels/marlin_glm_swiglu_template.h
+++ b/benchmarks/kernels/marlin_glm_swiglu_template.h
@@ -1,0 +1,2280 @@
+// Archived Phase 4.1 experiment; NOT used by serving builds.
+// Marlin baseline: 6cba6fdee. Only the paired SwiGLU epilogue was added.
+/*
+ * Modified by Neural Magic
+ * Copyright (C) Marlin.2024 Elias Frantar
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Adapted from https://github.com/IST-DASLab/marlin
+ */
+
+#ifndef MARLIN_NAMESPACE_NAME
+  #define MARLIN_NAMESPACE_NAME marlin_moe_wna16
+#endif
+
+#include "libtorch_stable/quantization/marlin/marlin.cuh"
+#include "libtorch_stable/quantization/marlin/marlin_dtypes.cuh"
+#include "libtorch_stable/quantization/marlin/dequant.h"
+#include "libtorch_stable/quantization/marlin/marlin_mma.h"
+#include "core/scalar_type.hpp"
+
+#define STATIC_ASSERT_SCALAR_TYPE_VALID(scalar_t)               \
+  static_assert(std::is_same<scalar_t, half>::value ||          \
+                    std::is_same<scalar_t, nv_bfloat16>::value, \
+                "only float16 and bfloat16 is supported");
+
+namespace MARLIN_NAMESPACE_NAME {
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 750
+
+template <typename scalar_t,  // compute dtype, half or nv_float16
+          const vllm::ScalarTypeId b_type_id,  // weight MarlinScalarType id
+          const int threads,          // number of threads in a threadblock
+          const int thread_m_blocks,  // number of 16x16 blocks in the m
+                                      // dimension (batchsize) of the
+                                      // threadblock
+          const int thread_n_blocks,  // same for n dimension (output)
+          const int thread_k_blocks,  // same for k dimension (reduction)
+          const bool m_block_size_8,  // whether m_block_size == 8
+                                      // only works when thread_m_blocks == 1
+          const int stages,  // number of stages for the async global->shared
+                             // fetch pipeline
+          const bool has_act_order,  // whether act_order is enabled
+          const int group_blocks,    // number of consecutive 16x16 blocks
+                                     // with a separate quantization scale
+          const bool is_zp_float     // is zero point of float16 type?
+          >
+__global__ void Marlin(
+    const int4* __restrict__ A,  // fp16 input matrix of shape mxk
+    const int4* __restrict__ B,  // 4bit quantized weight matrix of shape kxn
+    int4* __restrict__ C,        // fp16 output buffer of shape mxn
+    int4* __restrict__ C_tmp,    // fp32 tmp output buffer (for reduce)
+    const int4* __restrict__ scales_ptr,  // fp16 quantization scales of shape
+                                          // (k/groupsize)xn
+    const int4* __restrict__ zp_ptr,      // 4bit packed zero-points of shape
+                                          // (k/groupsize)x(n/pack_factor)
+    const int* __restrict__ g_idx,        // int32 group indices of shape k
+    const int32_t* __restrict__ sorted_token_ids_ptr,        // moe sorted_ids
+    const int32_t* __restrict__ expert_ids_ptr,              // moe expert ids
+    const int32_t* __restrict__ num_tokens_past_padded_ptr,  // moe num tokens
+    const float* __restrict__ topk_weights_ptr,              // moe top weights
+    int top_k,              // num of experts per token
+    bool mul_topk_weights,  // mul topk weights or not
+    int num_groups,         // number of scale groups per output channel
+    int prob_m,             // batch dimension m
+    int prob_n,             // output dimension n
+    int prob_k,             // reduction dimension k
+    int* locks,             // extra global storage for barrier synchronization
+    bool use_atomic_add,    // whether to use atomic add to reduce
+    bool use_fp32_reduce    // whether to use fp32 global reduce
+) {}
+
+}  // namespace MARLIN_NAMESPACE_NAME
+
+#else
+
+// Instruction for loading a full 16x16 matrix fragment of operand A from shared
+// memory, directly in tensor core layout.
+template <int count, vllm::ScalarTypeId type_id>
+__device__ inline void ldsm(typename MarlinScalarType<type_id>::FragA& frag_a,
+                            const void* smem_ptr) {
+  uint32_t* a = reinterpret_cast<uint32_t*>(&frag_a);
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  if constexpr (count == 4) {
+    asm volatile(
+        "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];\n"
+        : "=r"(a[0]), "=r"(a[1]), "=r"(a[2]), "=r"(a[3])
+        : "r"(smem));
+  } else if constexpr (count == 2) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0,%1}, [%2];\n"
+                 : "=r"(a[0]), "=r"(a[1])
+                 : "r"(smem));
+  } else if constexpr (count == 1) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x1.shared.b16 {%0}, [%1];\n"
+                 : "=r"(a[0])
+                 : "r"(smem));
+  } else {
+    static_assert(count == 1 || count == 2 || count == 4, "invalid count");
+  }
+}
+
+// Multiply dequantized values by the corresponding quantization scale; used
+// only for grouped quantization.
+template <vllm::ScalarTypeId type_id>
+__device__ inline void scale(typename MarlinScalarType<type_id>::FragB& frag_b,
+                             typename MarlinScalarType<type_id>::FragS& frag_s,
+                             int i) {
+  using scalar_t = typename MarlinScalarType<type_id>::scalar_t;
+  using scalar_t2 = typename MarlinScalarType<type_id>::scalar_t2;
+  scalar_t2 s = MarlinScalarType<type_id>::num2num2(
+      reinterpret_cast<scalar_t*>(&frag_s)[i]);
+  frag_b[0] = __hmul2(frag_b[0], s);
+  frag_b[1] = __hmul2(frag_b[1], s);
+}
+
+template <vllm::ScalarTypeId type_id>
+__device__ inline void scale_and_sub(
+    typename MarlinScalarType<type_id>::FragB& frag_b,
+    typename MarlinScalarType<type_id>::scalar_t s,
+    typename MarlinScalarType<type_id>::scalar_t zp) {
+  using scalar_t = typename MarlinScalarType<type_id>::scalar_t;
+  using scalar_t2 = typename MarlinScalarType<type_id>::scalar_t2;
+  scalar_t2 s2 = MarlinScalarType<type_id>::num2num2(s);
+  scalar_t2 zp2 = MarlinScalarType<type_id>::num2num2(zp);
+  frag_b[0] = __hfma2(frag_b[0], s2, __hneg2(zp2));
+  frag_b[1] = __hfma2(frag_b[1], s2, __hneg2(zp2));
+}
+
+template <vllm::ScalarTypeId type_id>
+__device__ inline void sub_zp(
+    typename MarlinScalarType<type_id>::FragB& frag_b,
+    typename MarlinScalarType<type_id>::scalar_t2& frag_zp, int i) {
+  using scalar_t = typename MarlinScalarType<type_id>::scalar_t;
+  using scalar_t2 = typename MarlinScalarType<type_id>::scalar_t2;
+  scalar_t2 zp = MarlinScalarType<type_id>::num2num2(
+      reinterpret_cast<scalar_t*>(&frag_zp)[i]);
+  frag_b[0] = __hsub2(frag_b[0], zp);
+  frag_b[1] = __hsub2(frag_b[1], zp);
+}
+
+// Same as above, but for act_order (each K is multiplied individually)
+template <vllm::ScalarTypeId type_id>
+__device__ inline void scale4(
+    typename MarlinScalarType<type_id>::FragB& frag_b,
+    typename MarlinScalarType<type_id>::FragS& frag_s_1,
+    typename MarlinScalarType<type_id>::FragS& frag_s_2,
+    typename MarlinScalarType<type_id>::FragS& frag_s_3,
+    typename MarlinScalarType<type_id>::FragS& frag_s_4, int i) {
+  using scalar_t = typename MarlinScalarType<type_id>::scalar_t;
+  using scalar_t2 = typename MarlinScalarType<type_id>::scalar_t2;
+
+  scalar_t2 s_val_1_2;
+  s_val_1_2.x = reinterpret_cast<scalar_t*>(&frag_s_1)[i];
+  s_val_1_2.y = reinterpret_cast<scalar_t*>(&frag_s_2)[i];
+
+  scalar_t2 s_val_3_4;
+  s_val_3_4.x = reinterpret_cast<scalar_t*>(&frag_s_3)[i];
+  s_val_3_4.y = reinterpret_cast<scalar_t*>(&frag_s_4)[i];
+
+  frag_b[0] = __hmul2(frag_b[0], s_val_1_2);
+  frag_b[1] = __hmul2(frag_b[1], s_val_3_4);
+}
+
+// Given 2 floats multiply by 2 scales (halves)
+template <vllm::ScalarTypeId type_id>
+__device__ inline void scale_float(
+    float* c, typename MarlinScalarType<type_id>::FragS& s) {
+  using scalar_t = typename MarlinScalarType<type_id>::scalar_t;
+  scalar_t* s_ptr = reinterpret_cast<scalar_t*>(&s);
+  c[0] = __fmul_rn(c[0], MarlinScalarType<type_id>::num2float(s_ptr[0]));
+  c[1] = __fmul_rn(c[1], MarlinScalarType<type_id>::num2float(s_ptr[1]));
+}
+
+// Wait until barrier reaches `count`, then lock for current threadblock.
+__device__ inline void barrier_acquire(int* lock, int count) {
+  if (threadIdx.x == 0) {
+    int state = -1;
+    do
+      // Guarantee that subsequent writes by this threadblock will be visible
+      // globally.
+      asm volatile("ld.global.acquire.gpu.b32 %0, [%1];\n"
+                   : "=r"(state)
+                   : "l"(lock));
+    while (state != count);
+  }
+  __syncthreads();
+}
+
+// Release barrier and increment visitation count.
+__device__ inline void barrier_release(int* lock, bool reset = false) {
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    if (reset) {
+      lock[0] = 0;
+      return;
+    }
+    int val = 1;
+    // Make sure that all writes since acquiring this barrier are visible
+    // globally, while releasing the barrier.
+    asm volatile("fence.acq_rel.gpu;\n");
+    asm volatile("red.relaxed.gpu.global.add.s32 [%0], %1;\n"
+                 :
+                 : "l"(lock), "r"(val));
+  }
+}
+
+// Wait until value of lock to be negative, and then add 1
+__device__ inline void wait_negative_and_add(int* lock) {
+  if (threadIdx.x == 0) {
+    int state = 0;
+    do
+      // Guarantee that subsequent writes by this threadblock will be visible
+      // globally.
+      asm volatile("ld.global.acquire.gpu.b32 %0, [%1];\n"
+                   : "=r"(state)
+                   : "l"(lock));
+    while (state >= 0);
+    atomicAdd(lock, 1);
+  }
+  __syncthreads();
+}
+
+template <const vllm::ScalarTypeId a_type_id,  // A ScalarType id
+          const vllm::ScalarTypeId b_type_id,  // B ScalarType id
+          const vllm::ScalarTypeId c_type_id,  // C ScalarType id
+          const vllm::ScalarTypeId s_type_id,  // B_SCALE ScalarType id
+          const int threads,          // number of threads in a threadblock
+          const int thread_m_blocks,  // number of 16x16 blocks in the m
+                                      // dimension (batchsize) of the
+                                      // threadblock
+          const int thread_n_blocks,  // same for n dimension (output)
+          const int thread_k_blocks,  // same for k dimension (reduction)
+          const bool m_block_size_8,  // whether m_block_size == 8
+                                      // only works when thread_m_blocks == 1
+          const int stages,  // number of stages for the async global->shared
+                             // fetch pipeline
+          const int group_blocks,  // number of consecutive 16x16 blocks
+                                   // with a separate quantization scale
+          const bool is_zp_float,  // is zero point of float16 type?
+          const bool fused_glm_swiglu = false
+          >
+__global__ void Marlin(
+    const int4* __restrict__ A,  // fp16 input matrix of shape mxk
+    const int4* __restrict__ B,  // 4bit quantized weight matrix of shape kxn
+    int4* __restrict__ C,        // fp16 output buffer of shape mxn
+    int4* __restrict__ C_tmp,    // fp32 tmp output buffer (for reduce)
+    const int4* __restrict__ b_bias_ptr,
+    // float scales of input matrix, only used when is_a_8bit == true.
+    // shape (m,)
+    const float* __restrict__ a_scales_ptr,
+    // fp16 quantization scales. shape (k/groupsize, n)
+    const int4* __restrict__ scales_ptr,
+    // fp16 global scale (for nvfp4// only)
+    const float* __restrict__ global_scale_ptr,
+    // 4bit packed zero-points of shape
+    // (k/groupsize, n/pack_factor)
+    const int4* __restrict__ zp_ptr,
+    // int32 group indices of shape k
+    const int* __restrict__ g_idx,
+    const int32_t* __restrict__ sorted_token_ids_ptr,        // moe sorted_ids
+    const int32_t* __restrict__ expert_ids_ptr,              // moe expert ids
+    const int32_t* __restrict__ num_tokens_past_padded_ptr,  // moe num tokens
+    const float* __restrict__ topk_weights_ptr,              // moe top weights
+    int top_k,              // num of experts per token
+    bool mul_topk_weights,  // mul topk weights or not
+    int num_groups,         // number of scale groups per output channel
+    int prob_m,             // batch dimension m
+    int prob_n,             // output dimension n
+    int prob_k,             // reduction dimension k
+    int* locks,             // extra global storage for barrier synchronization
+    bool has_bias,
+    bool use_atomic_add,  // whether to use atomic add to reduce
+    bool use_fp32_reduce  // whether to use fp32 global reduce
+) {
+  // Each threadblock processes one "stripe" of the B matrix with (roughly) the
+  // same size, which might involve multiple column "slices" (of width 16 *
+  // `thread_n_blocks`). Stripes are defined as shown in the 3x3 matrix 5 SM
+  // example:
+  //   0 1 3
+  //   0 2 3
+  //   1 2 4
+  // While this kind of partitioning makes things somewhat more complicated, it
+  // ensures good utilization of all SMs for many kinds of shape and GPU
+  // configurations, while requiring as few slow global cross-threadblock
+  // reductions as possible.
+
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 890
+  // FP8 computation is only supported for Ada Lovelace or newer architectures.
+  if constexpr (a_type_id == vllm::kFE4M3fn.id()) return;
+  #endif
+
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750
+  // Turing TensorCore only supports fp16 and int8
+  if constexpr (a_type_id != vllm::kFloat16.id() && a_type_id != vllm::kS8.id())
+    return;
+  #endif
+
+  int num_tokens_past_padded = num_tokens_past_padded_ptr[0];
+  constexpr int moe_block_size = m_block_size_8 ? 8 : (16 * thread_m_blocks);
+
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750
+  static constexpr auto num_bits =
+      vllm::ScalarType::from_id(b_type_id).size_bits();
+  // Disable use_fp16_accum for NVFP4 and cases when group_size == -1 &&
+  // num_bits == 4
+  constexpr bool use_fp16_accum =
+      a_type_id == vllm::kFloat16.id() &&
+      (!(b_type_id == vllm::kFE2M1f.id() && s_type_id == vllm::kFE4M3fn.id()) &&
+       !(group_blocks == -1 && num_bits == 4));
+  #else
+  constexpr bool use_fp16_accum = false;
+  #endif
+  using Adtype = MarlinScalarType<a_type_id>;
+  using Cdtype = MarlinScalarType<c_type_id>;
+
+  using scalar_t = typename MarlinScalarType<a_type_id>::scalar_t;
+  using scalar_t2 = typename MarlinScalarType<a_type_id>::scalar_t2;
+  using scalar_32bit_t = typename MarlinScalarType<a_type_id>::scalar_32bit_t;
+
+  using c_scalar_t = typename MarlinScalarType<c_type_id>::scalar_t;
+  using c_scalar_t2 = typename MarlinScalarType<c_type_id>::scalar_t2;
+
+  using FragA = typename MarlinScalarType<a_type_id>::FragA;
+  using FragB = typename MarlinScalarType<a_type_id>::FragB;
+  using FragC = typename MarlinScalarType<a_type_id>::FragC;
+  using FragS = typename MarlinScalarType<c_type_id>::FragS;
+  using FragZP = typename MarlinScalarType<c_type_id>::FragZP;
+
+  extern __shared__ int4 sh[];
+  static constexpr auto a_type = vllm::ScalarType::from_id(a_type_id);
+  static constexpr auto b_type = vllm::ScalarType::from_id(b_type_id);
+  static constexpr auto c_type = vllm::ScalarType::from_id(c_type_id);
+  static constexpr auto s_type = vllm::ScalarType::from_id(s_type_id);
+  if constexpr (b_type == vllm::kFE2M1f) {
+    static_assert(s_type == vllm::kFE4M3fn && group_blocks == 1 ||
+                  s_type == vllm::kFE8M0fnu && group_blocks == 2);
+  } else if constexpr (b_type == vllm::kFE4M3fn && s_type == vllm::kFE8M0fnu) {
+    static_assert(group_blocks == 2);
+  } else if constexpr (std::is_same<scalar_t, nv_bfloat16>::value) {
+    static_assert(s_type == vllm::kBFloat16);
+  } else if constexpr (std::is_same<scalar_t, half>::value) {
+    static_assert(s_type == vllm::kFloat16);
+  }
+
+  constexpr bool is_a_8bit = a_type.size_bits() == 8;
+  if constexpr (!is_a_8bit) {
+    static_assert(std::is_same<scalar_t, c_scalar_t>::value);
+  }
+  constexpr bool has_zp = b_type == vllm::kU4 || b_type == vllm::kU8;
+  constexpr bool is_int_type = b_type == vllm::kU4 || b_type == vllm::kU8 ||
+                               b_type == vllm::kS4 || b_type == vllm::kS8 ||
+                               b_type == vllm::kU4B8 || b_type == vllm::kU8B128;
+  constexpr bool is_8bit_scale = s_type.size_bits() == 8;
+  // see comments of dequant.h for more details
+  constexpr bool dequant_skip_flop =
+      is_a_8bit || (b_type == vllm::kFE4M3fn && !(s_type == vllm::kFE8M0fnu)) ||
+      b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn ||
+      has_zp && !is_zp_float && !std::is_same<scalar_t, nv_bfloat16>::value ||
+      has_zp && !is_zp_float && !(b_type == vllm::kU8);
+
+  float global_scale_f32 = 1.0f;
+
+  constexpr bool has_act_order = group_blocks == 0;
+
+  constexpr int pack_factor = 32 / b_type.size_bits();
+  static_assert(thread_m_blocks == 1 || !m_block_size_8);
+  const int group_size =
+      (!has_act_order && group_blocks == -1) ? prob_k : prob_k / num_groups;
+  const int scales_expert_stride =
+      prob_n * prob_k / group_size / (is_8bit_scale ? 16 : 8);
+  const int zp_expert_stride =
+      is_zp_float ? prob_n * prob_k / group_size / 8
+                  : prob_n * prob_k / group_size / (pack_factor * 4);
+  const int b_bias_expert_stride = prob_n / 8;
+
+  // parallel: num valid moe blocks
+  int parallel = num_tokens_past_padded / moe_block_size;
+
+  int k_tiles = prob_k / 16 / thread_k_blocks;
+  int n_tiles = prob_n / 16 / thread_n_blocks;
+
+  int global_mn_tiles = parallel * n_tiles;
+  int part2_mn_tiles = global_mn_tiles;
+  int part1_mn_iters = 0;
+  bool in_part2 = false;
+
+  // we use DP + two-tile SK here
+  // part1: DP
+  // part2: two-tile SK
+  // see https://github.com/vllm-project/vllm/pull/24722 for more details
+  if (global_mn_tiles > gridDim.x) {
+    part2_mn_tiles = global_mn_tiles % gridDim.x;
+    if (part2_mn_tiles * 3 <= gridDim.x) part2_mn_tiles += gridDim.x;
+    part1_mn_iters = (global_mn_tiles - part2_mn_tiles) / gridDim.x;
+  }
+
+  int iters = div_ceil(k_tiles * part2_mn_tiles, gridDim.x);
+
+  if constexpr (!has_act_order && group_blocks != -1) {
+    if (group_blocks >= thread_k_blocks) {
+      // Ensure that the number of tiles in each stripe is a multiple of the
+      // groupsize; this avoids an annoying special case where a stripe starts
+      // in the middle of group.
+      iters = (group_blocks / thread_k_blocks) *
+              div_ceil(iters, (group_blocks / thread_k_blocks));
+    }
+  }
+
+  int slice_row = 0;
+  int slice_col_par = blockIdx.x;
+  int slice_col;
+  int slice_iters =
+      k_tiles;  // number of threadblock tiles in the current slice
+  // total number of active threadblocks in the current slice
+  int slice_count = 1;
+  // index of threadblock in current slice; numbered bottom to top
+  int slice_idx = 0;
+
+  int par_id = 0;
+  int block_id = -1;
+  int64_t expert_id = 0;  // use int64 to avoid computation result overflow
+  int old_expert_id = 0;
+  int64_t B_expert_off = 0;
+
+  float* sh_a_s = reinterpret_cast<float*>(sh);
+  int4* sh_block_sorted_ids_int4 = sh + (is_a_8bit ? (4 * thread_m_blocks) : 0);
+  int4* sh_rd_block_sorted_ids_int4 =
+      sh_block_sorted_ids_int4 + moe_block_size / 4;
+  int4* sh_block_topk_weights_int4 =
+      sh_rd_block_sorted_ids_int4 + moe_block_size / 4;
+  // sh_block_topk_weights_int4 only need (moe_block_size / 4);
+  // but we pad to align to 256 bytes
+  int4* sh_new = sh_block_topk_weights_int4 + moe_block_size / 2;
+  int32_t* sh_block_sorted_ids =
+      reinterpret_cast<int*>(sh_block_sorted_ids_int4);
+  int32_t* sh_rd_block_sorted_ids =
+      reinterpret_cast<int*>(sh_rd_block_sorted_ids_int4);
+  c_scalar_t2* sh_block_topk_weights =
+      reinterpret_cast<c_scalar_t2*>(sh_block_topk_weights_int4);
+
+  int32_t block_num_valid_tokens = 0;
+  int32_t locks_off = 0;
+
+  // We can easily implement parallel problem execution by just remapping
+  // indices and advancing global pointers
+  if (part2_mn_tiles >= gridDim.x) {
+    // when part2_mn_tiles >= sms
+    // then there are at most $sms$ conflict tile blocks
+    locks_off = blockIdx.x;
+  } else {
+    locks_off = (iters * blockIdx.x) / k_tiles - 1;
+  }
+
+  int prob_m_top_k = prob_m * top_k;
+  // read moe block data given block_id
+  // block_sorted_ids / block_num_valid_tokens / block_topk_weights
+  auto read_moe_block_data = [&](int block_id) {
+    block_num_valid_tokens = moe_block_size;
+
+    cp_async4_pred(sh_block_sorted_ids_int4 + threadIdx.x,
+                   reinterpret_cast<const int4*>(sorted_token_ids_ptr) +
+                       (block_id * moe_block_size / 4 + threadIdx.x),
+                   threadIdx.x < moe_block_size / 4);
+
+    cp_async_fence();
+    cp_async_wait<0>();
+
+    __syncthreads();
+
+    if (threadIdx.x >= threads - 32) {
+      constexpr int size_per_thread = div_ceil(moe_block_size, 32);
+      int lane_id = threadIdx.x - (threads - 32);
+
+      int local_count = 0;
+  #pragma unroll
+      for (int i = 0; i < size_per_thread; i++) {
+        int j = lane_id * size_per_thread + i;
+        if (j < moe_block_size) {
+          int idx = sh_block_sorted_ids[j];
+          if (idx < prob_m_top_k) local_count++;
+        }
+      }
+
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750
+
+      if constexpr (moe_block_size >= 16)
+        local_count += __shfl_down_sync(0xFFFFFFFF, local_count, 16);
+      if constexpr (moe_block_size >= 8)
+        local_count += __shfl_down_sync(0xFFFFFFFF, local_count, 8);
+      if constexpr (moe_block_size >= 4)
+        local_count += __shfl_down_sync(0xFFFFFFFF, local_count, 4);
+      if constexpr (moe_block_size >= 2)
+        local_count += __shfl_down_sync(0xFFFFFFFF, local_count, 2);
+
+      local_count += __shfl_down_sync(0xFFFFFFFF, local_count, 1);
+      block_num_valid_tokens = local_count;
+  #else
+      block_num_valid_tokens = __reduce_add_sync(0xffffffff, local_count);
+  #endif
+
+      if (lane_id == 0)
+        reinterpret_cast<int*>(sh_new)[0] = block_num_valid_tokens;
+    }
+
+    if (threadIdx.x < moe_block_size) {
+      int idx = sh_block_sorted_ids[threadIdx.x];
+      sh_rd_block_sorted_ids[threadIdx.x] = idx / top_k;
+
+      if (mul_topk_weights) {
+        idx = idx < prob_m_top_k ? idx : 0;
+        float topk_weight_tmp = topk_weights_ptr[idx];
+        if constexpr (b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn) {
+          topk_weight_tmp *= global_scale_f32;
+        }
+        c_scalar_t2 topk_weight_val =
+            Cdtype::num2num2(Cdtype::float2num(topk_weight_tmp));
+        sh_block_topk_weights[threadIdx.x] = topk_weight_val;
+      }
+    }
+
+    __syncthreads();
+
+    block_num_valid_tokens = reinterpret_cast<int*>(sh_new)[0];
+    __syncthreads();
+  };
+
+  // when move to next moe block, find the next block_id and expert_id
+  // and then read moe block data
+  auto update_next_moe_block_data = [&]() {
+    if (par_id >= parallel) return;
+
+    old_expert_id = expert_id;
+    block_id = par_id;
+    expert_id = expert_ids_ptr[block_id];
+
+    if constexpr (b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn) {
+      global_scale_f32 = global_scale_ptr[expert_id];
+    }
+
+    B_expert_off = expert_id * prob_n * prob_k / (pack_factor * 4);
+    scales_ptr += (expert_id - old_expert_id) * scales_expert_stride;
+    if constexpr (has_zp) {
+      zp_ptr += (expert_id - old_expert_id) * zp_expert_stride;
+    }
+    if constexpr (has_act_order) {
+      g_idx += (expert_id - old_expert_id) * prob_k;
+    }
+    if (has_bias) {
+      b_bias_ptr += (expert_id - old_expert_id) * b_bias_expert_stride;
+    }
+
+    read_moe_block_data(block_id);
+  };
+
+  // Compute all information about the current slice which is required for
+  // synchronization.
+  bool first_init = true;
+  auto init_part2_slice = [&]() {
+    slice_iters =
+        iters * (blockIdx.x + 1) - (k_tiles * slice_col_par + slice_row);
+    if (slice_iters < 0 || slice_col_par >= part2_mn_tiles) slice_iters = 0;
+    if (slice_iters == 0) return;
+    if (slice_row + slice_iters > k_tiles) slice_iters = k_tiles - slice_row;
+    slice_count = 1;
+    slice_idx = 0;
+    int col_first = iters * div_ceil(k_tiles * slice_col_par, iters);
+    if (col_first <= k_tiles * (slice_col_par + 1)) {
+      int col_off = col_first - k_tiles * slice_col_par;
+      slice_count = div_ceil(k_tiles - col_off, iters);
+      if (col_off > 0) slice_count++;
+      int delta_first = iters * blockIdx.x - col_first;
+      if (delta_first < 0 || (col_off == 0 && delta_first == 0))
+        slice_idx = slice_count - 1;
+      else {
+        slice_idx = slice_count - 1 - delta_first / iters;
+        if (col_off > 0) slice_idx--;
+      }
+    }
+    if (part2_mn_tiles >= gridDim.x) {
+      if (slice_count > 1 && slice_idx == slice_count - 1) {
+        locks_off++;
+      }
+    } else {
+      locks_off++;
+    }
+
+    if (first_init && use_atomic_add && slice_count > 1 && slice_idx == 0) {
+      constexpr int threads_per_m = 16 * thread_n_blocks / 8;
+      int m_per_thread =
+          div_ceil(block_num_valid_tokens, threads / threads_per_m);
+      for (int i = 0; i < m_per_thread; i++) {
+        int row = threads / threads_per_m * i + threadIdx.x / threads_per_m;
+        if (row < block_num_valid_tokens) {
+          int64_t sorted_row = sh_block_sorted_ids[row];
+          int col = slice_col * 16 * thread_n_blocks / 8 +
+                    threadIdx.x % threads_per_m;
+          C[sorted_row * prob_n / 8 + col] = {0, 0, 0, 0};
+        }
+      }
+      // After write zero to output, write a negative value to lock.
+      // Every SM that processes the same slice would wait for
+      // the negative value, and then atomicAdd 1 to it.
+      // After all SMs are processed, the lock value would back to 0 again.
+      __syncthreads();
+      if (threadIdx.x == 0) locks[locks_off] = 1 - slice_count;
+    }
+
+    if (slice_col == n_tiles) {
+      slice_col = 0;
+      par_id++;
+      update_next_moe_block_data();
+    }
+    if (is_a_8bit && (first_init || slice_col == 0)) {
+      __syncthreads();
+      cp_async1_ca_pred(&sh_a_s[threadIdx.x],
+                        &a_scales_ptr[sh_rd_block_sorted_ids[threadIdx.x]],
+                        threadIdx.x < block_num_valid_tokens);
+    }
+  };
+
+  auto init_part1_slice = [&]() {
+    if (part1_mn_iters) {
+      part1_mn_iters--;
+      par_id = slice_col_par / n_tiles;
+      slice_col = slice_col_par % n_tiles;
+      slice_iters = k_tiles;
+      update_next_moe_block_data();
+      if (is_a_8bit) {
+        __syncthreads();
+        cp_async1_ca_pred(&sh_a_s[threadIdx.x],
+                          &a_scales_ptr[sh_rd_block_sorted_ids[threadIdx.x]],
+                          threadIdx.x < block_num_valid_tokens);
+      }
+    }
+  };
+
+  auto init_slice = [&]() {
+    if (!in_part2 && !part1_mn_iters) {
+      in_part2 = true;
+      slice_col_par = (iters * blockIdx.x) / k_tiles;
+      slice_row = (iters * blockIdx.x) % k_tiles;
+      slice_col = (slice_col_par + global_mn_tiles - part2_mn_tiles) % n_tiles;
+      par_id = (slice_col_par + global_mn_tiles - part2_mn_tiles) / n_tiles;
+      update_next_moe_block_data();
+    }
+    if (!in_part2) {
+      init_part1_slice();
+    } else {
+      init_part2_slice();
+      first_init = false;
+    }
+  };
+
+  init_slice();
+
+  // A sizes/strides
+
+  // stride of the A matrix in global memory
+  int a_gl_stride = prob_k / (is_a_8bit ? 16 : 8);
+  // stride of an A matrix tile in shared memory
+  constexpr int a_sh_stride = 16 * thread_k_blocks / (is_a_8bit ? 16 : 8);
+  // delta between subsequent A tiles in global memory
+  constexpr int a_gl_rd_delta_o = 16 * thread_k_blocks / (is_a_8bit ? 16 : 8);
+  // between subsequent accesses within a tile
+  int a_gl_rd_delta_i = a_gl_stride * (threads / a_gl_rd_delta_o);
+  // between shared memory writes
+  constexpr int a_sh_wr_delta = a_sh_stride * (threads / a_gl_rd_delta_o);
+  // within a shared memory tile
+  constexpr int a_sh_rd_delta_i = a_sh_stride * 16;
+  // overall size of a tile
+  constexpr int a_sh_stage = a_sh_stride * (16 * thread_m_blocks);
+  // number of shared write iterations for a tile
+  constexpr int a_sh_wr_iters = div_ceil(a_sh_stage, a_sh_wr_delta);
+
+  // B sizes/strides
+  int b_gl_stride = 16 * prob_n / (pack_factor * (is_a_8bit ? 2 : 4));
+  constexpr int b_sh_stride =
+      ((thread_n_blocks * 16) * 16 / pack_factor) / (is_a_8bit ? 2 : 4);
+  constexpr int b_thread_vecs = b_type.size_bits() == 4 ? 1 : 2;
+  constexpr int b_sh_stride_threads = b_sh_stride / b_thread_vecs;
+
+  int b_gl_rd_delta_o = b_gl_stride * thread_k_blocks / (is_a_8bit ? 2 : 1);
+  constexpr int b_sh_wr_delta = threads * b_thread_vecs;
+  constexpr int b_sh_stage =
+      b_sh_stride * thread_k_blocks / (is_a_8bit ? 2 : 1);
+  constexpr int b_sh_wr_iters = b_sh_stage / b_sh_wr_delta;
+
+  // Scale sizes/strides without act_order
+  int s_gl_stride = prob_n / (is_8bit_scale ? 16 : 8);
+  constexpr int s_sh_stride = 16 * thread_n_blocks / (is_8bit_scale ? 16 : 8);
+  constexpr int s_tb_groups =
+      !has_act_order && group_blocks != -1 && group_blocks < thread_k_blocks
+          ? thread_k_blocks / group_blocks
+          : 1;
+  constexpr int s_sh_stage = s_tb_groups * s_sh_stride;
+  int s_gl_rd_delta = s_gl_stride;
+
+  // Scale size/strides with act_order
+  constexpr int tb_k = 16 * thread_k_blocks;
+  constexpr int g_idx_stage = has_act_order ? (tb_k * sizeof(int)) / 16 : 0;
+  // constexpr int act_s_row_stride      = 1;
+  // int           act_s_col_stride      = act_s_row_stride * num_groups;
+  constexpr int act_s_max_num_groups = 32;
+  int act_s_col_stride = 1;
+  int act_s_col_warp_stride = act_s_col_stride * 8;
+
+  constexpr int tb_n_warps = thread_n_blocks / (is_a_8bit ? 2 : 4);
+  int act_s_col_tb_stride = act_s_col_warp_stride * tb_n_warps;
+
+  // Zero-points sizes/strides
+  int zp_gl_stride = is_zp_float ? prob_n / 8 : (prob_n / pack_factor) / 4;
+  constexpr int zp_sh_stride = is_zp_float
+                                   ? 16 * thread_n_blocks / 8
+                                   : ((16 * thread_n_blocks) / pack_factor) / 4;
+  constexpr int zp_tb_groups = s_tb_groups;
+  constexpr int zp_sh_stage = has_zp ? zp_tb_groups * zp_sh_stride : 0;
+  int zp_gl_rd_delta = zp_gl_stride;
+
+  // Global A read index of current thread.
+  int a_gl_rd_row = threadIdx.x / a_gl_rd_delta_o;
+  int a_gl_rd_col = a_gl_rd_delta_o * slice_row + threadIdx.x % a_gl_rd_delta_o;
+  // Shared write index of current thread.
+  int a_sh_wr = a_sh_stride * (threadIdx.x / a_gl_rd_delta_o) +
+                (threadIdx.x % a_gl_rd_delta_o);
+  // Shared read index.
+  int a_sh_rd =
+      a_sh_stride * ((threadIdx.x % 32) % (16 / (m_block_size_8 ? 2 : 1))) +
+      (threadIdx.x % 32) / (16 / (m_block_size_8 ? 2 : 1));
+  a_sh_rd += 2 * ((threadIdx.x / 32) / tb_n_warps) * b_sh_wr_iters;
+
+  int b_gl_rd;
+  if (threads <= b_sh_stride) {
+    b_gl_rd = threadIdx.x;
+  } else {
+    b_gl_rd =
+        b_gl_stride * (threadIdx.x / b_sh_stride) + (threadIdx.x % b_sh_stride);
+  }
+
+  b_gl_rd += B_expert_off + b_sh_stride * slice_col;
+  b_gl_rd += b_gl_rd_delta_o * slice_row;
+  auto b_sh_rd = threadIdx.x * b_thread_vecs;
+  b_sh_rd += b_sh_rd / b_sh_stride * (b_sh_stride * (b_sh_wr_iters - 1));
+
+  // For act_order
+  int slice_k_start = tb_k * slice_row;
+  int slice_k_finish = slice_k_start + tb_k * slice_iters;
+  int slice_k_start_shared_fetch = slice_k_start;
+  int slice_n_offset = act_s_col_tb_stride * slice_col;
+
+  // No act_order
+  int s_gl_rd;
+  if constexpr (!has_act_order) {
+    if constexpr (group_blocks == -1) {
+      s_gl_rd = s_sh_stride * slice_col + threadIdx.x;
+    } else if constexpr (group_blocks >= thread_k_blocks) {
+      s_gl_rd = s_gl_stride * ((thread_k_blocks * slice_row) / group_blocks) +
+                s_sh_stride * slice_col + threadIdx.x;
+    } else {
+      s_gl_rd = s_gl_stride * ((thread_k_blocks * slice_row) / group_blocks +
+                               threadIdx.x / s_sh_stride) +
+                s_sh_stride * slice_col + threadIdx.x % s_sh_stride;
+    }
+  }
+  auto s_sh_wr = threadIdx.x;
+  bool s_sh_wr_pred = threadIdx.x < s_sh_stage;
+
+  // Zero-points
+  int zp_gl_rd;
+  if constexpr (has_zp) {
+    if constexpr (group_blocks == -1) {
+      zp_gl_rd = zp_sh_stride * slice_col + threadIdx.x;
+    } else if constexpr (group_blocks >= thread_k_blocks) {
+      zp_gl_rd = zp_gl_stride * ((thread_k_blocks * slice_row) / group_blocks) +
+                 zp_sh_stride * slice_col + threadIdx.x;
+    } else {
+      zp_gl_rd = zp_gl_stride * ((thread_k_blocks * slice_row) / group_blocks +
+                                 threadIdx.x / zp_sh_stride) +
+                 zp_sh_stride * slice_col + threadIdx.x % zp_sh_stride;
+    }
+  }
+  auto zp_sh_wr = threadIdx.x;
+  bool zp_sh_wr_pred = zp_sh_stage > 0 && threadIdx.x < zp_sh_stage;
+
+  // We use a different scale layout for grouped and column-wise quantization as
+  // we scale a `half2` tile in column-major layout in the former and in
+  // row-major in the latter case.
+  int s_sh_rd;
+  if constexpr (is_a_8bit) {
+    s_sh_rd = 4 * ((threadIdx.x / 32) % tb_n_warps) + (threadIdx.x % 4);
+  } else if constexpr (group_blocks != -1)
+    s_sh_rd = 8 * ((threadIdx.x / 32) % tb_n_warps) + (threadIdx.x % 32) / 4;
+  else if constexpr (group_blocks == -1 &&
+                     (m_block_size_8 || (has_zp && !dequant_skip_flop)))
+    s_sh_rd = 8 * ((threadIdx.x / 32) % tb_n_warps) + (threadIdx.x % 32) / 8;
+  else
+    s_sh_rd = 8 * ((threadIdx.x / 32) % tb_n_warps) + (threadIdx.x % 32) % 4;
+
+  int bias_sh_rd;
+  if constexpr (m_block_size_8) {
+    bias_sh_rd = 8 * ((threadIdx.x / 32) % tb_n_warps) + (threadIdx.x % 32) / 8;
+  } else {
+    bias_sh_rd = (is_a_8bit ? 4 : 8) * ((threadIdx.x / 32) % tb_n_warps) +
+                 (threadIdx.x % 32) % 4;
+  }
+
+  int bias_sh_wr = threadIdx.x;
+  int bias_gl_rd = (thread_n_blocks * 16 / 8) * slice_col + threadIdx.x;
+
+  // Zero-points have the same read layout as the scales
+  // (without column-wise case)
+  constexpr int num_col_threads = 8;
+  constexpr int num_row_threads = 4;
+  constexpr int num_ints_per_thread = 8 / pack_factor;
+  int zp_sh_rd;
+  if constexpr (has_zp) {
+    if constexpr (is_zp_float) {
+      if constexpr (group_blocks != -1) {
+        zp_sh_rd =
+            8 * ((threadIdx.x / 32) % tb_n_warps) + (threadIdx.x % 32) / 4;
+      }
+    } else if (is_a_8bit) {
+      zp_sh_rd = num_ints_per_thread * num_col_threads *
+                     ((threadIdx.x / 32) % tb_n_warps / 2) +
+                 num_ints_per_thread * ((threadIdx.x % 32) / num_row_threads);
+    } else {
+      zp_sh_rd = num_ints_per_thread * num_col_threads *
+                     ((threadIdx.x / 32) % tb_n_warps) +
+                 num_ints_per_thread * ((threadIdx.x % 32) / num_row_threads);
+    }
+  }
+
+  // To ensure that writing and reading A tiles to/from shared memory, the
+  // latter in fragment format, is fully bank conflict free, we need to use a
+  // rather fancy XOR-based layout. The key here is that neither reads nor
+  // writes of the 16-byte `int4` blocks of 8 consecutive threads involve the
+  // same shared memory banks. Further, it seems (based on NSight-Compute) that
+  // each warp must also write a consecutive memory segment?
+  auto transform_a = [&](int i) {
+    int row = i / a_gl_rd_delta_o;
+    return a_gl_rd_delta_o * row + (i % a_gl_rd_delta_o) ^ (row % 8);
+  };
+  // Since the computation of this remapping is non-trivial and, due to our main
+  // loop unrolls, all shared memory accesses are static, we simply precompute
+  // both transformed reads and writes.
+  int a_sh_wr_trans[a_sh_wr_iters];
+  #pragma unroll
+  for (int i = 0; i < a_sh_wr_iters; i++)
+    a_sh_wr_trans[i] = transform_a(a_sh_wr_delta * i + a_sh_wr);
+  int a_sh_rd_trans[b_sh_wr_iters][thread_m_blocks];
+  #pragma unroll
+  for (int i = 0; i < b_sh_wr_iters; i++) {
+  #pragma unroll
+    for (int j = 0; j < thread_m_blocks; j++)
+      a_sh_rd_trans[i][j] = transform_a(2 * i + a_sh_rd_delta_i * j + a_sh_rd);
+  }
+
+  // Since B-accesses have non-constant stride they have to be computed at
+  // runtime; we break dependencies between subsequent accesses with a tile by
+  // maintining multiple pointers (we have enough registers), a tiny
+  // optimization.
+
+  // Shared memory storage for global fetch pipelines.
+  constexpr int sh_red_size = (2 * thread_n_blocks + 1) * 16 * thread_m_blocks;
+  constexpr int sh_b_size = stages * b_sh_stage;
+  int4* sh_b = sh_new;
+  int4* sh_red = sh_new;
+
+  constexpr int sh_size_b_red_min =
+      (sh_red_size < sh_b_size ? sh_red_size : sh_b_size);
+  constexpr int sh_size_b_red_max =
+      (sh_red_size > sh_b_size ? sh_red_size : sh_b_size);
+  constexpr int sh_bias_size = (thread_n_blocks * 16 / 8);
+  constexpr int sh_b_red_bias_size =
+      sh_size_b_red_max > (sh_size_b_red_min + sh_bias_size)
+          ? sh_size_b_red_max
+          : (sh_size_b_red_min + sh_bias_size);
+
+  int4* sh_bias = sh_new + sh_size_b_red_min;
+  int4* sh_g_idx = sh_new + sh_b_red_bias_size;
+  int4* sh_zp = sh_g_idx + (stages * g_idx_stage);
+  constexpr int sh_s_size = has_act_order ? (act_s_max_num_groups * s_sh_stride)
+                                          : (stages * s_sh_stage);
+  int4* sh_s = sh_zp + (stages * zp_sh_stage);
+  int4* sh_a = sh_s + sh_s_size;
+
+  // Register storage for double buffer of shared memory reads.
+  FragA frag_a[2][thread_m_blocks];
+  I4 frag_b_quant[2][b_thread_vecs];
+  FragC frag_c[thread_m_blocks][is_a_8bit ? 2 : 4][2];
+  FragC frag_c_tmp[thread_m_blocks][is_a_8bit ? 2 : 4][2];
+  FragS frag_s[2][4];  // No act-order
+  FragS frag_bias[2][4];
+  FragS act_frag_s[2][4][4];             // For act-order
+  int frag_qzp[2][num_ints_per_thread];  // Zero-points
+  FragZP frag_zp;                        // Zero-points in fp16
+  FragZP frag_zpf[2];                    // Zero-points in fp16 in HQQ
+
+  if constexpr (is_a_8bit && group_blocks != -1) {
+  #pragma unroll
+    for (int j = 0; j < 2; j++) {
+  #pragma unroll
+      for (int i = 0; i < thread_m_blocks; i++) {
+  #pragma unroll
+        for (int g = 0; g < 4; g++) {
+          frag_c_tmp[i][j][0][g] = 0.0f;
+        }
+
+  #pragma unroll
+        for (int g = 0; g < 4; g++) {
+          frag_c_tmp[i][j][1][g] = 0.0f;
+        }
+      }
+    }
+  }
+
+  // Zero accumulators.
+  auto zero_accums = [&]() {
+  #pragma unroll
+    for (int i = 0; i < thread_m_blocks * 4 * 2 * 4; i++)
+      reinterpret_cast<float*>(frag_c)[i] = 0;
+  };
+
+  int sh_first_group_id = -1;
+  int sh_num_groups = -1;
+
+  auto fetch_act_order_scales_to_shared = [&](bool is_async, int first_group_id,
+                                              int last_group_id) {
+    sh_first_group_id = first_group_id;
+    sh_num_groups = last_group_id - first_group_id + 1;
+
+    if (sh_num_groups > act_s_max_num_groups) {
+      sh_num_groups = act_s_max_num_groups;
+    }
+
+    if (sh_first_group_id + sh_num_groups > num_groups) {
+      sh_num_groups = num_groups - sh_first_group_id;
+    }
+
+    int row_offset = first_group_id * s_gl_stride;
+
+    if (is_async) {
+      for (int i = 0; i < sh_num_groups; i++) {
+        if (threadIdx.x < s_sh_stride) {
+          cp_async4_pred(&sh_s[(i * s_sh_stride) + threadIdx.x],
+                         &scales_ptr[row_offset + (i * s_gl_stride) +
+                                     slice_n_offset + threadIdx.x]);
+        }
+      }
+    } else {
+      for (int i = 0; i < sh_num_groups; i++) {
+        if (threadIdx.x < s_sh_stride) {
+          sh_s[(i * s_sh_stride) + threadIdx.x] =
+              scales_ptr[row_offset + (i * s_gl_stride) + slice_n_offset +
+                         threadIdx.x];
+        }
+      }
+    }
+  };
+  // Asynchronously fetch the next A, B and s tile from global to the next
+  // shared memory pipeline location.
+  auto fetch_to_shared = [&](int pipe, int a_off, bool pred = true) {
+    if (pred) {
+      int4* sh_a_stage = sh_a + moe_block_size * a_sh_stride * pipe;
+  #pragma unroll
+      for (int i = 0; i < a_sh_wr_iters; i++) {
+        int row = a_gl_rd_delta_i / a_gl_stride * i + a_gl_rd_row;
+        int64_t sorted_row = 0;
+        if (!m_block_size_8 || row < 8)
+          sorted_row = sh_rd_block_sorted_ids[row];
+        int64_t true_idx =
+            sorted_row * a_gl_stride + a_gl_rd_col + a_gl_rd_delta_o * a_off;
+        cp_async4_pred(&sh_a_stage[a_sh_wr_trans[i]], &A[true_idx],
+                       row < block_num_valid_tokens);
+      }
+
+      int4* sh_b_stage = sh_b + b_sh_stage * pipe;
+  #pragma unroll
+      for (int i = 0; i < (b_sh_wr_iters * b_thread_vecs); i++) {
+        constexpr int count = div_ceil(b_sh_stride, threads);
+        int b_gl_idx =
+            b_gl_rd + (i % count) * threads +
+            b_gl_stride * (i / count) * div_ceil(threads, b_sh_stride);
+
+        cp_async4(&sh_b_stage[threads * i + threadIdx.x], &B[b_gl_idx]);
+      }
+
+      b_gl_rd += b_gl_rd_delta_o;
+
+      if constexpr (has_act_order) {
+        // Fetch g_idx thread-block portion
+        int full_pipe = a_off;
+        int cur_k = slice_k_start_shared_fetch + tb_k * full_pipe;
+        if (cur_k < prob_k && cur_k < slice_k_finish) {
+          int4* sh_g_idx_stage = sh_g_idx + g_idx_stage * pipe;
+
+          int4 const* cur_g_idx_stage_ptr =
+              reinterpret_cast<int4 const*>(&g_idx[cur_k]);
+
+          if (threadIdx.x < g_idx_stage) {
+            cp_async4_pred(&sh_g_idx_stage[threadIdx.x],
+                           &cur_g_idx_stage_ptr[threadIdx.x]);
+          }
+        }
+      } else {
+        if constexpr (group_blocks != -1) {
+          int4* sh_s_stage = sh_s + s_sh_stage * pipe;
+
+          // Only fetch scales if this tile starts a new group
+          if (pipe % div_ceil(group_blocks, thread_k_blocks) == 0) {
+            if (s_sh_wr_pred) {
+              cp_async4(&sh_s_stage[s_sh_wr], &scales_ptr[s_gl_rd]);
+            }
+            s_gl_rd += s_gl_rd_delta * s_tb_groups;
+          }
+        }
+
+        if constexpr (has_zp && group_blocks != -1) {
+          int4* sh_zp_stage = sh_zp + zp_sh_stage * pipe;
+
+          // Only fetch zero points if this tile starts a new group
+          if (pipe % div_ceil(group_blocks, thread_k_blocks) == 0) {
+            if (zp_sh_wr_pred) {
+              cp_async4(&sh_zp_stage[zp_sh_wr], &zp_ptr[zp_gl_rd]);
+            }
+            zp_gl_rd += zp_gl_rd_delta * zp_tb_groups;
+          }
+        }
+      }
+    }
+    // Insert a fence even when we are winding down the pipeline to ensure that
+    // waiting is also correct at this point.
+    cp_async_fence();
+  };
+
+  auto fetch_col_zp_to_shared = [&]() {
+    if (zp_sh_wr_pred) {
+      cp_async4(&sh_zp[zp_sh_wr], &zp_ptr[zp_gl_rd]);
+    }
+  };
+
+  auto fetch_col_scale_to_shared = [&]() {
+    if (s_sh_wr_pred) {
+      cp_async4(&sh_s[s_sh_wr], &scales_ptr[s_gl_rd]);
+    }
+  };
+
+  // Wait until the next thread tile has been loaded to shared memory.
+  auto wait_for_stage = [&]() {
+    // We only have `stages - 2` active fetches since we are double buffering
+    // and can only issue the next fetch when it is guaranteed that the previous
+    // shared memory load is fully complete (as it may otherwise be
+    // overwritten).
+    cp_async_wait<stages - 2>();
+    __syncthreads();
+  };
+
+  // Load the next sub-tile from the current location in the shared memory pipe
+  // into the current register buffer.
+  auto fetch_to_registers = [&](int k, int pipe) {
+    int4* sh_a_stage = sh_a + moe_block_size * a_sh_stride * pipe;
+  #pragma unroll
+    for (int i = 0; i < thread_m_blocks; i++)
+      ldsm<m_block_size_8 ? 2 : 4, a_type_id>(
+          frag_a[k % 2][i], &sh_a_stage[a_sh_rd_trans[k % b_sh_wr_iters][i]]);
+    int4* sh_b_stage = sh_b + b_sh_stage * pipe;
+
+  #pragma unroll
+    for (int i = 0; i < b_thread_vecs; i++) {
+      frag_b_quant[k % 2][i] = *reinterpret_cast<I4*>(
+          &sh_b_stage[b_sh_stride * (k % b_sh_wr_iters) + b_sh_rd + i]);
+    }
+  };
+
+  bool is_same_group[stages];
+  int same_group_id[stages];
+
+  auto init_same_group = [&](int pipe) {
+    if constexpr (!has_act_order) {
+      return;
+    }
+
+    int4* sh_g_idx_stage = sh_g_idx + g_idx_stage * pipe;
+    int* sh_g_idx_int_ptr = reinterpret_cast<int*>(sh_g_idx_stage);
+
+    int group_id_1 = sh_g_idx_int_ptr[0];
+    int group_id_2 = sh_g_idx_int_ptr[tb_k - 1];
+
+    is_same_group[pipe] = group_id_1 == group_id_2;
+    same_group_id[pipe] = group_id_1;
+  };
+
+  auto fetch_scales_to_registers = [&](int k, int full_pipe) {
+    int pipe = full_pipe % stages;
+    using IT1 = typename std::conditional_t<is_a_8bit, int2, int4>;
+    using IT0 = typename std::conditional_t<is_a_8bit, int, int2>;
+    constexpr int group_blocks2 = div_ceil(group_blocks, is_a_8bit ? 2 : 1);
+
+    if constexpr (!has_act_order) {
+      // No act-order case
+      if constexpr (group_blocks == -1) {
+        // load only when starting a new slice
+        if (k == 0 && full_pipe == 0 && dequant_skip_flop) {
+          reinterpret_cast<int4*>(&frag_s)[0] = sh_s[s_sh_rd];
+          reinterpret_cast<int4*>(&frag_s)[1] = sh_s[s_sh_rd + 4];
+        }
+      } else if constexpr (group_blocks != -1) {
+        if constexpr (group_blocks >= thread_k_blocks) {
+          constexpr int g = group_blocks / thread_k_blocks;
+          if (pipe % g == 0) {
+            if (k % b_sh_wr_iters == 0) {
+              int4* sh_s_stage = sh_s + s_sh_stage * (g * (pipe / g));
+              reinterpret_cast<int4*>(&frag_s[k % 2])[0] = sh_s_stage[s_sh_rd];
+            } else {
+              reinterpret_cast<int4*>(&frag_s[1])[0] =
+                  reinterpret_cast<int4*>(&frag_s[0])[0];
+            }
+          }
+        } else if (group_blocks2 < b_sh_wr_iters || k % b_sh_wr_iters == 0) {
+          auto warp_id = threadIdx.x / 32;
+          int warp_row = warp_id / tb_n_warps;
+
+          int k_blocks = b_sh_wr_iters * warp_row + k % b_sh_wr_iters;
+          int cur_group_id = k_blocks / group_blocks2;
+
+          int4* sh_s_stage = sh_s + s_sh_stage * pipe;
+
+          if constexpr (!is_8bit_scale) {
+            reinterpret_cast<int4*>(&frag_s[k % 2])[0] =
+                sh_s_stage[s_sh_rd + cur_group_id * s_sh_stride];
+          } else {
+            reinterpret_cast<int2*>(&frag_s[k % 2])[0] =
+                reinterpret_cast<int2*>(
+                    sh_s_stage)[s_sh_rd + cur_group_id * (2 * s_sh_stride)];
+          }
+        } else if (group_blocks >= b_sh_wr_iters) {
+          if constexpr (!is_8bit_scale) {
+            reinterpret_cast<int4*>(&frag_s[1])[0] =
+                reinterpret_cast<int4*>(&frag_s[0])[0];
+          } else {
+            reinterpret_cast<int2*>(&frag_s[1])[0] =
+                reinterpret_cast<int2*>(&frag_s[0])[0];
+          }
+        }
+      }
+
+      return;
+    }
+
+    // Act-order case
+
+    // Determine K of the "current" thread-block
+    int cur_k = slice_k_start + tb_k * full_pipe;
+    if (cur_k >= prob_k || cur_k >= slice_k_finish) {
+      return;
+    }
+
+    // Reset (to current thread-block) since we read g_idx portion from the
+    // shared memory
+    cur_k = 0;
+
+    // Progress to current iteration
+    cur_k += k % b_sh_wr_iters;
+
+    // Determine "position" inside the thread-block (based on warp and
+    // thread-id)
+    auto warp_id = threadIdx.x / 32;
+    int warp_row = warp_id / tb_n_warps;
+    int warp_col = warp_id % tb_n_warps;
+
+    cur_k += warp_row * 16 * b_sh_wr_iters;
+
+    auto th_id = threadIdx.x % 32;
+    cur_k += (th_id % 4) * 2;  // Due to tensor-core layout for fp16 B matrix
+
+    int s_col_shift =
+        /*slice_n_offset +*/ (act_s_col_warp_stride * warp_col) +
+        (th_id / 4) * act_s_col_stride;
+
+    if (is_same_group[pipe]) {
+      if (k % 2 == 0) {
+        *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][0][0]))) =
+            sh_s[(same_group_id[pipe] - sh_first_group_id) * s_sh_stride +
+                 s_col_shift];
+      } else {
+        *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][0][0]))) =
+            *(reinterpret_cast<int4*>(&(act_frag_s[(k - 1) % 2][0][0])));
+      }
+
+      for (int i = 1; i < 4; i++) {
+        *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][i][0]))) =
+            *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][0][0])));
+      }
+      return;
+    }
+
+    int4* sh_g_idx_stage = sh_g_idx + g_idx_stage * pipe;
+    int* sh_g_idx_int_ptr = reinterpret_cast<int*>(sh_g_idx_stage);
+
+    constexpr int k_frag_offsets[4] = {0, 1, 8,
+                                       9};  // Tensor core offsets per thread
+
+  #pragma unroll
+    for (int i = 0; i < 4; i++) {
+      int actual_k = cur_k + k_frag_offsets[i];
+
+      int group_id = sh_g_idx_int_ptr[actual_k];
+      int rel_group_id = group_id - sh_first_group_id;
+
+      *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][i][0]))) =
+          sh_s[rel_group_id * s_sh_stride + s_col_shift];
+    }
+  };
+
+  auto fetch_zp_to_registers = [&](int k, int full_pipe) {
+    // This code does not handle group_blocks == 0,
+    // which signifies act_order.
+    // has_zp implies AWQ, which doesn't have act_order,
+    static_assert(!has_zp || group_blocks != 0);
+
+    if constexpr (has_zp && !is_zp_float) {
+      int pipe = full_pipe % stages;
+
+      if constexpr (group_blocks == -1) {
+        // load only when starting a new slice
+        if (k == 0 && full_pipe == 0 || is_a_8bit) {
+  #pragma unroll
+          for (int i = 0; i < num_ints_per_thread; i++) {
+            frag_qzp[k % 2][i] = (reinterpret_cast<int*>(sh_zp))[zp_sh_rd + i];
+          }
+        }
+      } else if constexpr (group_blocks >= thread_k_blocks) {
+        constexpr int g = group_blocks / thread_k_blocks;
+        if (pipe % g == 0 && k % b_sh_wr_iters == 0 || is_a_8bit) {
+          int4* sh_zp_stage = sh_zp + zp_sh_stage * (g * (pipe / g));
+  #pragma unroll
+          for (int i = 0; i < num_ints_per_thread; i++) {
+            frag_qzp[k % 2][i] =
+                (reinterpret_cast<int*>(sh_zp_stage))[zp_sh_rd + i];
+          }
+        }
+      } else {
+        auto warp_id = threadIdx.x / 32;
+
+        int warp_row = warp_id / tb_n_warps;
+
+        int k_blocks = b_sh_wr_iters * warp_row + k % b_sh_wr_iters;
+        int cur_group_id = k_blocks / div_ceil(group_blocks, is_a_8bit ? 2 : 1);
+
+        int4* sh_zp_stage = sh_zp + zp_sh_stage * pipe;
+
+        sh_zp_stage += cur_group_id * zp_sh_stride;
+
+  #pragma unroll
+        for (int i = 0; i < num_ints_per_thread; i++) {
+          frag_qzp[k % 2][i] =
+              (reinterpret_cast<int*>(sh_zp_stage))[zp_sh_rd + i];
+        }
+      }
+    }
+
+    else if constexpr (has_zp && is_zp_float) {
+      int pipe = full_pipe % stages;
+
+      if constexpr (group_blocks != -1) {
+        if constexpr (group_blocks >= thread_k_blocks) {
+          constexpr int g = group_blocks / thread_k_blocks;
+          if (pipe % g == 0 && k % b_sh_wr_iters == 0) {
+            int4* sh_zp_stage = sh_zp + zp_sh_stage * (g * (pipe / g));
+            reinterpret_cast<int4*>(&frag_zpf[k % 2])[0] =
+                sh_zp_stage[zp_sh_rd];
+          }
+        } else if (group_blocks < b_sh_wr_iters || k % b_sh_wr_iters == 0) {
+          auto warp_id = threadIdx.x / 32;
+
+          int warp_row = warp_id / tb_n_warps;
+          int k_blocks = b_sh_wr_iters * warp_row + k % b_sh_wr_iters;
+          int cur_group_id = k_blocks / group_blocks;
+
+          int4* sh_zp_stage = sh_zp + zp_sh_stage * pipe;
+
+          reinterpret_cast<int4*>(&frag_zpf[k % 2])[0] =
+              sh_zp_stage[zp_sh_rd + cur_group_id * zp_sh_stride];
+        }
+      }
+    }
+  };
+
+  auto dequant_data = [&](int q, scalar_32bit_t* frag_b_ptr, int zp = 0) {
+    if constexpr (a_type.size_bits() != b_type.size_bits()) {
+      if constexpr (is_a_8bit && has_zp) {
+        sub_zp_and_dequant<scalar_32bit_t, b_type_id, dequant_skip_flop>(
+            q, frag_b_ptr, zp);
+      } else {
+        dequant<scalar_32bit_t, b_type_id, dequant_skip_flop>(q, frag_b_ptr);
+      }
+    }
+  };
+
+  // Execute the actual tensor core matmul of a sub-tile.
+  bool is_first_matmul_in_slice = true;
+  auto matmul = [&](int k, int pipe) {
+    if (is_a_8bit) return;
+    int k2 = k % 2;
+    constexpr int g =
+        group_blocks > 0 ? div_ceil(group_blocks, thread_k_blocks) : 1;
+    const bool is_new_zp =
+        (group_blocks == 0) ||
+        ((group_blocks > 0) && (group_blocks < b_sh_wr_iters || k == 0)) &&
+            (pipe % g == 0) ||
+        (group_blocks == -1 && is_first_matmul_in_slice);
+    if constexpr (has_zp && !is_zp_float) {
+      if (is_new_zp) {
+        if constexpr (group_blocks == -1) is_first_matmul_in_slice = false;
+        int zp_quant_0, zp_quant_1;
+
+        if constexpr (b_type.size_bits() == 4) {
+          zp_quant_0 = frag_qzp[k2][0];
+          zp_quant_1 = zp_quant_0 >> 8;
+        } else {
+          static_assert(b_type.size_bits() == 8);
+          zp_quant_0 = frag_qzp[k2][0];
+          zp_quant_1 = frag_qzp[k2][1];
+        }
+
+        dequant_data(zp_quant_0, reinterpret_cast<scalar_32bit_t*>(&frag_zp));
+        dequant_data(zp_quant_1,
+                     reinterpret_cast<scalar_32bit_t*>(&frag_zp) + 2);
+      }
+    }
+    if constexpr (!dequant_skip_flop && has_zp && is_zp_float) {
+      if (is_new_zp) {
+        reinterpret_cast<int4*>(&frag_zp)[0] =
+            reinterpret_cast<int4*>(&frag_zpf[k2])[0];
+      }
+    }
+
+    if constexpr (s_type == vllm::kFE4M3fn || s_type == vllm::kFE8M0fnu) {
+      int s_quant_0 = reinterpret_cast<int*>(frag_s[k2])[0];
+      int s_quant_1 = reinterpret_cast<int*>(frag_s[k2])[1];
+
+      dequant_fp8_scales<c_scalar_t2, s_type_id>(
+          s_quant_0, reinterpret_cast<c_scalar_t2*>(&frag_s[k2]));
+      dequant_fp8_scales<c_scalar_t2, s_type_id>(
+          s_quant_1, reinterpret_cast<c_scalar_t2*>(&frag_s[k2]) + 2);
+    }
+
+  // We have the m dimension as the inner loop in order to encourage overlapping
+  // dequantization and matmul operations.
+  #pragma unroll
+    for (int j = 0; j < 4; j++) {
+      FragB frag_b0;
+      FragB frag_b1;
+      int b_quant_0, b_quant_1;
+
+      if constexpr (b_type_id == vllm::kFE2M1f.id()) {
+        b_quant_1 = frag_b_quant[k2][0][j];
+        b_quant_0 = b_quant_1 << 8;
+      } else if constexpr (b_type.size_bits() == 4) {
+        b_quant_0 = frag_b_quant[k2][0][j];
+        b_quant_1 = b_quant_0 >> 8;
+      } else {
+        static_assert(b_type.size_bits() == 8);
+        int* frag_b_quant_ptr = reinterpret_cast<int*>(frag_b_quant[k2]);
+        b_quant_0 = frag_b_quant_ptr[j * 2 + 0];
+        b_quant_1 = frag_b_quant_ptr[j * 2 + 1];
+      }
+
+      dequant_data(b_quant_0, reinterpret_cast<scalar_32bit_t*>(&frag_b0));
+      dequant_data(b_quant_1, reinterpret_cast<scalar_32bit_t*>(&frag_b1));
+
+      if constexpr (dequant_skip_flop && has_zp && !is_zp_float && !is_a_8bit) {
+        sub_zp<a_type_id>(frag_b0, frag_zp[j], 0);
+        sub_zp<a_type_id>(frag_b1, frag_zp[j], 1);
+      }
+
+      // Apply scale to frag_b0
+      if constexpr (has_act_order && !is_a_8bit) {
+        static_assert(group_blocks != -1);
+        scale4<a_type_id>(frag_b0, act_frag_s[k2][0][j], act_frag_s[k2][1][j],
+                          act_frag_s[k2][2][j], act_frag_s[k2][3][j], 0);
+        scale4<a_type_id>(frag_b1, act_frag_s[k2][0][j], act_frag_s[k2][1][j],
+                          act_frag_s[k2][2][j], act_frag_s[k2][3][j], 1);
+      } else if constexpr (!dequant_skip_flop && has_zp && !is_zp_float &&
+                           group_blocks == -1 && !is_a_8bit) {
+        int idx = (threadIdx.x / 4) % 2;
+        scalar_t2 s2 = Adtype::nums2num2(
+            reinterpret_cast<scalar_t*>(&frag_s[j / 2][j % 2 * 2 + 0])[idx],
+            reinterpret_cast<scalar_t*>(&frag_s[j / 2][j % 2 * 2 + 1])[idx]);
+        if (is_new_zp) frag_zp[j] = __hmul2(frag_zp[j], s2);
+        scale_and_sub<a_type_id>(frag_b0, s2.x, frag_zp[j].x);
+        scale_and_sub<a_type_id>(frag_b1, s2.y, frag_zp[j].y);
+      } else if constexpr (!dequant_skip_flop && has_zp && group_blocks != -1 &&
+                           !is_a_8bit) {
+        if (is_new_zp)
+          frag_zp[j] = __hmul2(frag_zp[j],
+                               *reinterpret_cast<scalar_t2*>(&frag_s[k2][j]));
+        scale_and_sub<a_type_id>(frag_b0, frag_s[k2][j][0].x, frag_zp[j].x);
+        scale_and_sub<a_type_id>(frag_b1, frag_s[k2][j][0].y, frag_zp[j].y);
+      } else if constexpr (group_blocks != -1 && !is_a_8bit) {
+        scale<a_type_id>(frag_b0, frag_s[k2][j], 0);
+        scale<a_type_id>(frag_b1, frag_s[k2][j], 1);
+      }
+
+  #pragma unroll
+      for (int i = 0; i < thread_m_blocks; i++) {
+        if constexpr (m_block_size_8) {
+          mma_trans<a_type_id, use_fp16_accum>(frag_a[k2][i], frag_b0, frag_b1,
+                                               frag_c[i][j][0]);
+        } else {
+          mma<a_type_id, use_fp16_accum>(frag_a[k2][i], frag_b0,
+                                         frag_c[i][j][0]);
+          mma<a_type_id, use_fp16_accum>(frag_a[k2][i], frag_b1,
+                                         frag_c[i][j][1]);
+        }
+      }
+    }
+  };
+
+  auto matmul_a8 = [&](int k) {
+    int k2 = k % 2;
+  #pragma unroll
+    for (int j = 0; j < 2; j++) {
+      FragB frag_b[2];
+
+      if (is_a_8bit && b_type.size_bits() == 4 && !has_zp) {
+        dequant_data(frag_b_quant[k2][0][j * 2],
+                     reinterpret_cast<scalar_32bit_t*>(&frag_b));
+        dequant_data(frag_b_quant[k2][0][j * 2 + 1],
+                     reinterpret_cast<scalar_32bit_t*>(&frag_b) + 2);
+      } else if (is_a_8bit && b_type.size_bits() == 4 && has_zp) {
+        int off = (threadIdx.x / 32) % 2 * 2 + j;
+        int zp = (frag_qzp[k2][0] >> (off * 8)) & 0xF;
+        dequant_data(frag_b_quant[k2][0][j * 2],
+                     reinterpret_cast<scalar_32bit_t*>(&frag_b), zp);
+        zp = (frag_qzp[k2][0] >> (off * 8 + 4)) & 0xF;
+        dequant_data(frag_b_quant[k2][0][j * 2 + 1],
+                     reinterpret_cast<scalar_32bit_t*>(&frag_b) + 2, zp);
+      } else {
+        reinterpret_cast<int2*>(&frag_b)[0] =
+            reinterpret_cast<int2*>(&frag_b_quant[k2][j])[0];
+        reinterpret_cast<int2*>(&frag_b)[1] =
+            reinterpret_cast<int2*>(&frag_b_quant[k2][j])[1];
+      }
+
+  #pragma unroll
+      for (int i = 0; i < thread_m_blocks; i++) {
+        mma<a_type_id, false, 32>(
+            frag_a[k2][i], frag_b[0],
+            (group_blocks == -1 ? frag_c : frag_c_tmp)[i][j][0]);
+        mma<a_type_id, false, 32>(
+            frag_a[k2][i], frag_b[1],
+            (group_blocks == -1 ? frag_c : frag_c_tmp)[i][j][1]);
+      }
+
+      if constexpr (group_blocks != -1) {
+        if (group_blocks == 2 || k == 1) {
+          if constexpr (a_type == vllm::kS8) {
+            int2 s_vals[2];
+            s_vals[0] = {
+                (int)reinterpret_cast<uint16_t*>(&frag_s[k2][j * 2][0])[0],
+                (int)reinterpret_cast<uint16_t*>(&frag_s[k2][j * 2][0])[1]};
+            s_vals[1] = {
+                (int)reinterpret_cast<uint16_t*>(&frag_s[k2][j * 2 + 1][0])[0],
+                (int)reinterpret_cast<uint16_t*>(&frag_s[k2][j * 2 + 1][0])[1]};
+
+  #pragma unroll
+            for (int i = 0; i < thread_m_blocks; i++) {
+  #pragma unroll
+              for (int g = 0; g < 4; g++) {
+                int scale = reinterpret_cast<int*>(&s_vals[0])[g % 2];
+                *reinterpret_cast<int32_t*>(&frag_c[i][j][0][g]) +=
+                    *reinterpret_cast<int32_t*>(&frag_c_tmp[i][j][0][g]) *
+                    scale;
+                frag_c_tmp[i][j][0][g] = 0.0f;
+              }
+
+  #pragma unroll
+              for (int g = 0; g < 4; g++) {
+                int scale = reinterpret_cast<int*>(&s_vals[1])[g % 2];
+                *reinterpret_cast<int32_t*>(&frag_c[i][j][1][g]) +=
+                    *reinterpret_cast<int32_t*>(&frag_c_tmp[i][j][1][g]) *
+                    scale;
+                frag_c_tmp[i][j][1][g] = 0.0f;
+              }
+            }
+          } else {
+            float2 s_vals[2];
+            if constexpr (s_type_id != vllm::kFE8M0fnu.id()) {
+              static_assert(a_type.size_bits() == 16 ||
+                            s_type.size_bits() == 16);
+              s_vals[0] = Cdtype::num22float2(frag_s[k2][j * 2][0]);
+              s_vals[1] = Cdtype::num22float2(frag_s[k2][j * 2 + 1][0]);
+            } else {
+              int32_t* s_vals_int = reinterpret_cast<int32_t*>(&s_vals[0]);
+              int32_t s_vals_e8m0 =
+                  *reinterpret_cast<int32_t*>(&frag_s[k2][j][0]);
+
+              s_vals_int[0] = (s_vals_e8m0 & 0xFF) << 23;
+              s_vals_int[1] = (s_vals_e8m0 & 0xFF00) << 15;
+              s_vals_int[2] = (s_vals_e8m0 & 0xFF0000) << 7;
+              s_vals_int[3] = (s_vals_e8m0 & 0xFF000000) >> 1;
+            }
+
+  #pragma unroll
+            for (int i = 0; i < thread_m_blocks; i++) {
+  #pragma unroll
+              for (int g = 0; g < 4; g++) {
+                float scale = reinterpret_cast<float*>(&s_vals[0])[g % 2];
+                frag_c[i][j][0][g] += frag_c_tmp[i][j][0][g] * scale;
+                frag_c_tmp[i][j][0][g] = 0.0f;
+              }
+
+  #pragma unroll
+              for (int g = 0; g < 4; g++) {
+                float scale = reinterpret_cast<float*>(&s_vals[1])[g % 2];
+                frag_c[i][j][1][g] += frag_c_tmp[i][j][1][g] * scale;
+                frag_c_tmp[i][j][1][g] = 0.0f;
+              }
+            }
+          }
+        }
+      }
+    }
+  };
+
+  // Since we slice across the k dimension of a tile in order to increase the
+  // number of warps while keeping the n dimension of a tile reasonable, we have
+  // multiple warps that accumulate their partial sums of the same output
+  // location; which we have to reduce over in the end. We do in shared memory.
+  auto thread_block_reduce = [&]() {
+    // sh_red aliases sh_b. Every warp must finish reading the staged weight
+    // tiles before any warp overwrites that storage with reduction results.
+    // The preceding cp_async_wait only waits for the calling thread's copies.
+    __syncthreads();
+    constexpr int red_off = threads / b_sh_stride_threads / 2;
+    if (red_off >= 1) {
+      auto red_idx = threadIdx.x / b_sh_stride_threads;
+      constexpr int red_sh_stride =
+          b_sh_stride_threads * (is_a_8bit ? 2 : 4) * 2;
+      constexpr int red_sh_delta = b_sh_stride_threads;
+      int red_sh_rd = red_sh_stride * (threadIdx.x / b_sh_stride_threads) +
+                      (threadIdx.x % b_sh_stride_threads);
+
+      // Parallel logarithmic shared memory reduction. We make sure to avoid any
+      // unnecessary read or write iterations, e.g., for two warps we write only
+      // once by warp 1 and read only once by warp 0.
+
+  #pragma unroll
+      for (int m_block = 0; m_block < thread_m_blocks; m_block++) {
+  #pragma unroll
+        for (int i = red_off; i > 0; i /= 2) {
+          if (i <= red_idx && red_idx < 2 * i) {
+  #pragma unroll
+            for (int j = 0; j < (is_a_8bit ? 2 : 4) * 2;
+                 j += (m_block_size_8 ? 2 : 1)) {
+              int red_sh_wr =
+                  red_sh_delta * j + (red_sh_rd - red_sh_stride * i);
+              if (i < red_off) {
+                float* c_rd = reinterpret_cast<float*>(
+                    &sh_red[red_sh_delta * j + red_sh_rd]);
+                float* c_wr = reinterpret_cast<float*>(&sh_red[red_sh_wr]);
+  #pragma unroll
+                for (int k = 0; k < 4; k++)
+                  reinterpret_cast<FragC*>(
+                      frag_c)[(is_a_8bit ? 2 : 4) * 2 * m_block + j][k] +=
+                      c_rd[k] + c_wr[k];
+              }
+              sh_red[red_sh_wr] = reinterpret_cast<int4*>(
+                  &frag_c)[(is_a_8bit ? 2 : 4) * 2 * m_block + j];
+            }
+          }
+          __syncthreads();
+        }
+        if (red_idx == 0) {
+  #pragma unroll
+          for (int i = 0; i < (is_a_8bit ? 2 : 4) * 2;
+               i += (m_block_size_8 ? 2 : 1)) {
+            float* c_rd =
+                reinterpret_cast<float*>(&sh_red[red_sh_delta * i + red_sh_rd]);
+  #pragma unroll
+            for (int j = 0; j < 4; j++)
+              reinterpret_cast<FragC*>(
+                  frag_c)[(is_a_8bit ? 2 : 4) * 2 * m_block + i][j] += c_rd[j];
+          }
+        }
+        __syncthreads();
+      }
+    }
+  };
+
+  // Since multiple threadblocks may process parts of the same column slice, we
+  // finally have to globally reduce over the results. As the striped
+  // partitioning minimizes the number of such reductions and our outputs are
+  // usually rather small, we perform this reduction serially in L2 cache.
+  auto global_reduce_fp16 = [&](bool first = false, bool last = false) {
+    // We are very careful here to reduce directly in the output buffer to
+    // maximize L2 cache utilization in this step. To do this, we write out
+    // results in FP16 (but still reduce with FP32 compute).
+    constexpr int active_threads = 32 * tb_n_warps;
+    bool is_th_active = threadIdx.x < active_threads;
+    if (!is_th_active) {
+      return;
+    }
+
+    int c_gl_stride = prob_n / 8 * (is_a_8bit ? 2 : 1);
+    int c_gl_wr_delta_o = 8 * c_gl_stride;
+    int c_gl_wr_delta_i = 4 * (active_threads / 32);
+    int c_gl_wr;
+    if constexpr (m_block_size_8) {
+      c_gl_wr = c_gl_stride * ((threadIdx.x % 4) * 2) + 4 * (threadIdx.x / 32) +
+                (threadIdx.x % 32) / 8;
+      c_gl_wr += (2 * thread_n_blocks) * slice_col;
+    } else {
+      c_gl_wr = c_gl_stride * ((threadIdx.x % 32) / 4) +
+                4 * (threadIdx.x / 32) + threadIdx.x % 4;
+      c_gl_wr += (2 * thread_n_blocks) * slice_col * (is_a_8bit ? 2 : 1);
+    }
+    constexpr int c_sh_wr_delta = active_threads;
+    int c_sh_wr = threadIdx.x;
+
+    if (!first) {
+
+  #pragma unroll
+      for (int i = 0; i < (m_block_size_8 ? 2 : thread_m_blocks * 4); i++) {
+        int c_idx;
+        if constexpr (m_block_size_8)
+          c_idx = c_gl_wr + i * c_gl_stride +
+                  (threadIdx.x % 8) / 4 * c_gl_wr_delta_i;
+        else
+          c_idx =
+              c_gl_wr + c_gl_wr_delta_o * (i / 2) + c_gl_wr_delta_i * (i % 2);
+        if (c_idx / c_gl_stride < block_num_valid_tokens) {
+          int64_t sorted_row = sh_block_sorted_ids[c_idx / c_gl_stride];
+          int64_t true_idx = sorted_row * c_gl_stride + c_idx % c_gl_stride;
+          if constexpr (is_a_8bit) {
+            int2* sh_red_int2 = reinterpret_cast<int2*>(sh_red);
+            int2* c_int2 = reinterpret_cast<int2*>(C);
+            sh_red_int2[c_sh_wr + c_sh_wr_delta * i] = c_int2[true_idx];
+          } else {
+            sh_red[c_sh_wr + c_sh_wr_delta * i] = C[true_idx];
+          }
+        }
+      }
+    }
+
+  #pragma unroll
+    for (int i = 0; i < (m_block_size_8 ? 2 : thread_m_blocks * 4); i++) {
+      if (!first) {
+        c_scalar_t* c_red_f16;
+        if constexpr (is_a_8bit) {
+          int2 tmp =
+              reinterpret_cast<int2*>(sh_red)[c_sh_wr + i * c_sh_wr_delta];
+          c_red_f16 = reinterpret_cast<c_scalar_t*>(&tmp);
+        } else {
+          int4 tmp = sh_red[c_sh_wr + i * c_sh_wr_delta];
+          c_red_f16 = reinterpret_cast<c_scalar_t*>(&tmp);
+        }
+  #pragma unroll
+        for (int j = 0; j < 2 * (is_a_8bit ? 2 : 4); j++) {
+          int delta = 0;
+          if constexpr (m_block_size_8) {
+            delta = j % 2 == 1 ? -2 : 0;
+          }
+          reinterpret_cast<float*>(
+              &frag_c)[(is_a_8bit ? 2 : 4) * 2 * 4 * (i / 4) + 4 * j + (i % 4) +
+                       delta] += Cdtype::num2float(c_red_f16[j]);
+        }
+      }
+      if (!last) {
+        c_scalar_t c_f16[is_a_8bit ? 4 : 8];
+  #pragma unroll
+        for (int j = 0; j < 2 * (is_a_8bit ? 2 : 4); j++) {
+          int delta = 0;
+          if constexpr (m_block_size_8) {
+            delta = j % 2 == 1 ? -2 : 0;
+          }
+          c_f16[j] = Cdtype::float2num(reinterpret_cast<float*>(
+              &frag_c)[(is_a_8bit ? 2 : 4) * 2 * 4 * (i / 4) + 4 * j + (i % 4) +
+                       delta]);
+        }
+
+        int c_idx;
+        if constexpr (m_block_size_8)
+          c_idx = c_gl_wr + i * c_gl_stride +
+                  (threadIdx.x % 8) / 4 * c_gl_wr_delta_i;
+        else
+          c_idx =
+              c_gl_wr + c_gl_wr_delta_o * (i / 2) + c_gl_wr_delta_i * (i % 2);
+        if (c_idx / c_gl_stride < block_num_valid_tokens) {
+          int64_t sorted_row = sh_block_sorted_ids[c_idx / c_gl_stride];
+          int64_t true_idx = sorted_row * c_gl_stride + c_idx % c_gl_stride;
+          if constexpr (is_a_8bit) {
+            int2* c_int2 = reinterpret_cast<int2*>(C);
+            c_int2[true_idx] = *reinterpret_cast<int2*>(c_f16);
+          } else {
+            C[true_idx] = *reinterpret_cast<int4*>(c_f16);
+          }
+        }
+      }
+    }
+  };
+
+  // Globally reduce over threadblocks that compute the same column block.
+  // We use a tmp C buffer to reduce in full fp32 precision.
+  auto global_reduce_fp32 = [&](bool first = false, bool last = false) {
+    constexpr int tb_m = thread_m_blocks * 16;
+    constexpr int tb_n = thread_n_blocks * 16;
+
+    constexpr int c_size = tb_m * tb_n * sizeof(float) / 16;
+
+    constexpr int active_threads = 32 * tb_n_warps;
+    bool is_th_active = threadIdx.x < active_threads;
+
+    constexpr int num_floats = thread_m_blocks * (is_a_8bit ? 2 : 4) * 2 * 4;
+    constexpr int th_size = num_floats * sizeof(float) / 16;
+
+    int c_cur_offset = locks_off * c_size;
+
+    if (!is_th_active) {
+      return;
+    }
+
+    if (!first) {
+      float* frag_c_ptr = reinterpret_cast<float*>(&frag_c);
+  #pragma unroll
+      for (int k = 0; k < th_size; k++) {
+        if constexpr (m_block_size_8) {
+          if (k % 2) continue;
+        } else {
+          if (k / 8 * 16 + (threadIdx.x % 32) / 4 >= block_num_valid_tokens)
+            continue;
+        }
+
+        sh_red[threadIdx.x] =
+            C_tmp[c_cur_offset + active_threads * k + threadIdx.x];
+
+        float* sh_c_ptr = reinterpret_cast<float*>(&sh_red[threadIdx.x]);
+  #pragma unroll
+        for (int f = 0; f < 4; f++) {
+          frag_c_ptr[k * 4 + f] += sh_c_ptr[f];
+        }
+      }
+    }
+
+    if (!last) {
+      int4* frag_c_ptr = reinterpret_cast<int4*>(&frag_c);
+  #pragma unroll
+      for (int k = 0; k < th_size; k++) {
+        if constexpr (m_block_size_8) {
+          if (k % 2) continue;
+        } else {
+          if (k / 8 * 16 + (threadIdx.x % 32) / 4 >= block_num_valid_tokens)
+            continue;
+        }
+
+        C_tmp[c_cur_offset + active_threads * k + threadIdx.x] = frag_c_ptr[k];
+      }
+    }
+  };
+
+  // Write out the reduce final result in the correct layout. We only actually
+  // reshuffle matrix fragments in this step, the reduction above is performed
+  // in fragment layout.
+  auto write_result = [&](bool last) {
+    int c_gl_stride = prob_n / 8;
+    constexpr int c_sh_stride = 2 * thread_n_blocks + 1;
+    int c_gl_wr_delta = c_gl_stride * (threads / (2 * thread_n_blocks));
+    constexpr int c_sh_rd_delta =
+        c_sh_stride * (threads / (2 * thread_n_blocks));
+
+    int c_gl_wr = c_gl_stride * (threadIdx.x / (2 * thread_n_blocks)) +
+                  (threadIdx.x % (2 * thread_n_blocks));
+    c_gl_wr += (2 * thread_n_blocks) * slice_col;
+    int c_sh_wr;
+    if constexpr (m_block_size_8) {
+      c_sh_wr = (8 * c_sh_stride) * ((threadIdx.x % 32) % 4 * 2) +
+                (threadIdx.x % 32) / 4;
+      c_sh_wr += 64 * (threadIdx.x / 32);
+    } else {
+      c_sh_wr =
+          (4 * c_sh_stride) * ((threadIdx.x % 32) / 4) + (threadIdx.x % 32) % 4;
+      c_sh_wr += (is_a_8bit ? 16 : 32) * (threadIdx.x / 32);
+    }
+
+    int c_sh_rd = c_sh_stride * (threadIdx.x / (2 * thread_n_blocks)) +
+                  (threadIdx.x % (2 * thread_n_blocks));
+
+    // We first reorder in shared memory to guarantee the most efficient final
+    // global write patterns
+    auto write = [&](int idx, float c0, float c1, FragS& s, FragS& b_bias) {
+      if constexpr (b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn) {
+        if (!mul_topk_weights) {
+          c0 *= global_scale_f32;
+          c1 *= global_scale_f32;
+        }
+      }
+
+      c_scalar_t2 res =
+          Cdtype::nums2num2(Cdtype::float2num(c0), Cdtype::float2num(c1));
+
+      // For per-column quantization we finally apply the scale here (only for
+      // 4-bit)
+      if constexpr (!has_act_order && group_blocks == -1 && !is_a_8bit &&
+                    b_type.size_bits() == 4 &&
+                    (has_zp && dequant_skip_flop || !has_zp)) {
+        c_scalar_t2 tmp_scale = s[0];
+        if constexpr (m_block_size_8) {
+          tmp_scale = Cdtype::num2num2(
+              reinterpret_cast<scalar_t*>(&s[0])[(threadIdx.x % 8) / 4]);
+        }
+        res = __hmul2(res, tmp_scale);
+      }
+
+      if (has_bias && last) {
+        c_scalar_t2 tmp_bias = b_bias[0];
+        if constexpr (m_block_size_8) {
+          tmp_bias = Cdtype::num2num2(
+              reinterpret_cast<scalar_t*>(&b_bias[0])[(threadIdx.x % 8) / 4]);
+        }
+        res = __hadd2(res, tmp_bias);
+      }
+
+      if constexpr (m_block_size_8) {
+        ((c_scalar_t*)sh_red)[idx] = res.x;
+        ((c_scalar_t*)sh_red)[idx + 8 * c_sh_stride] = res.y;
+      } else {
+        ((c_scalar_t2*)sh_red)[idx] = res;
+      }
+    };
+
+    if (threadIdx.x / 32 < tb_n_warps) {
+  #pragma unroll
+      for (int i = 0; i < thread_m_blocks; i++) {
+  #pragma unroll
+        for (int j = 0; j < (is_a_8bit ? 2 : 4); j++) {
+          if constexpr (m_block_size_8) {
+            int wr = c_sh_wr + 16 * j;
+            write(wr, frag_c[i][j][0][0], frag_c[i][j][0][1],
+                  frag_s[j / 2][2 * (j % 2) + 0],
+                  frag_bias[j / 2][2 * (j % 2) + 0]);
+            write(wr + 8, frag_c[i][j][0][2], frag_c[i][j][0][3],
+                  frag_s[j / 2][2 * (j % 2) + 1],
+                  frag_bias[j / 2][2 * (j % 2) + 1]);
+          } else {
+            int wr = c_sh_wr + 8 * j;
+            write(wr + (4 * c_sh_stride) * 0 + 0, frag_c[i][j][0][0],
+                  frag_c[i][j][0][1], frag_s[j / 2][2 * (j % 2) + 0],
+                  frag_bias[j / 2][2 * (j % 2) + 0]);
+            write(wr + (4 * c_sh_stride) * 8 + 0, frag_c[i][j][0][2],
+                  frag_c[i][j][0][3], frag_s[j / 2][2 * (j % 2) + 0],
+                  frag_bias[j / 2][2 * (j % 2) + 0]);
+            write(wr + (4 * c_sh_stride) * 0 + 4, frag_c[i][j][1][0],
+                  frag_c[i][j][1][1], frag_s[j / 2][2 * (j % 2) + 1],
+                  frag_bias[j / 2][2 * (j % 2) + 1]);
+            write(wr + (4 * c_sh_stride) * 8 + 4, frag_c[i][j][1][2],
+                  frag_c[i][j][1][3], frag_s[j / 2][2 * (j % 2) + 1],
+                  frag_bias[j / 2][2 * (j % 2) + 1]);
+          }
+        }
+        c_sh_wr += 16 * (4 * c_sh_stride);
+      }
+    }
+    __syncthreads();
+
+    if constexpr (fused_glm_swiglu) {
+      // GLM53 decode: each 64-column group contains [gate32 | up32].
+      // The load-time permutation changes no quant bytes/scales. Both halves
+      // already underwent the usual FP32 split-K reduction and BF16 output
+      // rounding above. Consume them here instead of materializing gate/up
+      // and launching a separate clamped activation kernel.
+      static_assert(c_type_id == vllm::kBFloat16.id() && !is_a_8bit &&
+                    group_blocks == 1 && m_block_size_8);
+      constexpr int half_n = thread_n_blocks * 8;
+      auto* values = reinterpret_cast<c_scalar_t*>(sh_red);
+      auto* output = reinterpret_cast<c_scalar_t*>(C);
+      for (int idx = threadIdx.x; idx < 8 * half_n; idx += threads) {
+        const int row = idx / half_n;
+        const int col = idx % half_n;
+        if (row < block_num_valid_tokens) {
+          const int offset = row * c_sh_stride * 8 + (col / 32) * 64 + col % 32;
+          const float gate = fminf(float(values[offset]), 10.0f);
+          const float up = fmaxf(fminf(float(values[offset + 32]), 10.0f),
+                                -10.0f);
+          // Match act_and_mul_kernel: BF16 SiLU, then FP32 multiply and
+          // BF16 output. Keeping the SiLU rounding is essential.
+          const c_scalar_t activated = Cdtype::float2num(
+              gate / (1.0f + expf(-gate)));
+          const int64_t sorted_row = sh_block_sorted_ids[row];
+          output[sorted_row * (prob_n / 2) + slice_col * half_n + col] =
+              Cdtype::float2num(float(activated) * up);
+        }
+      }
+      __syncthreads();
+      return;
+    }
+
+  #pragma unroll
+    for (int i = 0;
+         i < div_ceil(16 * thread_m_blocks, threads / (2 * thread_n_blocks));
+         i++) {
+      int row = c_gl_wr / c_gl_stride;
+      if (row < block_num_valid_tokens) {
+        int64_t sorted_row = sh_block_sorted_ids[row];
+        int64_t true_idx = sorted_row * c_gl_stride + c_gl_wr % c_gl_stride;
+        c_scalar_t2 topk_weight_score;
+        if (mul_topk_weights) topk_weight_score = sh_block_topk_weights[row];
+        if (use_atomic_add && slice_count > 1 || mul_topk_weights) {
+          c_scalar_t2* C_half2 = reinterpret_cast<c_scalar_t2*>(&C[true_idx]);
+          c_scalar_t2* sh_red_half2 =
+              reinterpret_cast<c_scalar_t2*>(&sh_red[c_sh_rd]);
+          if (mul_topk_weights) {
+  #pragma unroll
+            for (int a = 0; a < 4; a++) {
+              sh_red_half2[a] = __hmul2(sh_red_half2[a], topk_weight_score);
+            }
+          }
+
+          if (use_atomic_add && slice_count > 1) {
+  #pragma unroll
+            for (int a = 0; a < 4; a++) {
+              atomicAdd(&C_half2[a], sh_red_half2[a]);
+            }
+          } else {
+            C[true_idx] = *reinterpret_cast<int4*>(sh_red_half2);
+          }
+        } else {
+          C[true_idx] = sh_red[c_sh_rd];
+        }
+        c_gl_wr += c_gl_wr_delta;
+        c_sh_rd += c_sh_rd_delta;
+      }
+    }
+    __syncthreads();
+  };
+
+  // Start global fetch and register load pipelines.
+  auto start_pipes = [&]() {
+
+  #pragma unroll
+    for (int i = 0; i < stages - 1; i++) {
+      if (has_act_order && i == 0) {
+        int last_g_idx = slice_k_start + stages * tb_k * 2;
+        if (last_g_idx >= prob_k) {
+          last_g_idx = prob_k - 1;
+        }
+        fetch_act_order_scales_to_shared(true, g_idx[slice_k_start],
+                                         g_idx[last_g_idx]);
+      }
+
+      if constexpr (has_zp && !is_zp_float && group_blocks == -1) {
+        if (i == 0) {
+          fetch_col_zp_to_shared();
+          if constexpr (!dequant_skip_flop) {
+            fetch_col_scale_to_shared();
+          }
+        }
+      }
+      fetch_to_shared(i, i, i < slice_iters);
+    }
+
+    zero_accums();
+    wait_for_stage();
+    init_same_group(0);
+    fetch_to_registers(0, 0);
+    fetch_scales_to_registers(0, 0);
+    fetch_zp_to_registers(0, 0);
+    a_gl_rd_col += a_gl_rd_delta_o * (stages - 1);
+    if constexpr (has_act_order) {
+      slice_k_start_shared_fetch += tb_k * (stages - 1);
+    }
+  };
+  if (slice_iters) {
+    start_pipes();
+  }
+
+  // Main loop.
+  while (slice_iters) {
+    // We unroll over both the global fetch and the register load pipeline to
+    // ensure all shared memory accesses are static. Note that both pipelines
+    // have even length meaning that the next iteration will always start at
+    // index 0.
+
+  #pragma unroll
+    for (int pipe = 0; pipe < stages;) {
+  #pragma unroll
+      for (int k = 0; k < b_sh_wr_iters; k++) {
+        fetch_to_registers(k + 1, pipe % stages);
+        fetch_scales_to_registers(k + 1, pipe);
+        fetch_zp_to_registers(k + 1, pipe);
+        if (k == b_sh_wr_iters - 2) {
+          fetch_to_shared((pipe + stages - 1) % stages, pipe,
+                          slice_iters >= stages);
+          pipe++;
+          wait_for_stage();
+          init_same_group(pipe % stages);
+        }
+
+        if constexpr (!is_a_8bit) {
+          matmul(k, pipe - (k >= b_sh_wr_iters - 2 ? 1 : 0));
+        } else {
+          static_assert(group_blocks != 0 && group_blocks != 1);
+          matmul_a8(k);
+        }
+      }
+      slice_iters--;
+      if (slice_iters == 0) {
+        break;
+      }
+    }
+
+    a_gl_rd_col += a_gl_rd_delta_o * stages;
+
+    if constexpr (has_act_order) {
+      slice_k_start += tb_k * stages;
+
+      if (slice_k_start < prob_k) {
+        slice_k_start_shared_fetch += tb_k * stages;
+        int first_group_id = g_idx[slice_k_start];
+        int last_g_idx = slice_k_start + stages * tb_k * 2;
+        if (last_g_idx >= prob_k) {
+          last_g_idx = prob_k - 1;
+        }
+        int last_group_id = g_idx[last_g_idx];
+        if (last_group_id >= sh_first_group_id + sh_num_groups) {
+          fetch_act_order_scales_to_shared(false, first_group_id,
+                                           last_group_id);
+          __syncthreads();
+        }
+      }
+    }
+
+    // Process results and, if necessary, proceed to the next column slice.
+    // While this pattern may not be the most readable, other ways of writing
+    // the loop seemed to noticeably worse performance after compilation.
+    if (slice_iters == 0) {
+      // convert fp16 accum to fp32 for reduction
+      if constexpr (use_fp16_accum) {
+  #pragma unroll
+        for (int i = 0; i < (thread_m_blocks * (is_a_8bit ? 2 : 4) * 2); i++) {
+          float* frag_c_part_float = reinterpret_cast<float*>(frag_c) + i * 4;
+          scalar_t* frag_c_part_half =
+              reinterpret_cast<scalar_t*>(frag_c_part_float);
+
+  #pragma unroll
+          for (int i = 3; i >= 0; i--) {
+            frag_c_part_float[i] = Cdtype::num2float(frag_c_part_half[i]);
+          }
+        }
+      }
+
+      if constexpr (is_a_8bit) {
+        float frag_a_s[2 * thread_m_blocks];
+
+        for (int i = 0; i < 2 * thread_m_blocks; i++)
+          frag_a_s[i] = sh_a_s[i * 8 + (threadIdx.x % 32) / 4];
+
+  #pragma unroll
+        for (int j = 0; j < 2; j++) {
+  #pragma unroll
+          for (int i = 0; i < thread_m_blocks; i++) {
+  #pragma unroll
+            for (int g = 0; g < 4; g++) {
+              float c_val = frag_c[i][j][0][g];
+
+              if constexpr (a_type == vllm::kS8) {
+                c_val = __int2float_rn(*reinterpret_cast<int32_t*>(&c_val));
+              }
+              float s_val = frag_a_s[i * 2 + g / 2];
+              frag_c[i][j][0][g] = c_val * s_val;
+            }
+  #pragma unroll
+            for (int g = 0; g < 4; g++) {
+              float c_val = frag_c[i][j][1][g];
+
+              if constexpr (a_type == vllm::kS8) {
+                c_val = __int2float_rn(*reinterpret_cast<int32_t*>(&c_val));
+              }
+              float s_val = frag_a_s[i * 2 + g / 2];
+              frag_c[i][j][1][g] = c_val * s_val;
+            }
+          }
+        }
+      }
+
+      cp_async_wait<0>();
+      bool last = slice_idx == slice_count - 1;
+      // For per-column scales, we only fetch them here in the final step before
+      // write-out
+      if constexpr (!has_act_order && group_blocks == -1 &&
+                    (has_zp && dequant_skip_flop || !has_zp)) {
+        if (b_type.size_bits() == 8 || (last || use_atomic_add) || is_a_8bit) {
+          if (s_sh_wr_pred) {
+            cp_async4(&sh_s[s_sh_wr], &scales_ptr[s_gl_rd]);
+          }
+          cp_async_fence();
+        }
+      }
+
+      thread_block_reduce();
+
+      if (has_bias && last) {
+        __syncthreads();
+        cp_async4_pred(&sh_bias[bias_sh_wr], &b_bias_ptr[bias_gl_rd],
+                       threadIdx.x < 16 * thread_n_blocks / 8);
+        cp_async_fence();
+      }
+
+      if constexpr (!has_act_order && group_blocks == -1 &&
+                    (has_zp && dequant_skip_flop || !has_zp || is_a_8bit)) {
+        if constexpr (is_a_8bit) {
+          cp_async_wait<0>();
+          __syncthreads();
+          if (threadIdx.x / 32 < tb_n_warps) {
+            reinterpret_cast<int4*>(&frag_s)[0] = sh_s[s_sh_rd + 0];
+          }
+        } else if (b_type.size_bits() == 8 || (last || use_atomic_add)) {
+          cp_async_wait<0>();
+          __syncthreads();
+          if (threadIdx.x / 32 < tb_n_warps) {
+            reinterpret_cast<int4*>(&frag_s)[0] = sh_s[s_sh_rd + 0];
+            reinterpret_cast<int4*>(&frag_s)[1] = sh_s[s_sh_rd + 4];
+            if constexpr (m_block_size_8) {
+              int idx = (threadIdx.x / 4) % 2;
+              c_scalar_t2* frag_s_half2 =
+                  reinterpret_cast<c_scalar_t2*>(frag_s);
+  #pragma unroll
+              for (int i = 0; i < 8; i++) {
+                frag_s_half2[i] = Cdtype::num2num2(
+                    reinterpret_cast<c_scalar_t*>(&frag_s_half2[i])[idx]);
+              }
+            }
+          }
+        }
+      }
+
+      // For 8-bit channelwise, we apply the scale before the global reduction
+      // that converts the fp32 results to fp16 (so that we avoid possible
+      // overflow in fp16)
+      if constexpr (!has_act_order && group_blocks == -1 && is_a_8bit) {
+  #pragma unroll
+        for (int j = 0; j < 2; j++) {
+          float2 aa[2];
+          aa[0] = Cdtype::num22float2(frag_s[0][j * 2][0]);
+          aa[1] = Cdtype::num22float2(frag_s[0][j * 2 + 1][0]);
+
+  #pragma unroll
+          for (int i = 0; i < thread_m_blocks; i++) {
+  #pragma unroll
+            for (int g = 0; g < 4; g++) {
+              float scale = reinterpret_cast<float*>(&aa[0])[g % 2];
+              frag_c[i][j][0][g] *= scale;
+            }
+
+  #pragma unroll
+            for (int g = 0; g < 4; g++) {
+              float scale = reinterpret_cast<float*>(&aa[1])[g % 2];
+              frag_c[i][j][1][g] *= scale;
+            }
+          }
+        }
+      } else if (!has_act_order && group_blocks == -1 &&
+                 b_type.size_bits() == 8 &&
+                 (has_zp && dequant_skip_flop || !has_zp)) {
+        if (threadIdx.x / 32 < tb_n_warps) {
+  #pragma unroll
+          for (int i = 0; i < thread_m_blocks; i++) {
+  #pragma unroll
+            for (int j = 0; j < 4; j++) {
+              scale_float<c_type_id>(
+                  reinterpret_cast<float*>(&frag_c[i][j][0][0]),
+                  frag_s[j / 2][2 * (j % 2) + 0]);
+              scale_float<c_type_id>(
+                  reinterpret_cast<float*>(&frag_c[i][j][0][2]),
+                  frag_s[j / 2][2 * (j % 2) + (m_block_size_8 ? 1 : 0)]);
+
+              if constexpr (!m_block_size_8) {
+                scale_float<c_type_id>(
+                    reinterpret_cast<float*>(&frag_c[i][j][1][0]),
+                    frag_s[j / 2][2 * (j % 2) + 1]);
+                scale_float<c_type_id>(
+                    reinterpret_cast<float*>(&frag_c[i][j][1][2]),
+                    frag_s[j / 2][2 * (j % 2) + 1]);
+              }
+            }
+          }
+        }
+      }
+
+      if (slice_count > 1 && !use_atomic_add) {
+        // only globally reduce if there is more than one block in a slice
+        barrier_acquire(&locks[locks_off], slice_idx);
+        if (use_fp32_reduce) {
+          global_reduce_fp32(slice_idx == 0, last);
+        } else {
+          global_reduce_fp16(slice_idx == 0, last);
+        }
+        barrier_release(&locks[locks_off], last);
+      }
+
+      if (has_bias && last) {
+        cp_async_wait<0>();
+        __syncthreads();
+        reinterpret_cast<int4*>(&frag_bias)[0] = sh_bias[bias_sh_rd];
+        if constexpr (!is_a_8bit)
+          reinterpret_cast<int4*>(&frag_bias)[1] = sh_bias[bias_sh_rd + 4];
+        __syncthreads();
+      }
+
+      if (use_atomic_add && slice_count > 1 && slice_idx != 0)
+        wait_negative_and_add(&locks[locks_off]);
+      if (last || use_atomic_add)
+        // only the last block in a slice actually writes the result
+        write_result(last);
+      slice_row = 0;
+      if (!in_part2) {
+        slice_col_par += gridDim.x;
+      } else {
+        slice_col_par++;
+        slice_col++;
+      }
+      is_first_matmul_in_slice = true;
+      init_slice();
+
+      if (slice_iters) {
+        a_gl_rd_col =
+            a_gl_rd_delta_o * slice_row + threadIdx.x % a_gl_rd_delta_o;
+        b_gl_rd = B_expert_off + b_gl_stride * (threadIdx.x / b_sh_stride) +
+                  (threadIdx.x % b_sh_stride);
+        b_gl_rd += b_sh_stride * slice_col + b_gl_rd_delta_o * slice_row;
+
+        bias_gl_rd = (thread_n_blocks * 16 / 8) * slice_col + threadIdx.x;
+        // Update slice k/n for scales loading
+        if constexpr (has_act_order) {
+          slice_k_start = tb_k * slice_row;
+          slice_k_finish = slice_k_start + tb_k * slice_iters;
+          slice_k_start_shared_fetch = slice_k_start;
+          slice_n_offset = act_s_col_tb_stride * slice_col;
+        } else {
+          if constexpr (group_blocks == -1) {
+            s_gl_rd = s_sh_stride * slice_col + threadIdx.x;
+            zp_gl_rd = zp_sh_stride * slice_col + threadIdx.x;
+          } else if constexpr (group_blocks >= thread_k_blocks) {
+            s_gl_rd =
+                s_gl_stride * ((thread_k_blocks * slice_row) / group_blocks) +
+                s_sh_stride * slice_col + threadIdx.x;
+            zp_gl_rd =
+                zp_gl_stride * ((thread_k_blocks * slice_row) / group_blocks) +
+                zp_sh_stride * slice_col + threadIdx.x;
+          } else {
+            s_gl_rd =
+                s_gl_stride * ((thread_k_blocks * slice_row) / group_blocks +
+                               threadIdx.x / s_sh_stride) +
+                s_sh_stride * slice_col + threadIdx.x % s_sh_stride;
+            zp_gl_rd =
+                zp_gl_stride * ((thread_k_blocks * slice_row) / group_blocks +
+                                threadIdx.x / zp_sh_stride) +
+                zp_sh_stride * slice_col + threadIdx.x % zp_sh_stride;
+          }
+        }
+        start_pipes();
+      }
+    }
+  }
+}
+
+}  // namespace MARLIN_NAMESPACE_NAME
+
+#endif

--- a/benchmarks/kernels/marlin_prefill_stages.cu
+++ b/benchmarks/kernels/marlin_prefill_stages.cu
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Isolated SM120 NVFP4 prefill pipeline-depth experiment. No registered ops.
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#define MARLIN_NAMESPACE_NAME marlin_prefill_stages
+#include "libtorch_stable/moe/marlin_moe_wna16/marlin_template.h"
+
+template <int N, int STAGES>
+at::Tensor launch(at::Tensor a, at::Tensor out, at::Tensor weight,
+                 at::Tensor scales, at::Tensor global_scale, at::Tensor workspace,
+                 at::Tensor sorted_ids, at::Tensor experts, at::Tensor padded,
+                 at::Tensor routing_weights, int top_k, bool weighted, int blocks) {
+  constexpr int M = 64, K = 64, THREADS = std::min(N, 256);
+  constexpr int a_bytes = STAGES * M * K * 2;
+  constexpr int b_bytes = STAGES * K * N / 2;
+  constexpr int red_bytes = M * (N + 8) * 2;
+  constexpr int bias_bytes = N * 2;
+  constexpr int min_br = std::min(b_bytes, red_bytes);
+  constexpr int max_br = std::max(b_bytes, red_bytes);
+  constexpr int smem = std::max(max_br, min_br + bias_bytes) + a_bytes +
+                       STAGES * (K / 16) * N + M * 16;
+  auto kernel = MARLIN_NAMESPACE_NAME::Marlin<
+      vllm::kBFloat16.id(), vllm::kFE2M1f.id(), vllm::kBFloat16.id(),
+      vllm::kFE4M3fn.id(), THREADS, M / 16, N / 16, K / 16,
+      false, STAGES, 1, false>;
+  int sms, max_shared;
+  C10_CUDA_CHECK(cudaDeviceGetAttribute(
+      &sms, cudaDevAttrMultiProcessorCount, a.get_device()));
+  C10_CUDA_CHECK(cudaDeviceGetAttribute(
+      &max_shared, cudaDevAttrMaxSharedMemoryPerMultiprocessor, a.get_device()));
+  TORCH_CHECK(smem + 1024 <= max_shared / blocks, "Invalid thread config: smem");
+  TORCH_CHECK(workspace.numel() >= sms * 4);
+  int m = a.size(0), k = a.size(1), n = out.size(1);
+  auto temp = at::empty({std::min(int64_t(n) * sorted_ids.numel(),
+                                 int64_t(sms) * 4 * M * 256)},
+                        a.options().dtype(at::kFloat));
+  C10_CUDA_CHECK(cudaFuncSetAttribute(
+      kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem));
+  kernel<<<sms * blocks, THREADS, smem, at::cuda::getCurrentCUDAStream()>>>(
+      (const int4*)a.data_ptr(), (const int4*)weight.data_ptr(),
+      (int4*)out.data_ptr(), (int4*)temp.data_ptr(), nullptr, nullptr,
+      (const int4*)scales.data_ptr(), global_scale.data_ptr<float>(), nullptr,
+      nullptr, sorted_ids.data_ptr<int>(), experts.data_ptr<int>(),
+      padded.data_ptr<int>(), routing_weights.data_ptr<float>(), top_k, weighted,
+      k / 16, m, n, k, workspace.data_ptr<int>(), false, false, true);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return out;
+}
+
+at::Tensor run(at::Tensor a, at::Tensor out, at::Tensor weight,
+               at::Tensor scales, at::Tensor global_scale, at::Tensor workspace,
+               at::Tensor sorted_ids, at::Tensor experts, at::Tensor padded,
+               at::Tensor routing_weights, int top_k, bool weighted,
+               int n_tile, int blocks, int stages) {
+  TORCH_CHECK(a.is_cuda() && a.scalar_type() == at::kBFloat16);
+  const c10::cuda::CUDAGuard guard(a.device());
+  for (const auto& t : {a, out, weight, scales, global_scale, workspace,
+                       sorted_ids, experts, padded, routing_weights})
+    TORCH_CHECK(t.device() == a.device() && t.is_contiguous());
+  TORCH_CHECK(out.scalar_type() == at::kBFloat16 &&
+              weight.scalar_type() == at::kInt &&
+              scales.scalar_type() == at::kFloat8_e4m3fn &&
+              global_scale.scalar_type() == at::kFloat &&
+              routing_weights.scalar_type() == at::kFloat);
+  TORCH_CHECK(workspace.scalar_type() == at::kInt && sorted_ids.scalar_type() == at::kInt &&
+              experts.scalar_type() == at::kInt && padded.scalar_type() == at::kInt);
+  TORCH_CHECK(a.dim() == 2 && out.dim() == 2 && out.size(0) == a.size(0) * top_k);
+  TORCH_CHECK((top_k == 8 && !weighted && a.size(1) == 4096 && out.size(1) == 1024) ||
+              (top_k == 1 && weighted && a.size(1) == 512 && out.size(1) == 4096));
+  TORCH_CHECK(weight.sizes() == at::IntArrayRef({288, a.size(1) / 16, out.size(1) * 2}));
+  TORCH_CHECK(scales.sizes() == at::IntArrayRef({288, a.size(1) / 16, out.size(1)}));
+  TORCH_CHECK(global_scale.numel() == 288 && padded.numel() == 1 &&
+              routing_weights.numel() == out.size(0) &&
+              experts.numel() * 64 >= sorted_ids.numel());
+  TORCH_CHECK(blocks >= 1 && blocks <= 2);
+#define CALL(N, S) return launch<N, S>(a, out, weight, scales, global_scale, workspace, \
+    sorted_ids, experts, padded, routing_weights, top_k, weighted, blocks)
+  if (n_tile == 128) {
+    if (stages == 2) { CALL(128, 2); }
+    if (stages == 3) { CALL(128, 3); }
+    if (stages == 4) { CALL(128, 4); }
+  } else if (n_tile == 256) {
+    if (stages == 2) { CALL(256, 2); }
+    if (stages == 3) { CALL(256, 3); }
+    if (stages == 4) { CALL(256, 4); }
+  } else if (n_tile == 512) {
+    if (stages == 2) { CALL(512, 2); }
+    if (stages == 3) { CALL(512, 3); }
+  }
+#undef CALL
+  TORCH_CHECK(false, "unsupported pipeline configuration");
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) { m.def("run", &run); }

--- a/benchmarks/kernels/mhc_fp64_oracle.py
+++ b/benchmarks/kernels/mhc_fp64_oracle.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Independent CPU FP64 accuracy contract for the GLM53 mHC prefill probe.
+
+This is NOT the original installed-kernel parity gate. See
+perf/glm53-mhc-tc-accuracy-contract.md for the separately prescribed gates.
+The fused residual must first pass exact installed-kernel bit parity; this
+oracle evaluates the subsequent projection, normalization, gates and mix.
+"""
+
+import math
+
+import torch
+
+RTOL = 2e-5
+ATOL = 2e-6
+GAMMA4 = (4 * 2**-24) / (1 - 4 * 2**-24)
+
+
+def direct_bf16_rne(value):
+    """Round finite, BF16-range CPU FP64 values without FP32 double rounding.
+
+    Torch's double->BF16 conversion is only the initial estimate. Its adjacent
+    values bracket any double-rounding error; choose the nearest using FP64
+    distances and the even BF16 low bit for exact ties. Preserve signed zero.
+    Overflow is deliberately out of this oracle's scope, not silently clamped.
+    """
+    if value.device.type != "cpu" or value.dtype != torch.float64:
+        raise ValueError("direct rounding requires CPU float64")
+    if (
+        not torch.isfinite(value).all()
+        or (value.abs() > torch.finfo(torch.bfloat16).max).any()
+    ):
+        raise ValueError("direct rounding requires finite BF16-range values")
+    estimate = value.bfloat16()
+    rounded = estimate
+    distance = (estimate.double() - value).abs()
+    # Pairwise selection implements the same nearest/even ordering without
+    # a strided three-way argmin over millions of hidden coordinates.
+    for direction in (-math.inf, math.inf):
+        neighbor = torch.nextafter(estimate, torch.full_like(estimate, direction))
+        other_distance = (neighbor.double() - value).abs()
+        even = (neighbor.view(torch.int16) & 1) == 0
+        better = (other_distance < distance) | ((other_distance == distance) & even)
+        rounded = torch.where(better, neighbor, rounded)
+        distance = torch.minimum(distance, other_distance)
+    return torch.where(value == 0, estimate, rounded)
+
+
+def ideal_outputs(residual, fn, scale, base):
+    """Model equations in FP64, independent of CUDA splits/tiles/reductions."""
+    if (
+        residual.ndim != 3
+        or tuple(residual.shape[1:]) != (4, 4096)
+        or tuple(fn.shape) != (24, 16384)
+        or tuple(scale.shape) != (3,)
+        or tuple(base.shape) != (24,)
+    ):
+        raise ValueError("invalid GLM53 mHC oracle shapes")
+    for tensor in (residual, fn, scale, base):
+        if tensor.device.type != "cpu" or tensor.dtype != torch.float64:
+            raise ValueError("ideal equations require CPU float64 inputs")
+        if not torch.isfinite(tensor).all():
+            raise ValueError("nonfinite oracle input")
+    flat = residual.flatten(1)
+    normalized = (flat @ fn.T) * torch.rsqrt(
+        flat.square().mean(-1, keepdim=True) + 1e-5
+    )
+    pre = torch.sigmoid(normalized[:, :4] * scale[0] + base[:4]) + 1e-6
+    post = torch.sigmoid(normalized[:, 4:8] * scale[1] + base[4:8]) * 2.0
+    logits = (normalized[:, 8:] * scale[2] + base[8:]).reshape(-1, 4, 4)
+    comb = torch.softmax(logits, dim=-1) + 1e-6
+    for iteration in range(20):
+        if iteration:
+            comb = comb / (comb.sum(-1, keepdim=True) + 1e-6)
+        comb = comb / (comb.sum(-2, keepdim=True) + 1e-6)
+    products = pre.unsqueeze(-1) * residual
+    layer_input = products.sum(1)
+    # Propagate the existing FP32 relative/absolute coefficient contract
+    # through the four-stream sum, plus its FP32 summation allowance. This is
+    # an acceptance budget, not a proof of every possible CUDA input's error.
+    allowance = (RTOL + GAMMA4) * products.abs().sum(1)
+    allowance += ATOL * residual.abs().sum(1)
+    return post, comb, layer_input, allowance
+
+
+def layer_accuracy(observed, ideal, allowance):
+    """BF16 error must not exceed optimal rounding error + FP32 budget."""
+    if (
+        observed.shape != ideal.shape
+        or observed.dtype != torch.bfloat16
+        or ideal.shape != allowance.shape
+        or ideal.dtype != torch.float64
+        or allowance.dtype != torch.float64
+        or any(t.device.type != "cpu" for t in (observed, ideal, allowance))
+    ):
+        raise ValueError("invalid layer-input oracle shapes, dtypes or devices")
+    if (
+        not all(torch.isfinite(t).all() for t in (observed, ideal, allowance))
+        or (allowance < 0).any()
+    ):
+        raise ValueError("nonfinite value or negative error budget")
+    rounded = direct_bf16_rne(ideal)
+    error = (observed.double() - ideal).abs()
+    optimal = (rounded.double() - ideal).abs()
+    excess = (error - optimal).clamp_min(0)
+    # Allow only FP64 comparison roundoff at the already-declared boundary.
+    comparison_slack = 8 * torch.finfo(torch.float64).eps * ideal.abs()
+    violations = excess > allowance + comparison_slack
+    return {
+        "elements": ideal.numel(),
+        "violations": int(violations.sum()),
+        "max_excess_over_budget": float((excess - allowance).clamp_min(0).max()),
+        "max_abs_error": float(error.max()),
+        "squared_error": float(error.square().sum()),
+        "ideal_squared_sum": float(ideal.square().sum()),
+        "optimal_squared_error": float(optimal.square().sum()),
+        "not_ideally_rounded": int(
+            (observed.view(torch.int16) != rounded.view(torch.int16)).sum()
+        ),
+    }
+
+
+def accuracy_pair(residual, fn, scale, base, reference, candidate, chunk_rows=256):
+    """Check every supplied row against one shared CPU FP64 calculation.
+
+    reference/candidate contain post, comb and BF16 layer_input, not residual.
+    Graph callers can supply a documented row selection; eager census callers
+    supply all rows. Chunking bounds memory, never subsamples hidden columns.
+    """
+    if chunk_rows < 1 or residual.dtype != torch.bfloat16 or fn.dtype != torch.bfloat16:
+        raise ValueError("positive chunk size and lossless BF16 values required")
+    if residual.ndim != 3 or not residual.shape[0]:
+        raise ValueError("nonempty three-dimensional residual required")
+    if scale.dtype != torch.float32 or base.dtype != torch.float32:
+        raise ValueError("native FP32 scale/base required")
+    batch = residual.shape[0]
+    shapes = [(batch, 4), (batch, 4, 4), (batch, 4096)]
+    for arm in (reference, candidate):
+        if len(arm) != 3:
+            raise ValueError("expected three output tensors")
+        for tensor, shape, dtype in zip(
+            arm, shapes, (torch.float32, torch.float32, torch.bfloat16)
+        ):
+            if tuple(tensor.shape) != shape or tensor.dtype != dtype:
+                raise ValueError("output shape or dtype changed")
+    w, s, b = (t.detach().cpu().double() for t in (fn, scale, base))
+    result = {
+        arm: {
+            "post_violations": 0,
+            "comb_violations": 0,
+            "post_max_abs_error": 0.0,
+            "comb_max_abs_error": 0.0,
+        }
+        for arm in ("reference", "candidate")
+    }
+    sum_keys = {
+        "elements",
+        "violations",
+        "squared_error",
+        "ideal_squared_sum",
+        "optimal_squared_error",
+        "not_ideally_rounded",
+    }
+    for first in range(0, batch, chunk_rows):
+        rows = slice(first, first + chunk_rows)
+        expected = ideal_outputs(residual[rows].detach().cpu().double(), w, s, b)
+        for name, outputs in (("reference", reference), ("candidate", candidate)):
+            stats = result[name]
+            for field, got, want in zip(("post", "comb"), outputs[:2], expected[:2]):
+                got = got[rows].detach().cpu().double()
+                if not torch.isfinite(got).all():
+                    raise ValueError(f"nonfinite {name} {field}")
+                error = (got - want).abs()
+                stats[field + "_violations"] += int(
+                    (error > RTOL * want.abs() + ATOL).sum()
+                )
+                stats[field + "_max_abs_error"] = max(
+                    stats[field + "_max_abs_error"], float(error.max())
+                )
+            layer = layer_accuracy(outputs[2][rows].detach().cpu(), *expected[2:])
+            for key, value in layer.items():
+                stats[key] = (
+                    stats.get(key, 0) + value
+                    if key in sum_keys
+                    else max(stats.get(key, 0), value)
+                )
+    for stats in result.values():
+        stats["normalized_rms"] = math.sqrt(
+            stats["squared_error"] / max(stats["ideal_squared_sum"], 1e-60)
+        )
+        stats["passed"] = not any(
+            stats[k] for k in ("post_violations", "comb_violations", "violations")
+        )
+    result["candidate_rms_noninferior"] = result["candidate"]["normalized_rms"] <= (
+        1.001 * result["reference"]["normalized_rms"] + 1e-7
+    )
+    result["passed"] = (
+        all(result[k]["passed"] for k in ("reference", "candidate"))
+        and result["candidate_rms_noninferior"]
+    )
+    result["rows"] = batch
+    return result

--- a/benchmarks/kernels/mhc_output_parallel.cuh
+++ b/benchmarks/kernels/mhc_output_parallel.cuh
@@ -1,0 +1,116 @@
+#pragma once
+// Isolated experimental mHC decode partials, outside the serving source tree.
+// Reuse the existing FP32 weights, FP32 post-mix expression/BF16 rounding,
+// cooperative synchronization and nonlinear tail. Each warp owns three of the
+// 24 outputs and traverses the complete split, replacing 25 warp reductions
+// per warp with three (plus the square sum in warp zero). This trades repeated
+// cached residual/post-mix work for fewer shuffles; it needs measured validation.
+#include "mhc_ampere.cuh"
+
+namespace tms::dsv4_mhc {
+
+template <bool FUSED_POST, int HIDDEN_SIZE, int NSPLITS>
+__device__ __forceinline__ void output_parallel_partials(
+    const __nv_bfloat16* x,
+    const __nv_bfloat16* residual,
+    const float* post_mix,
+    const float* comb_mix,
+    const float* fn,
+    __nv_bfloat16* residual_out,
+    float* partial,
+    int split,
+    int token) {
+    static_assert(THREADS == 256 && MIXES == 24);
+    static_assert((HC * HIDDEN_SIZE) % NSPLITS == 0);
+    constexpr int TOTAL = HC * HIDDEN_SIZE;
+    constexpr int FLATS = TOTAL / NSPLITS;
+    const int tid = threadIdx.x;
+    const int lane = tid & 31;
+    const int warp = tid >> 5;
+    __shared__ float coeffs[HC + HC * HC];
+    __shared__ float block_partials[MIXES + 1];
+    if constexpr (FUSED_POST) {
+        if (tid < HC) coeffs[tid] = post_mix[token * HC + tid];
+        if (tid < HC * HC) coeffs[HC + tid] = comb_mix[token * HC * HC + tid];
+        __syncthreads();
+    }
+
+    float accum[3] = {};
+    float square_sum = 0.0f;
+#pragma unroll
+    for (int local = lane; local < FLATS; local += 32) {
+        const int flat = split * FLATS + local;
+        float value;
+        if constexpr (FUSED_POST) {
+            const int stream = flat / HIDDEN_SIZE;
+            const int dim = flat % HIDDEN_SIZE;
+            value = coeffs[stream] * float(x[token * HIDDEN_SIZE + dim]);
+#pragma unroll
+            for (int input = 0; input < HC; ++input) {
+                value += coeffs[HC + input * HC + stream] *
+                         float(residual[(token * HC + input) * HIDDEN_SIZE + dim]);
+            }
+            const __nv_bfloat16 rounded = __float2bfloat16_rn(value);
+            if (warp == 0) residual_out[token * TOTAL + flat] = rounded;
+            value = float(rounded);
+        } else {
+            value = float(residual[token * TOTAL + flat]);
+        }
+#pragma unroll
+        for (int output = 0; output < 3; ++output) {
+            accum[output] += value * fn[(warp * 3 + output) * TOTAL + flat];
+        }
+        if (warp == 0) square_sum += value * value;
+    }
+#pragma unroll
+    for (int output = 0; output < 3; ++output) {
+        const float sum = warp_sum(accum[output]);
+        if (lane == 0) {
+            block_partials[warp * 3 + output] = sum;
+        }
+    }
+    if (warp == 0) {
+        square_sum = warp_sum(square_sum);
+        if (lane == 0) block_partials[MIXES] = square_sum;
+    }
+    __syncthreads();
+    // One coalesced warp store, instead of 25 lane-zero global stores.
+    if (tid < MIXES + 1) {
+        partial[(token * NSPLITS + split) * (MIXES + 1) + tid] = block_partials[tid];
+    }
+}
+
+template <bool FUSED_POST, bool RMS_NORM, int NSPLITS = 64>
+__global__ void fused_pre_transition_output_parallel(
+    const __nv_bfloat16* x,
+    const __nv_bfloat16* residual,
+    const float* post_mix,
+    const float* comb_mix,
+    const float* fn,
+    __nv_bfloat16* residual_out,
+    float* partial,
+    const float* scale,
+    const float* base,
+    float* next_post,
+    float* next_comb,
+    __nv_bfloat16* layer_input,
+    const __nv_bfloat16* norm_weight,
+    float rms_eps,
+    float pre_eps,
+    float sinkhorn_eps,
+    float post_multiplier,
+    int sinkhorn_repeat,
+    float norm_eps) {
+    const int split = blockIdx.x;
+    const int token = blockIdx.y;
+    output_parallel_partials<FUSED_POST, 4096, NSPLITS>(
+        x, residual, post_mix, comb_mix, fn, residual_out, partial, split, token);
+    cooperative_groups::this_grid().sync();
+    if (split != 0) return;
+    pre_transition_tail<FUSED_POST, RMS_NORM, 4096, NSPLITS>(
+        residual, residual_out, partial, scale, base, next_post, next_comb,
+        layer_input, norm_weight, rms_eps, pre_eps, sinkhorn_eps,
+        post_multiplier, sinkhorn_repeat, norm_eps, token);
+}
+
+}  // namespace tms::dsv4_mhc

--- a/benchmarks/kernels/mhc_output_parallel_probe.cu
+++ b/benchmarks/kernels/mhc_output_parallel_probe.cu
@@ -3,6 +3,7 @@
 #include <torch/extension.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
 #include "mhc_output_parallel.cuh"
 
 using torch::Tensor;
@@ -35,8 +36,10 @@ std::vector<Tensor> run_typed(
         ? fused_pre_transition_output_parallel<FUSED, NORM, 64>
         : fused_pre_transition<FUSED, NORM, 4096, 64, float>;
     int sms = 0, blocks = 0;
-    cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, residual.get_device());
-    cudaOccupancyMaxActiveBlocksPerMultiprocessor(&blocks, kernel, THREADS, 0);
+    C10_CUDA_CHECK(cudaDeviceGetAttribute(
+        &sms, cudaDevAttrMultiProcessorCount, residual.get_device()));
+    C10_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &blocks, kernel, THREADS, 0));
     TORCH_CHECK(T * 64 <= sms * blocks, "cooperative grid exceeds residency");
     void* args[] = {&xp, &rp, &pp, &cp, &fp, &rop, &parp, &sp, &basp,
                    &npp, &ncp, &op, &np, &rms_eps, &pre_eps, &sinkhorn_eps,

--- a/benchmarks/kernels/mhc_output_parallel_probe.cu
+++ b/benchmarks/kernels/mhc_output_parallel_probe.cu
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Isolated A/B wrapper. Does not replace or register serving operators.
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include "mhc_output_parallel.cuh"
+
+using torch::Tensor;
+using namespace tms::dsv4_mhc;
+
+template <bool FUSED, bool NORM>
+std::vector<Tensor> run_typed(
+    Tensor x, Tensor residual, Tensor post, Tensor comb, Tensor fn,
+    Tensor scale, Tensor base, Tensor norm, bool candidate) {
+    const int T = residual.size(0);
+    auto residual_out = FUSED ? torch::empty_like(residual) : residual;
+    auto partial = torch::empty({T, 64, 25}, fn.options());
+    auto next_post = torch::empty({T, 4}, fn.options());
+    auto next_comb = torch::empty({T, 4, 4}, fn.options());
+    auto out = torch::empty({T, 4096}, residual.options());
+    auto bp = [](Tensor t) { return reinterpret_cast<const __nv_bfloat16*>(t.data_ptr()); };
+    const __nv_bfloat16 *xp = bp(x), *rp = bp(residual), *np = bp(norm);
+    const float *pp = post.data_ptr<float>(), *cp = comb.data_ptr<float>(),
+                *fp = fn.data_ptr<float>(), *sp = scale.data_ptr<float>(),
+                *basp = base.data_ptr<float>();
+    auto rop = reinterpret_cast<__nv_bfloat16*>(residual_out.data_ptr());
+    auto op = reinterpret_cast<__nv_bfloat16*>(out.data_ptr());
+    float *parp = partial.data_ptr<float>(), *npp = next_post.data_ptr<float>(),
+          *ncp = next_comb.data_ptr<float>();
+    // Pinned GLM-5.3 settings, not the older three-iteration unit-test fixture.
+    float rms_eps = 1e-5f, pre_eps = 1e-6f, sinkhorn_eps = 1e-6f,
+          post_multiplier = 2.0f, norm_eps = 1e-5f;
+    int repeats = 20;
+    auto kernel = candidate
+        ? fused_pre_transition_output_parallel<FUSED, NORM, 64>
+        : fused_pre_transition<FUSED, NORM, 4096, 64, float>;
+    int sms = 0, blocks = 0;
+    cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, residual.get_device());
+    cudaOccupancyMaxActiveBlocksPerMultiprocessor(&blocks, kernel, THREADS, 0);
+    TORCH_CHECK(T * 64 <= sms * blocks, "cooperative grid exceeds residency");
+    void* args[] = {&xp, &rp, &pp, &cp, &fp, &rop, &parp, &sp, &basp,
+                   &npp, &ncp, &op, &np, &rms_eps, &pre_eps, &sinkhorn_eps,
+                   &post_multiplier, &repeats, &norm_eps};
+    const auto error = cudaLaunchCooperativeKernel(
+        reinterpret_cast<const void*>(kernel), dim3(64, T), dim3(THREADS),
+        args, 0, at::cuda::getCurrentCUDAStream());
+    TORCH_CHECK(error == cudaSuccess, cudaGetErrorString(error));
+    return {residual_out, next_post, next_comb, out};
+}
+
+std::vector<Tensor> run(
+    Tensor x, Tensor residual, Tensor post, Tensor comb, Tensor fn,
+    Tensor scale, Tensor base, Tensor norm, bool fused, bool with_norm,
+    bool candidate) {
+    TORCH_CHECK(residual.is_cuda() && residual.dim() == 3 &&
+                residual.size(0) >= 1 && residual.size(0) <= 8 &&
+                residual.size(1) == 4 && residual.size(2) == 4096,
+                "expected residual [1..8,4,4096]");
+    const c10::cuda::CUDAGuard guard(residual.device());
+    for (const auto& t : {x, residual, post, comb, fn, scale, base, norm}) {
+        TORCH_CHECK(t.device() == residual.device() && t.is_contiguous(),
+                    "all inputs must be contiguous and on the residual device");
+    }
+    for (const auto& t : {x, residual, norm})
+        TORCH_CHECK(t.scalar_type() == torch::kBFloat16, "expected BF16 input");
+    for (const auto& t : {post, comb, fn, scale, base})
+        TORCH_CHECK(t.scalar_type() == torch::kFloat32, "expected FP32 parameters");
+    const int T = residual.size(0);
+    TORCH_CHECK(x.sizes() == at::IntArrayRef({T, 4096}) &&
+                post.sizes() == at::IntArrayRef({T, 4}) &&
+                comb.sizes() == at::IntArrayRef({T, 4, 4}) &&
+                fn.sizes() == at::IntArrayRef({24, 16384}) &&
+                scale.numel() == 3 && base.numel() == 24 && norm.numel() == 4096,
+                "unexpected probe parameter shape");
+#define RUN(F, N) run_typed<F, N>(x, residual, post, comb, fn, scale, base, norm, candidate)
+    if (fused) {
+        if (with_norm) return RUN(true, true);
+        return RUN(true, false);
+    }
+    if (with_norm) return RUN(false, true);
+    return RUN(false, false);
+#undef RUN
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("run", &run);
+}

--- a/benchmarks/kernels/mhc_prefill_tc_probe.cu
+++ b/benchmarks/kernels/mhc_prefill_tc_probe.cu
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+// Isolated SM120 mHC prefill experiment; never registered as a serving op.
+// Same BF16 values and fused residual expression, but tensor-core FP32 dot
+// accumulation changes summation order. Requires an independent oracle.
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include "mhc_ampere.cuh"
+#include "bf16_decode_gemm.cuh"
+
+namespace mhc_tc_probe {
+using namespace tms::dsv4_mhc;
+using namespace tms::decode_gemm;
+using torch::Tensor;
+constexpr int H = 4096, FLATS = 512, ROW = 520, TILE = 32;
+constexpr int BYTES = (MIXES + TILE) * ROW * sizeof(__nv_bfloat16);
+static_assert(HC == 4 && SPLITS == 32 && MIXES == 24);
+static_assert(ROW % 8 == 0 && BYTES < 64 * 1024);
+
+template <bool FUSED>
+__global__ void __launch_bounds__(256) partials_tc(
+    const __nv_bfloat16* __restrict__ x,
+    const __nv_bfloat16* __restrict__ residual,
+    const float* __restrict__ post,
+    const float* __restrict__ comb,
+    const __nv_bfloat16* __restrict__ fn,
+    __nv_bfloat16* __restrict__ residual_out,
+    float* __restrict__ partial, int tokens) {
+    extern __shared__ __align__(16) unsigned char raw[];
+    auto* ft = reinterpret_cast<__nv_bfloat16*>(raw);
+    auto* vt = ft + MIXES * ROW;
+    const int split = blockIdx.x, first = blockIdx.y * TILE;
+    const int tid = threadIdx.x, lane = tid & 31, warp = tid >> 5;
+    const int dim_split = split * 128;
+
+    // Stage the original four stream slices without a persistent repack.
+    for (int vec = tid; vec < MIXES * FLATS / 8; vec += 256) {
+        const int output = vec / (FLATS / 8);
+        const int flat = (vec % (FLATS / 8)) * 8;
+        const int stream = flat / 128, dim = dim_split + flat % 128;
+        cp_async16(smem_u32(ft + output * ROW + flat),
+                   fn + output * (HC * H) + stream * H + dim, true);
+    }
+    cp_async_commit();
+
+    // The same vectorized fused post-mix expression/order as partials_prefill.
+    // Eight threads per token, two 8-wide chunks per thread/stream. Invalid
+    // token rows are explicitly zeroed because warp MMA reads full tiles.
+    const int t = tid >> 3, g = tid & 7, token = first + t;
+    auto* vr = vt + t * ROW;
+    if (token < tokens) {
+        if constexpr (FUSED) {
+            float pm[HC], cm[HC * HC];
+#pragma unroll
+            for (int i = 0; i < HC; ++i) pm[i] = post[token * HC + i];
+#pragma unroll
+            for (int i = 0; i < HC * HC; ++i) cm[i] = comb[token * HC * HC + i];
+#pragma unroll
+            for (int c = 0; c < 2; ++c) {
+                const int dim = dim_split + g * 16 + c * 8;
+                const uint4 xv = *reinterpret_cast<const uint4*>(x + size_t(token) * H + dim);
+                uint4 rv[HC];
+#pragma unroll
+                for (int i = 0; i < HC; ++i)
+                    rv[i] = *reinterpret_cast<const uint4*>(
+                        residual + (size_t(token) * HC + i) * H + dim);
+                const auto* xb = reinterpret_cast<const __nv_bfloat16*>(&xv);
+#pragma unroll
+                for (int out_stream = 0; out_stream < HC; ++out_stream) {
+                    __align__(16) __nv_bfloat16 rounded[8];
+#pragma unroll
+                    for (int j = 0; j < 8; ++j) {
+                        float value = pm[out_stream] * float(xb[j]);
+#pragma unroll
+                        for (int in_stream = 0; in_stream < HC; ++in_stream) {
+                            const auto* rb = reinterpret_cast<const __nv_bfloat16*>(&rv[in_stream]);
+                            value += cm[in_stream * HC + out_stream] * float(rb[j]);
+                        }
+                        rounded[j] = __float2bfloat16_rn(value);
+                    }
+                    *reinterpret_cast<uint4*>(
+                        residual_out + (size_t(token) * HC + out_stream) * H + dim) =
+                        *reinterpret_cast<const uint4*>(rounded);
+                    *reinterpret_cast<uint4*>(vr + out_stream * 128 + g * 16 + c * 8) =
+                        *reinterpret_cast<const uint4*>(rounded);
+                }
+            }
+        } else {
+#pragma unroll
+            for (int stream = 0; stream < HC; ++stream) {
+#pragma unroll
+                for (int c = 0; c < 2; ++c) {
+                    const int dim = dim_split + g * 16 + c * 8;
+                    *reinterpret_cast<uint4*>(vr + stream * 128 + g * 16 + c * 8) =
+                        *reinterpret_cast<const uint4*>(
+                            residual + (size_t(token) * HC + stream) * H + dim);
+                }
+            }
+        }
+    } else {
+#pragma unroll
+        for (int stream = 0; stream < HC; ++stream) {
+#pragma unroll
+            for (int c = 0; c < 2; ++c)
+                *reinterpret_cast<uint4*>(vr + stream * 128 + g * 16 + c * 8) =
+                    make_uint4(0, 0, 0, 0);
+        }
+    }
+    cp_async_wait<0>();
+    __syncthreads();
+
+    // Six warps cover 2 token tiles x 3 mix tiles. Use the proven BF16
+    // decode-GEMM fragment mapping; 520-element rows align every ldmatrix
+    // address to 16 bytes. The seventh warp preserves the old square-sum
+    // order; no BF16-rounded norm or approximate reduction is introduced.
+    if (warp < 6) {
+        const int m0 = (warp / 3) * 16, n0 = (warp % 3) * 8;
+        const int mat = lane >> 3, row = lane & 7;
+        float acc[4] = {};
+#pragma unroll 4
+        for (int k = 0; k < FLATS; k += 16) {
+            uint32_t a[4], b[2];
+            ldmatrix_x4(a, smem_u32(vt + (m0 + row + 8 * (mat & 1)) * ROW + k + 8 * (mat >> 1)));
+            ldmatrix_x2(b, smem_u32(ft + (n0 + row) * ROW + k + 8 * (mat & 1)));
+            mma_bf16_16816(acc, a, b[0], b[1]);
+        }
+        const int r0 = first + m0 + (lane >> 2), col = n0 + (lane & 3) * 2;
+        if (r0 < tokens) {
+            float* dst = partial + (size_t(r0) * SPLITS + split) * (MIXES + 1);
+            dst[col] = acc[0];
+            dst[col + 1] = acc[1];
+        }
+        if (r0 + 8 < tokens) {
+            float* dst = partial + (size_t(r0 + 8) * SPLITS + split) * (MIXES + 1);
+            dst[col] = acc[2];
+            dst[col + 1] = acc[3];
+        }
+    } else if (warp == 6) {
+        float sum = 0.0f;
+        const auto* src = vt + lane * ROW;
+#pragma unroll 8
+        for (int k = 0; k < FLATS; k += 2) {
+            const float2 v = __bfloat1622float2(
+                *reinterpret_cast<const __nv_bfloat162*>(src + k));
+            sum += v.x * v.x;
+            sum += v.y * v.y;
+        }
+        if (first + lane < tokens)
+            partial[(size_t(first + lane) * SPLITS + split) * (MIXES + 1) + MIXES] = sum;
+    }
+}
+
+template <bool FUSED>
+static std::vector<Tensor> run_typed(
+    Tensor x, Tensor residual, Tensor post, Tensor comb, Tensor fn,
+    Tensor scale, Tensor base, bool partial_only) {
+    const int tokens = residual.size(0);
+    auto fopt = fn.options().dtype(torch::kFloat32);
+    auto ro = FUSED ? torch::empty_like(residual) : residual;
+    auto partial = torch::empty({tokens, SPLITS, MIXES + 1}, fopt);
+    auto bp = [](Tensor t) { return reinterpret_cast<__nv_bfloat16*>(t.data_ptr()); };
+    const auto stream = at::cuda::getCurrentCUDAStream();
+    static thread_local int configured_device = -1;
+    if (configured_device != residual.get_device()) {
+        C10_CUDA_CHECK(cudaFuncSetAttribute(partials_tc<FUSED>,
+            cudaFuncAttributeMaxDynamicSharedMemorySize, BYTES));
+        configured_device = residual.get_device();
+    }
+    partials_tc<FUSED><<<dim3(SPLITS, (tokens + TILE - 1) / TILE), 256, BYTES, stream>>>(
+        bp(x), bp(residual), post.data_ptr<float>(), comb.data_ptr<float>(),
+        bp(fn), bp(ro), partial.data_ptr<float>(), tokens);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    if (partial_only) return {ro, partial};
+    auto next_post = torch::empty({tokens, HC}, fopt);
+    auto next_comb = torch::empty({tokens, HC, HC}, fopt);
+    auto out = torch::empty({tokens, H}, residual.options());
+    finalize_pre_mix<<<tokens, 32, 0, stream>>>(
+        partial.data_ptr<float>(), scale.data_ptr<float>(), base.data_ptr<float>(),
+        next_post.data_ptr<float>(), next_comb.data_ptr<float>(),
+        H, 1e-5f, 1e-6f, 1e-6f, 2.0f, 20);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    apply_pre_mix<MIXES + 1><<<dim3(H / 256, tokens), 256, 0, stream>>>(
+        partial.data_ptr<float>(), bp(ro), bp(out), H);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return {ro, next_post, next_comb, out};
+}
+
+static std::vector<Tensor> run(
+    Tensor x, Tensor residual, Tensor post, Tensor comb, Tensor fn,
+    Tensor scale, Tensor base, bool fused, bool partial_only) {
+    TORCH_CHECK(residual.is_cuda() && residual.dim() == 3 &&
+        residual.size(0) >= 64 && residual.size(0) <= 7616 &&
+        residual.size(1) == HC && residual.size(2) == H,
+        "expected residual [64..7616,4,4096]");
+    const c10::cuda::CUDAGuard guard(residual.device());
+    const auto* device = at::cuda::getDeviceProperties(residual.get_device());
+    TORCH_CHECK(device->major == 12 && device->minor == 0, "SM120 probe only");
+    for (const auto& t : {x, residual, post, comb, fn, scale, base})
+        TORCH_CHECK(t.device() == residual.device() && t.is_contiguous(),
+                    "all inputs must be contiguous on the same device");
+    for (const auto& t : {x, residual, fn})
+        TORCH_CHECK(t.scalar_type() == torch::kBFloat16 &&
+                    reinterpret_cast<uintptr_t>(t.data_ptr()) % 16 == 0,
+                    "expected 16-byte-aligned BF16 activations/fn");
+    for (const auto& t : {post, comb, scale, base})
+        TORCH_CHECK(t.scalar_type() == torch::kFloat32, "expected FP32 parameters");
+    const int tokens = residual.size(0);
+    TORCH_CHECK(x.sizes() == at::IntArrayRef({tokens, H}) &&
+        post.sizes() == at::IntArrayRef({tokens, HC}) &&
+        comb.sizes() == at::IntArrayRef({tokens, HC, HC}) &&
+        fn.sizes() == at::IntArrayRef({MIXES, HC * H}) &&
+        scale.numel() == 3 && base.numel() == MIXES, "invalid probe shapes");
+    if (fused) return run_typed<true>(x, residual, post, comb, fn, scale, base, partial_only);
+    return run_typed<false>(x, residual, post, comb, fn, scale, base, partial_only);
+}
+
+static pybind11::list resources() {
+    pybind11::list result;
+    for (bool fused : {false, true}) {
+        cudaFuncAttributes attr{};
+        C10_CUDA_CHECK(cudaFuncGetAttributes(&attr,
+            fused ? partials_tc<true> : partials_tc<false>));
+        pybind11::dict row;
+        row["fused"] = fused;
+        row["registers"] = attr.numRegs;
+        row["local_bytes"] = attr.localSizeBytes;
+        row["dynamic_shared_bytes"] = BYTES;
+        result.append(row);
+    }
+    return result;
+}
+}  // namespace mhc_tc_probe
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("run", &mhc_tc_probe::run, pybind11::arg("x"), pybind11::arg("residual"),
+        pybind11::arg("post"), pybind11::arg("comb"), pybind11::arg("fn"),
+        pybind11::arg("scale"), pybind11::arg("base"), pybind11::arg("fused"),
+        pybind11::arg("partial_only") = false);
+    m.def("resources", &mhc_tc_probe::resources);
+}

--- a/benchmarks/kernels/mhc_storage_probe.cu
+++ b/benchmarks/kernels/mhc_storage_probe.cu
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Same serving kernels with FP32 versus losslessly stored BF16 fn weights.
+// This isolated extension neither registers nor replaces serving operators.
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include "mhc_ampere.cuh"
+
+using torch::Tensor;
+using namespace tms::dsv4_mhc;
+
+template <bool FUSED, typename FnT, bool PAIRED_FN = false>
+std::vector<Tensor> run_typed(
+    Tensor x, Tensor residual, Tensor post, Tensor comb, Tensor fn,
+    Tensor scale, Tensor base) {
+    const int T = residual.size(0);
+    auto floats = fn.options().dtype(torch::kFloat32);
+    auto residual_out = FUSED ? torch::empty_like(residual) : residual;
+    auto partial = torch::empty({T, 64, 25}, floats);
+    auto next_post = torch::empty({T, 4}, floats);
+    auto next_comb = torch::empty({T, 4, 4}, floats);
+    auto out = torch::empty({T, 4096}, residual.options());
+    auto bp = [](Tensor t) { return reinterpret_cast<const __nv_bfloat16*>(t.data_ptr()); };
+    const __nv_bfloat16 *xp = bp(x), *rp = bp(residual), *np = nullptr;
+    const float *pp = post.data_ptr<float>(), *cp = comb.data_ptr<float>(),
+                *sp = scale.data_ptr<float>(), *basp = base.data_ptr<float>();
+    const FnT* fp = reinterpret_cast<const FnT*>(fn.data_ptr());
+    auto rop = reinterpret_cast<__nv_bfloat16*>(residual_out.data_ptr());
+    auto op = reinterpret_cast<__nv_bfloat16*>(out.data_ptr());
+    float *parp = partial.data_ptr<float>(), *npp = next_post.data_ptr<float>(),
+          *ncp = next_comb.data_ptr<float>();
+    float rms_eps = 1e-5f, pre_eps = 1e-6f, sinkhorn_eps = 1e-6f,
+          post_multiplier = 2.0f, norm_eps = 0.0f;
+    int repeats = 20;
+    const auto stream = at::cuda::getCurrentCUDAStream();
+    if (T <= 8) {
+        auto kernel = fused_pre_transition<FUSED, false, 4096, 64, FnT>;
+        int sms = 0, blocks = 0;
+        C10_CUDA_CHECK(cudaDeviceGetAttribute(
+            &sms, cudaDevAttrMultiProcessorCount, residual.get_device()));
+        C10_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+            &blocks, kernel, THREADS, 0));
+        TORCH_CHECK(T * 64 <= sms * blocks, "cooperative grid exceeds residency");
+        void* args[] = {&xp, &rp, &pp, &cp, &fp, &rop, &parp, &sp, &basp,
+                       &npp, &ncp, &op, &np, &rms_eps, &pre_eps, &sinkhorn_eps,
+                       &post_multiplier, &repeats, &norm_eps};
+        C10_CUDA_CHECK(cudaLaunchCooperativeKernel(
+            reinterpret_cast<const void*>(kernel), dim3(64, T), dim3(THREADS),
+            args, 0, stream));
+    } else {
+        if (T >= 64) {
+            auto kernel = partials_prefill<
+                FUSED, 4096, FnT, PAIRED_FN && std::is_same_v<FnT, __nv_bfloat16>>;
+            static const auto configured = cudaFuncSetAttribute(
+                kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, PREFILL_SMEM);
+            C10_CUDA_CHECK(configured);
+            kernel<<<dim3(SPLITS, (T + PREFILL_TILE - 1) / PREFILL_TILE),
+                     THREADS, PREFILL_SMEM, stream>>>(
+                xp, rp, pp, cp, fp, rop, parp, T);
+        } else {
+            partials<MIXES, FUSED, FnT><<<dim3(SPLITS, T), THREADS, 0, stream>>>(
+                xp, rp, pp, cp, fp, rop, parp, 4096);
+        }
+        finalize_pre_mix<<<T, 32, 0, stream>>>(
+            parp, sp, basp, npp, ncp, 4096, rms_eps, pre_eps, sinkhorn_eps,
+            post_multiplier, repeats);
+        apply_pre_mix<MIXES + 1><<<dim3(4096 / THREADS, T), THREADS, 0, stream>>>(
+            parp, FUSED ? rop : rp, op, 4096);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+    }
+    return {residual_out, next_post, next_comb, out};
+}
+
+template <bool PAIRED_FN>
+std::vector<Tensor> run(
+    Tensor x, Tensor residual, Tensor post, Tensor comb, Tensor fn,
+    Tensor scale, Tensor base, bool fused) {
+    TORCH_CHECK(residual.is_cuda() && residual.dim() == 3 &&
+                residual.size(0) >= 1 && residual.size(0) <= 7616 &&
+                residual.size(1) == 4 && residual.size(2) == 4096,
+                "expected residual [1..7616,4,4096]");
+    const c10::cuda::CUDAGuard guard(residual.device());
+    for (const auto& t : {x, residual, post, comb, fn, scale, base})
+        TORCH_CHECK(t.device() == residual.device() && t.is_contiguous(),
+                    "all inputs must be contiguous and on the residual device");
+    for (const auto& t : {x, residual})
+        TORCH_CHECK(t.scalar_type() == torch::kBFloat16, "expected BF16 activations");
+    for (const auto& t : {post, comb, scale, base})
+        TORCH_CHECK(t.scalar_type() == torch::kFloat32, "expected FP32 parameters");
+    TORCH_CHECK(fn.scalar_type() == torch::kFloat32 ||
+                fn.scalar_type() == torch::kBFloat16, "expected FP32 or BF16 fn");
+    if constexpr (PAIRED_FN) {
+        TORCH_CHECK(reinterpret_cast<uintptr_t>(fn.data_ptr()) % 4 == 0,
+                    "paired fn staging requires a four-byte-aligned allocation");
+    }
+    const int T = residual.size(0);
+    TORCH_CHECK(x.sizes() == at::IntArrayRef({T, 4096}) &&
+                post.sizes() == at::IntArrayRef({T, 4}) &&
+                comb.sizes() == at::IntArrayRef({T, 4, 4}) &&
+                fn.sizes() == at::IntArrayRef({24, 16384}) &&
+                scale.numel() == 3 && base.numel() == 24,
+                "unexpected probe parameter shape");
+#define RUN(F, TYPE) run_typed<F, TYPE, PAIRED_FN>(x, residual, post, comb, fn, scale, base)
+    if (fn.scalar_type() == torch::kBFloat16) {
+        if (fused) return RUN(true, __nv_bfloat16);
+        return RUN(false, __nv_bfloat16);
+    }
+    if (fused) return RUN(true, float);
+    return RUN(false, float);
+#undef RUN
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("run", &run<false>);
+    m.def("run_paired", &run<true>);
+}

--- a/benchmarks/kernels/mhc_storage_probe.cu
+++ b/benchmarks/kernels/mhc_storage_probe.cu
@@ -52,9 +52,13 @@ std::vector<Tensor> run_typed(
         if (T >= 64) {
             auto kernel = partials_prefill<
                 FUSED, 4096, FnT, PAIRED_FN && std::is_same_v<FnT, __nv_bfloat16>>;
-            static const auto configured = cudaFuncSetAttribute(
-                kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, PREFILL_SMEM);
-            C10_CUDA_CHECK(configured);
+            static thread_local int configured_device = -1;
+            const int device = residual.get_device();
+            if (configured_device != device) {
+                C10_CUDA_CHECK(cudaFuncSetAttribute(
+                    kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, PREFILL_SMEM));
+                configured_device = device;
+            }
             kernel<<<dim3(SPLITS, (T + PREFILL_TILE - 1) / PREFILL_TILE),
                      THREADS, PREFILL_SMEM, stream>>>(
                 xp, rp, pp, cp, fp, rop, parp, T);

--- a/benchmarks/kernels/nvfp4_decode_pipeline.cu
+++ b/benchmarks/kernels/nvfp4_decode_pipeline.cu
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Isolated Phase 4.1 binding. No installed serving library is modified.
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include "nvfp4_decode_sm120.cuh"
+
+namespace {
+using namespace tms::nvfp4_decode_sm120;
+
+template <bool PIPELINE, int K>
+void launch(torch::Tensor x, torch::Tensor w, torch::Tensor sc, torch::Tensor gs,
+            torch::Tensor eid, torch::Tensor rows, torch::Tensor counts,
+            torch::Tensor offsets, torch::Tensor out, int sms) {
+    using C = Cfg<16, 8, 512, 4>;
+    constexpr int shared = PIPELINE ? 4 * C::STAGE_BYTES + C::RED_BYTES : C::SMEM_BYTES;
+    static_assert(shared <= 48 * 1024);
+    const int slots = eid.numel(), n = w.size(1);
+    const int blocks = std::min(sms, slots * (n / 16));
+    nvfp4_moe_gemm_kernel<16, 8, 512, 4, PIPELINE, K>
+        <<<blocks, 256, shared, at::cuda::getCurrentCUDAStream()>>>(
+            reinterpret_cast<const __nv_bfloat16*>(x.data_ptr()),
+            w.data_ptr<uint8_t>(), reinterpret_cast<const uint8_t*>(sc.data_ptr()),
+            gs.data_ptr<float>(), eid.data_ptr<int>(), rows.data_ptr<int>(),
+            counts.data_ptr<int>(), offsets.data_ptr<int>(),
+            reinterpret_cast<__nv_bfloat16*>(out.data_ptr()), slots, n, K, 0);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+void run(torch::Tensor x, torch::Tensor w, torch::Tensor sc, torch::Tensor gs,
+         torch::Tensor eid, torch::Tensor rows, torch::Tensor counts,
+         torch::Tensor offsets, torch::Tensor out, bool pipeline) {
+    for (const auto& t : {x, w, sc, gs, eid, rows, counts, offsets, out}) {
+        TORCH_CHECK(t.is_cuda() && t.device() == x.device() && t.is_contiguous(),
+                    "contiguous tensors on one CUDA device required");
+    }
+    TORCH_CHECK(x.dim() == 2 && x.scalar_type() == torch::kBFloat16);
+    TORCH_CHECK(w.dim() == 3 && w.scalar_type() == torch::kUInt8);
+    TORCH_CHECK(sc.dim() == 3 && sc.scalar_type() == torch::kFloat8_e4m3fn);
+    const int k = x.size(1), n = w.size(1), slots = eid.numel();
+    TORCH_CHECK((k == 4096 && n == 1024) || (k == 512 && n == 4096));
+    TORCH_CHECK(slots == 8 && w.size(0) == 8 && w.size(2) == k / 2);
+    TORCH_CHECK(sc.size(0) == 8 && sc.size(1) == n && sc.size(2) == k / 16);
+    TORCH_CHECK(gs.scalar_type() == torch::kFloat32 && gs.numel() == 8);
+    for (const auto& t : {eid, rows, counts, offsets})
+        TORCH_CHECK(t.scalar_type() == torch::kInt32);
+    TORCH_CHECK(eid.dim() == 1 && rows.sizes() == torch::IntArrayRef({8, 16}));
+    TORCH_CHECK(counts.numel() == 8 && offsets.numel() == 8);
+    TORCH_CHECK(out.scalar_type() == torch::kBFloat16 && out.sizes() == torch::IntArrayRef({8, n}));
+    // The benchmark constructs and checks one valid row per slot, row indices
+    // 0 for gate/up or 0..7 for down, with offsets/eids 0..7. No device->host
+    // inspection is performed in this graph-captured diagnostic binding.
+    TORCH_CHECK(x.size(0) == (k == 4096 ? 1 : 8));
+    const c10::cuda::CUDAGuard guard(x.device());
+    int sms = 0, major = 0, minor = 0;
+    C10_CUDA_CHECK(cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, x.get_device()));
+    C10_CUDA_CHECK(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, x.get_device()));
+    C10_CUDA_CHECK(cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, x.get_device()));
+    TORCH_CHECK(major == 12 && minor == 0, "SM120 only");
+    if (k == 4096) {
+        if (pipeline) launch<true, 4096>(x, w, sc, gs, eid, rows, counts, offsets, out, sms);
+        else launch<false, 4096>(x, w, sc, gs, eid, rows, counts, offsets, out, sms);
+    } else {
+        if (pipeline) launch<true, 512>(x, w, sc, gs, eid, rows, counts, offsets, out, sms);
+        else launch<false, 512>(x, w, sc, gs, eid, rows, counts, offsets, out, sms);
+    }
+}
+}  // namespace
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) { m.def("run", &run); }

--- a/benchmarks/kernels/nvfp4_decode_sm120.cuh
+++ b/benchmarks/kernels/nvfp4_decode_sm120.cuh
@@ -1,0 +1,238 @@
+#pragma once
+// SPDX-License-Identifier: Apache-2.0
+// Phase 4.1 rejected diagnostic: cross-item staging improves this prototype
+// but loses to retained Marlin. No serving dispatcher selects it.
+// Derived from the recorded 2026-09-08 planar NVFP4 prototype. Fixed NT16,
+// WARPS8, K512, stages4. PIPELINE keeps its ring alive between grid-stride
+// items and separates reduction scratch; false is the draining control.
+// No precision, quant or repack change between those two implementations.
+// Prototype: decode-shaped NVFP4 expert GEMM on tensor cores, M <= 16 rows per expert, weights in the
+// checkpoint's planar layout (no repack): w [E, N, K/2] uint8 (two e2m1 per byte, low nibble = even k),
+// scale [E, N, K/16] e4m3 (one per 16-wide group), gscale [E] fp32. Work item = (expert slot, NT rows);
+// blocks walk work items grid-stride (persistent when the grid is smaller than the item count). The rows
+// of an expert are gathered from x by a per-slot token list; only valid rows are loaded (rows >= M hold
+// stale smem and their mma rows are never stored). Same cp.async / ldmatrix / mma pipeline as
+// csrc/quixicore/serving/fp8_decode_gemm.cuh; a k16 mma step covers exactly one scale group, so the B
+// fragment is dequantised as bf16(scale * e2m1) from one byte pair per lane.
+//   out[pair0[s] + i, n] = bf16(gscale[e] * sum_k x[rows[s][i], k] * scale[e, n, k/16] * w[e, n, k])
+#include <cuda_fp16.h>
+#include "quixicore/serving/bf16_decode_gemm.cuh"
+
+namespace tms::nvfp4_decode_sm120 {
+using tms::decode_gemm::MT;
+using tms::decode_gemm::smem_u32;
+using tms::decode_gemm::cp_async16;
+using tms::decode_gemm::cp_async_commit;
+using tms::decode_gemm::cp_async_wait;
+using tms::decode_gemm::mma_bf16_16816;
+
+constexpr int G = 16;        // scale group along k
+constexpr int WPAD = 16;     // bytes of padding per packed weight row in smem
+constexpr int SPAD = 16;     // bytes of padding per scale row in smem
+
+// Bit-level dequant (the Marlin e2m1 trick). Weight words are layout-only repacked so that lane q of an
+// n8 tile reads one 32-bit word per k32 segment holding its eight nibbles: bits [15:12] k=2q, [31:28] 2q+1,
+// [11:8] 2q+8, [27:24] 2q+9, [7:4] 16+2q, [23:20] 17+2q, [3:0] 24+2q, [19:16] 25+2q. Placing a nibble's
+// (e1 e0 m) at bf16 bits [8:6] and its sign at bit 15 gives raw = true * 2^-126 exactly (e = 0 lands on the
+// bf16 subnormal m/2 * 2^-126). The e4m3 group scale is turned into bf16 with its exponent field offset by
+// SBIAS so that raw * s' = true * s * 2^-8 (normal bf16, exact: <= 7 significant bits); the epilogue
+// multiplies by gscale * 2^8. Marlin relies on the same subnormal-raw times bf16-scale product.
+constexpr int SBIAS = 238;   // bf16 exponent field = e4m3 exponent + 238: s' = s * 2^(238 - 120)
+constexpr float EPI = 256.0f;
+__device__ __forceinline__ uint32_t e2m1x2_raw_bf16x2(uint32_t q) {   // nibbles at [15:12] and [31:28]
+    return (q & 0x80008000u) | ((q & 0x70007000u) >> 6);
+}
+__device__ __forceinline__ uint32_t e4m3_scale_bf16x2(uint32_t b) {   // one e4m3 byte -> broadcast bf16x2
+    uint32_t h = ((b & 0x80u) << 8) | (((b & 0x7Fu) << 4) + (uint32_t(SBIAS) << 7));
+    // The exponent-offset shortcut only applies to normal E4M3 scales.
+    // Subnormal scales are mantissa * 2^-9, then biased by 2^118.
+    if ((b & 0x78u) == 0) {
+        float value = float(b & 7u) * 0x1p109f;
+        if (b & 0x80u) value = -value;
+        h = __bfloat16_as_ushort(__float2bfloat16_rn(value));
+    }
+    return h | (h << 16);
+}
+__device__ __forceinline__ uint32_t hmul2_bf16(uint32_t a, uint32_t b) {
+    uint32_t d;
+    asm("mul.rn.bf16x2 %0, %1, %2;\n" : "=r"(d) : "r"(a), "r"(b));
+    return d;
+}
+
+template <int NT, int WARPS, int KCHUNK, int STAGES>
+struct Cfg {
+    static constexpr int THREADS = WARPS * 32;
+    static constexpr int WROW = KCHUNK / 2 + WPAD;         // bytes
+    static constexpr int W_BYTES = NT * WROW;
+    static constexpr int SROW = KCHUNK / G + SPAD;         // bytes
+    static constexpr int S_BYTES = NT * SROW;
+    static constexpr int STAGE_BYTES = W_BYTES + S_BYTES;
+    static constexpr int RED_BYTES = WARPS * MT * NT * 4;
+    static constexpr int SMEM_BYTES = STAGES * STAGE_BYTES > RED_BYTES ? STAGES * STAGE_BYTES : RED_BYTES;
+    static constexpr int KSTEPS = KCHUNK / 32;             // k32 segments per chunk (two mma k-steps each)
+    static constexpr int NTILES = NT / 8;
+    static constexpr int WVEC = KCHUNK / 32;               // 16-byte vectors per packed weight row per chunk
+    static constexpr int SVEC = KCHUNK / 256;              // 16-byte vectors per scale row per chunk
+    static_assert(KCHUNK % 256 == 0, "scale rows load in 16-byte vectors");
+    static_assert(KSTEPS % WARPS == 0, "warps split the k32 segments of a chunk evenly");
+    static_assert(NT % 8 == 0 && STAGES >= 2, "n8 tiles, double buffering at least");
+    static_assert(STAGE_BYTES % 16 == 0 && WROW % 16 == 0 && SROW % 16 == 0, "16-byte aligned");
+};
+
+template <int NT, int WARPS, int KCHUNK, int STAGES, bool PIPELINE, int FIXED_K>
+__global__ void __launch_bounds__(WARPS * 32) nvfp4_moe_gemm_kernel(
+        const __nv_bfloat16* __restrict__ x,      // [T, K]
+        const uint8_t* __restrict__ w,            // [E, N, K/2]
+        const uint8_t* __restrict__ sc,           // [E, N, K/16] e4m3
+        const float* __restrict__ gs,             // [E]
+        const int* __restrict__ eid,              // [S]
+        const int* __restrict__ rows,             // [S, MT] token index or -1
+        const int* __restrict__ cnt,              // [S]
+        const int* __restrict__ pair0,            // [S]
+        __nv_bfloat16* __restrict__ out,          // [P, N]
+        int S, int N, int unused_k, int mode) {
+    constexpr int K = FIXED_K;           // mode 1: stream only (no mma)
+    using C = Cfg<NT, WARPS, KCHUNK, STAGES>;
+    extern __shared__ __align__(16) unsigned char smem_raw[];
+    const int tid = threadIdx.x, lane = tid & 31, warp = tid >> 5;
+    const int ntiles_n = (N + NT - 1) / NT;
+    const int total = ntiles_n * S;
+    const int nchunks = K / KCHUNK;
+    const int bn = lane >> 2, bq = lane & 3;   // B fragment: row bn of each n8 tile; k pairs (2bq, 2bq+1) and (+8)
+
+    auto stage_w = [&](int s) { return smem_raw + s * C::STAGE_BYTES; };
+    auto stage_s = [&](int s) { return smem_raw + s * C::STAGE_BYTES + C::W_BYTES; };
+    // A fragments come straight from x (L2-resident): lane holds rows r0 and r0+8 of the mma tile.
+    const int r0 = lane >> 2, q2 = (lane & 3) * 2;
+
+    int timeline = 0;
+    for (int item = blockIdx.x; item < total; item += gridDim.x, timeline += nchunks) {
+        const int slot = item / ntiles_n;
+        const int n0 = (item - slot * ntiles_n) * NT;
+        const int e = eid[slot];
+        const int M = cnt[slot];
+        const int* rowlist = rows + slot * MT;
+        const __nv_bfloat16* xa = r0 < M ? x + size_t(rowlist[r0]) * K + q2 : nullptr;
+        const __nv_bfloat16* xb = r0 + 8 < M ? x + size_t(rowlist[r0 + 8]) * K + q2 : nullptr;
+
+        auto load_chunk = [&](int c, int s) {
+            int target_n = n0, target_e = e;
+            if constexpr (PIPELINE) {
+                // c may reach a later grid-stride item. Keep issuing through
+                // expert boundaries without waiting for this item's epilogue.
+                const int target = item + (c / nchunks) * gridDim.x;
+                if (target >= total) return;
+                const int target_slot = target / ntiles_n;
+                target_n = (target - target_slot * ntiles_n) * NT;
+                target_e = eid[target_slot];
+                c %= nchunks;
+            }
+            const int k0 = c * KCHUNK;
+            const uint8_t* we = w + size_t(target_e) * N * (K / 2);
+            const uint8_t* se = sc + size_t(target_e) * N * (K / G);
+            unsigned char* ws = stage_w(s);
+            unsigned char* ss = stage_s(s);
+            for (int i = tid; i < NT * C::WVEC; i += C::THREADS) {
+                const int r = i / C::WVEC, v = i - r * C::WVEC;
+                const int n = min(target_n + r, N - 1);
+                cp_async16(smem_u32(ws + r * C::WROW + v * 16),
+                           we + size_t(n) * (K / 2) + k0 / 2 + v * 16, true);
+            }
+            for (int i = tid; i < NT * C::SVEC; i += C::THREADS) {
+                const int r = i / C::SVEC, v = i - r * C::SVEC;
+                const int n = min(target_n + r, N - 1);
+                cp_async16(smem_u32(ss + r * C::SROW + v * 16),
+                           se + size_t(n) * (K / G) + k0 / G + v * 16, true);
+            }
+        };
+
+        float acc[C::NTILES][4];
+#pragma unroll
+        for (int j = 0; j < C::NTILES; ++j)
+#pragma unroll
+            for (int q = 0; q < 4; ++q) acc[j][q] = 0.0f;
+
+        if (!PIPELINE || timeline == 0) {
+#pragma unroll
+            for (int c = 0; c < STAGES - 1; ++c) {
+                if (PIPELINE || c < nchunks) load_chunk(c, c);
+                cp_async_commit();
+            }
+        }
+
+        for (int c = 0; c < nchunks; ++c) {
+            cp_async_wait<STAGES - 2>();
+            __syncthreads();
+            {
+                const int cn = c + STAGES - 1;
+                if (PIPELINE || cn < nchunks)
+                    load_chunk(cn, (PIPELINE ? timeline + cn : cn) % STAGES);
+                cp_async_commit();
+            }
+            const int s = (PIPELINE ? timeline + c : c) % STAGES;
+            const unsigned char* ws = stage_w(s);
+            const unsigned char* ss = stage_s(s);
+            const int kc0 = c * KCHUNK;
+            if (mode == 1) continue;
+#pragma unroll
+            for (int step = warp; step < C::KSTEPS; step += WARPS) {
+                const int k0 = step * 32;
+                uint32_t a0[4], a1[4];
+                a0[0] = xa ? __ldg(reinterpret_cast<const unsigned int*>(xa + kc0 + k0)) : 0u;
+                a0[1] = xb ? __ldg(reinterpret_cast<const unsigned int*>(xb + kc0 + k0)) : 0u;
+                a0[2] = xa ? __ldg(reinterpret_cast<const unsigned int*>(xa + kc0 + k0 + 8)) : 0u;
+                a0[3] = xb ? __ldg(reinterpret_cast<const unsigned int*>(xb + kc0 + k0 + 8)) : 0u;
+                a1[0] = xa ? __ldg(reinterpret_cast<const unsigned int*>(xa + kc0 + k0 + 16)) : 0u;
+                a1[1] = xb ? __ldg(reinterpret_cast<const unsigned int*>(xb + kc0 + k0 + 16)) : 0u;
+                a1[2] = xa ? __ldg(reinterpret_cast<const unsigned int*>(xa + kc0 + k0 + 24)) : 0u;
+                a1[3] = xb ? __ldg(reinterpret_cast<const unsigned int*>(xb + kc0 + k0 + 24)) : 0u;
+#pragma unroll
+                for (int j = 0; j < C::NTILES; ++j) {
+                    const int r = 8 * j + bn;
+                    uint32_t q = *reinterpret_cast<const uint32_t*>(ws + r * C::WROW + step * 16 + bq * 4);
+                    const uint32_t sv = *reinterpret_cast<const uint16_t*>(ss + r * C::SROW + step * 2);
+                    const uint32_t s0 = e4m3_scale_bf16x2(sv & 0xFFu), s1 = e4m3_scale_bf16x2(sv >> 8);
+                    const uint32_t b00 = hmul2_bf16(e2m1x2_raw_bf16x2(q), s0);
+                    const uint32_t b01 = hmul2_bf16(e2m1x2_raw_bf16x2(q << 4), s0);
+                    const uint32_t b10 = hmul2_bf16(e2m1x2_raw_bf16x2(q << 8), s1);
+                    const uint32_t b11 = hmul2_bf16(e2m1x2_raw_bf16x2(q << 12), s1);
+                    mma_bf16_16816(acc[j], a0, b00, b01);
+                    mma_bf16_16816(acc[j], a1, b10, b11);
+                }
+            }
+        }
+
+        if constexpr (!PIPELINE) cp_async_wait<0>();
+        __syncthreads();
+        // Live prefetched weight tiles must never alias reduction scratch.
+        float* red = reinterpret_cast<float*>(
+            smem_raw + (PIPELINE ? STAGES * C::STAGE_BYTES : 0));
+        {
+            float* mine = red + warp * (MT * NT);
+            const int r0 = lane >> 2, cc = (lane & 3) * 2;
+#pragma unroll
+            for (int j = 0; j < C::NTILES; ++j) {
+                const int n = 8 * j + cc;
+                mine[r0 * NT + n] = acc[j][0];
+                mine[r0 * NT + n + 1] = acc[j][1];
+                mine[(r0 + 8) * NT + n] = acc[j][2];
+                mine[(r0 + 8) * NT + n + 1] = acc[j][3];
+            }
+        }
+        __syncthreads();
+        const float g = gs[e] * EPI;
+        const int p0 = pair0[slot];
+        for (int i = tid; i < M * NT; i += C::THREADS) {
+            const int m = i / NT, n = i - m * NT;
+            if (n0 + n >= N) continue;
+            float v = 0.0f;
+#pragma unroll
+            for (int wv = 0; wv < WARPS; ++wv) v += red[wv * (MT * NT) + m * NT + n];
+            out[size_t(p0 + m) * N + n0 + n] = __float2bfloat16_rn(v * g);
+        }
+        __syncthreads();  // Finish reduction reads before its next use.
+    }
+    cp_async_wait<0>();
+    __syncthreads();
+}
+}  // namespace tms::nvfp4_decode_sm120

--- a/benchmarks/kernels/profile_glm53_marlin.py
+++ b/benchmarks/kernels/profile_glm53_marlin.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Isolated Marlin counter probe with actual GLM53 weights and captured routes.
+
+Not an end-to-end benchmark. Activations and router weights are synthetic;
+expert IDs, checkpoint bytes, TP4 rank-local shapes and Marlin preparation are
+real. Profile only CUDA-profiler start/stop regions, with clock control disabled.
+Cold-cache counters do not represent all overlap/cache behavior in serving.
+"""
+
+import argparse
+import hashlib
+import json
+import subprocess
+from contextlib import ExitStack
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+from safetensors import safe_open
+
+
+def route_cases(path, batches, count):
+    rows = {batch: [] for batch in batches}
+    header = None
+    with path.open() as stream:
+        for line in stream:
+            row = json.loads(line)
+            if row["kind"] == "header":
+                header = row
+            elif row["kind"] == "invalid":
+                raise ValueError("journal contains an invalid capture")
+            elif row["kind"] == "decode" and len(row["request_ids"]) in rows:
+                rows[len(row["request_ids"])].append(row)
+    if header is None or (
+        header["num_layers"],
+        header["first_moe_layer"],
+        header["num_experts"],
+        header["top_k"],
+    ) != (45, 3, 288, 8):
+        raise ValueError("expected the GLM53 target routing journal")
+    selected = []
+    for batch in batches:
+        if len(rows[batch]) < count:
+            raise ValueError(f"insufficient batch-{batch} observations")
+        indices = (
+            [len(rows[batch]) // 2]
+            if count == 1
+            else [i * (len(rows[batch]) - 1) // (count - 1) for i in range(count)]
+        )
+        selected.extend((batch, rows[batch][i]) for i in indices)
+    return selected
+
+
+def load_layer(model, layer_id, rank, *, gate_up_tile=0):
+    """Use checkpoint planar bytes, then the SAME Marlin load-time conversion."""
+    from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
+        prepare_nvfp4_moe_layer_for_marlin,
+    )
+
+    index = json.loads((model / "model.safetensors.index.json").read_text())[
+        "weight_map"
+    ]
+    collected = {kind: [] for kind in ("w13", "s13", "g13", "w2", "s2", "g2")}
+    with ExitStack() as stack:
+        shards = {}
+
+        def tensor(key):
+            filename = index[key]
+            if filename not in shards:
+                shards[filename] = stack.enter_context(
+                    safe_open(model / filename, framework="pt", device="cpu")
+                )
+            return shards[filename].get_tensor(key)
+
+        for expert in range(288):
+            prefix = f"model.language_model.layers.{layer_id}.mlp.experts.{expert}."
+            gate = prefix + "gate_proj."
+            up = prefix + "up_proj."
+            down = prefix + "down_proj."
+            row = slice(rank * 512, (rank + 1) * 512)
+            wg, wu = tensor(gate + "weight_packed"), tensor(up + "weight_packed")
+            wd = tensor(down + "weight_packed")
+            if (
+                wg.shape != (2048, 2048)
+                or wu.shape != wg.shape
+                or wd.shape != (4096, 1024)
+            ):
+                raise ValueError("unexpected checkpoint expert dimensions")
+            collected["w13"].append(torch.cat([wg[row], wu[row]]))
+            collected["s13"].append(
+                torch.cat(
+                    [
+                        tensor(gate + "weight_scale")[row],
+                        tensor(up + "weight_scale")[row],
+                    ]
+                )
+            )
+            gg, gu = (
+                tensor(gate + "weight_global_scale"),
+                tensor(up + "weight_global_scale"),
+            )
+            if not torch.equal(gg, gu):
+                raise ValueError(
+                    "gate/up global scales differ; do not approximate the loader"
+                )
+            collected["g13"].append((1.0 / gg.float()).reshape(()))
+            collected["w2"].append(wd[:, rank * 256 : (rank + 1) * 256].contiguous())
+            collected["s2"].append(
+                tensor(down + "weight_scale")[
+                    :, rank * 32 : (rank + 1) * 32
+                ].contiguous()
+            )
+            collected["g2"].append(
+                (1.0 / tensor(down + "weight_global_scale").float()).reshape(())
+            )
+        raw = {key: torch.stack(value) for key, value in collected.items()}
+    identity = {
+        key: {
+            "shape": list(t.shape),
+            "dtype": str(t.dtype),
+            "sha256": hashlib.sha256(t.view(torch.uint8).numpy().tobytes()).hexdigest(),
+        }
+        for key, t in raw.items()
+    }
+    if gate_up_tile:
+        # Diagnostic layout-only gate/up pairing for a fused Marlin epilogue.
+        # Hashes above remain the original checkpoint bytes, not reordered data.
+        if gate_up_tile != 64:
+            raise ValueError("paired decode probe uses one fixed N64 tile")
+        order = torch.arange(1024).view(2, 16, 32).transpose(0, 1).reshape(-1)
+        for key in ("w13", "s13"):
+            raw[key] = (
+                raw[key].view(torch.uint8)[:, order].contiguous().view(raw[key].dtype)
+            )
+    device = {key: t.cuda() for key, t in raw.items()}
+    layer = SimpleNamespace(
+        num_experts=288,
+        hidden_size=4096,
+        intermediate_size_per_partition=512,
+        params_dtype=torch.bfloat16,
+    )
+    w13, s13, g13, w2, s2, g2 = prepare_nvfp4_moe_layer_for_marlin(
+        layer,
+        device["w13"],
+        device["s13"],
+        device["g13"],
+        device["w2"],
+        device["s2"],
+        device["g2"],
+        True,
+    )
+    return (w13, s13, g13, w2, s2, g2, layer.workspace), identity
+
+
+def run_case(weights, batch, record, layer_id):
+    from vllm.model_executor.layers.fused_moe.experts.marlin_moe import (
+        _fused_marlin_moe,
+    )
+    from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
+        moe_align_block_size,
+    )
+    from vllm.scalar_type import scalar_types
+
+    ids = torch.tensor(
+        [r[layer_id - 3] for r in record["routes"]], device="cuda", dtype=torch.int32
+    )
+    if ids.shape != (batch, 8) or ids.min() < 0 or ids.max() >= 288:
+        raise ValueError("invalid selected routing dimensions or expert IDs")
+    ordered = ids.sort(-1).values
+    if (ordered[:, 1:] == ordered[:, :-1]).any():
+        raise ValueError("duplicate selected expert IDs")
+    sorted_ids, expert_ids, padded = moe_align_block_size(ids, 8, 288)
+    x = torch.randn(batch, 4096, device="cuda", dtype=torch.bfloat16)
+    routing_weights = torch.full(
+        (batch, 8), 2.5 / 8, device="cuda", dtype=torch.float32
+    )
+    w13, s13, g13, w2, s2, g2, workspace = weights
+
+    def call():
+        return _fused_marlin_moe(
+            x,
+            w13,
+            w2,
+            None,
+            None,
+            s13,
+            s2,
+            routing_weights,
+            8,
+            scalar_types.float4_e2m1f,
+            False,
+            None,
+            8,
+            sorted_ids,
+            expert_ids,
+            padded,
+            topk_ids=ids,
+            global_scale1=g13,
+            global_scale2=g2,
+            workspace=workspace,
+            clamp_limit=10.0,
+        )
+
+    for _ in range(3):
+        eager = call()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = call()
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(captured, eager, rtol=0.01, atol=0.01)
+    if not torch.isfinite(captured).all():
+        raise ValueError("nonfinite isolated Marlin output")
+    label = f"layer{layer_id}-batch{batch}-step{record['step']}"
+    torch.cuda.nvtx.range_push(label)
+    torch.cuda.profiler.start()
+    measured = call()
+    torch.cuda.synchronize()
+    torch.cuda.profiler.stop()
+    torch.cuda.nvtx.range_pop()
+    torch.testing.assert_close(measured, eager, rtol=0.01, atol=0.01)
+    return {
+        "label": label,
+        "layer": layer_id,
+        "batch": batch,
+        "step": record["step"],
+        "expert_ids": ids.cpu().tolist(),
+        "unique_experts": ids.unique().numel(),
+        "padded_rows": padded.item(),
+        "request_ids": record["request_ids"],
+        "computed_tokens": record["computed_tokens"],
+        "finite": True,
+        "eager_graph_max_abs": (captured.float() - eager.float()).abs().max().item(),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--journal", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--layers", type=int, nargs="+", default=[3, 23, 44])
+    parser.add_argument("--batch", type=int, nargs="+", default=[1, 8, 16])
+    parser.add_argument("--cases-per-batch", type=int, default=1)
+    parser.add_argument("--rank", type=int, default=0)
+    args = parser.parse_args()
+    if args.output.exists() or not 0 <= args.rank < 4 or args.cases_per_batch < 1:
+        parser.error("output must be new; rank 0..3; cases per batch positive")
+    if any(not 3 <= layer <= 44 for layer in args.layers) or any(
+        not 1 <= b <= 16 for b in args.batch
+    ):
+        parser.error("only target MoE layers 3..44 and batches 1..16")
+    active = subprocess.check_output(
+        ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"], text=True
+    ).strip()
+    if active:
+        parser.error(f"GPUs already have compute processes: {active}")
+    cases = route_cases(args.journal, args.batch, args.cases_per_batch)
+    result = {
+        "status": "running",
+        "diagnostic_only": True,
+        "git": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "torch": torch.__version__,
+        "gpu": torch.cuda.get_device_name(),
+        "settings": {
+            k: str(v) if isinstance(v, Path) else v for k, v in vars(args).items()
+        },
+        "source_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        "journal_sha256": hashlib.sha256(args.journal.read_bytes()).hexdigest(),
+        "checkpoint_index_sha256": hashlib.sha256(
+            (args.model / "model.safetensors.index.json").read_bytes()
+        ).hexdigest(),
+        "layers": {},
+        "cases": [],
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("x") as stream:
+        json.dump(result, stream, indent=2)
+
+    def save():
+        args.output.write_text(json.dumps(result, indent=2) + "\n")
+
+    try:
+        torch.manual_seed(103)
+        for layer in args.layers:
+            weights, identity = load_layer(args.model, layer, args.rank)
+            result["layers"][layer] = identity
+            save()
+            for batch, record in cases:
+                row = run_case(weights, batch, record, layer)
+                result["cases"].append(row)
+                save()
+                print(json.dumps(row), flush=True)
+            del weights
+        result["status"] = "complete"
+    except Exception as error:
+        result["status"] = "failed"
+        result["error"] = repr(error)
+        save()
+        raise
+    save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/repro_marlin_shared_boundary.py
+++ b/benchmarks/kernels/repro_marlin_shared_boundary.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Isolate Marlin shared-memory phase boundaries without replacing serving.
+
+Builds two actual NVFP4/BF16 M8 templates from this repository's header, with
+line information. The optional barriers alter only the isolated source copy.
+Use racecheck --kernel-name kns=marlin_shared_probe to skip checkpoint repacks
+and the separately checked installed-library reference calls.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.benchmark_glm53_marlin_schedule import prepare_case
+from benchmarks.kernels.profile_glm53_marlin import load_layer, route_cases
+
+DECL = """void run(at::Tensor a, at::Tensor out, at::Tensor weight,
+at::Tensor scales, at::Tensor global_scale, at::Tensor workspace,
+at::Tensor sorted_ids, at::Tensor experts, at::Tensor padded,
+at::Tensor routing_weights, int top_k, bool weighted, int thread_k,
+int thread_n, int blocks_per_sm);"""
+
+WRAPPER = r"""
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+
+void run(at::Tensor a, at::Tensor out, at::Tensor weight,
+         at::Tensor scales, at::Tensor global_scale, at::Tensor workspace,
+         at::Tensor sorted_ids, at::Tensor experts, at::Tensor padded,
+         at::Tensor routing_weights, int top_k, bool weighted, int thread_k,
+         int thread_n, int blocks_per_sm) {
+  TORCH_CHECK(a.is_cuda() && a.scalar_type() == at::kBFloat16 && a.is_contiguous());
+  TORCH_CHECK(out.is_cuda() && out.scalar_type() == at::kBFloat16 &&
+              out.is_contiguous());
+  TORCH_CHECK(weight.is_contiguous() && scales.is_contiguous());
+  TORCH_CHECK(scales.scalar_type() == at::kFloat8_e4m3fn);
+  TORCH_CHECK(global_scale.scalar_type() == at::kFloat &&
+              routing_weights.scalar_type() == at::kFloat);
+  TORCH_CHECK((thread_k == 128 && thread_n == 64) ||
+              (thread_k == 64 && thread_n == 128));
+  TORCH_CHECK(blocks_per_sm >= 1 && blocks_per_sm <= 3);
+  const c10::cuda::CUDAGuard guard(a.device());
+  int m = a.size(0), k = a.size(1), n = out.size(1);
+  TORCH_CHECK(out.size(0) == m * top_k && k % thread_k == 0 && n % thread_n == 0);
+  TORCH_CHECK(weight.size(0) == 288 && weight.size(1) == k / 16);
+  TORCH_CHECK(scales.size(1) == k / 16 && scales.size(2) == n);
+  int sms, max_shared;
+  C10_CUDA_CHECK(cudaDeviceGetAttribute(
+      &sms, cudaDevAttrMultiProcessorCount, a.get_device()));
+  C10_CUDA_CHECK(cudaDeviceGetAttribute(
+      &max_shared, cudaDevAttrMaxSharedMemoryPerBlockOptin, a.get_device()));
+  TORCH_CHECK(workspace.numel() >= sms * 4);
+  if (blocks_per_sm > 1) max_shared = max_shared / blocks_per_sm - 1024;
+  long temp_size = std::min((long)n * sorted_ids.numel(), (long)sms * 4 * 8 * 256) * 2;
+  auto temp = at::empty({temp_size}, a.options().dtype(at::kFloat));
+  auto kernel = MARLIN_NAMESPACE_NAME::Marlin<
+      vllm::kBFloat16.id(), vllm::kFE2M1f.id(), vllm::kBFloat16.id(),
+      vllm::kFE4M3fn.id(), 128, 1, 4, 8, true, 4, 1, false>;
+  if (thread_n == 128) kernel = MARLIN_NAMESPACE_NAME::Marlin<
+      vllm::kBFloat16.id(), vllm::kFE2M1f.id(), vllm::kBFloat16.id(),
+      vllm::kFE4M3fn.id(), 128, 1, 8, 4, true, 4, 1, false>;
+  C10_CUDA_CHECK(cudaFuncSetAttribute(
+      kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, max_shared));
+  auto stream = at::cuda::getCurrentCUDAStream();
+  kernel<<<sms * blocks_per_sm, 128, max_shared, stream>>>(
+      (const int4*)a.data_ptr(), (const int4*)weight.data_ptr(),
+      (int4*)out.data_ptr(), (int4*)temp.data_ptr(), nullptr, nullptr,
+      (const int4*)scales.data_ptr(), global_scale.data_ptr<float>(), nullptr,
+      nullptr, sorted_ids.data_ptr<int>(), experts.data_ptr<int>(),
+      padded.data_ptr<int>(),
+      routing_weights.data_ptr<float>(), top_k, weighted, k / 16, m, n, k,
+      workspace.data_ptr<int>(), false, false, true);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+"""
+
+
+def isolated_source(original, boundary):
+    if boundary not in ("original", "compute", "output", "both"):
+        raise ValueError("unknown boundary")
+    compute = "  auto thread_block_reduce = [&]() {"
+    output = "  auto write_result = [&](bool last) {"
+    if original.count(compute) != 1 or original.count(output) != 1:
+        raise ValueError("Marlin header no longer matches expected boundaries")
+    if boundary in ("compute", "both"):
+        original = original.replace(compute, compute + "\n    __syncthreads();")
+    if boundary in ("output", "both"):
+        original = original.replace(output, output + "\n    __syncthreads();")
+    return original
+
+
+def build(args):
+    from torch.utils.cpp_extension import load_inline
+
+    cuda_home = Path(os.environ.get("CUDA_HOME", "/usr/local/cuda"))
+    version = subprocess.check_output(
+        [str(cuda_home / "bin/nvcc"), "--version"], text=True
+    )
+    match = re.search(r"release (\d+\.\d+)", version)
+    if not match or match.group(1) != torch.version.cuda:
+        raise ValueError("probe toolkit must match the installed Torch toolkit")
+    root = Path(__file__).resolve().parents[2]
+    header_path = args.source_header or (
+        root / "csrc/libtorch_stable/moe/marlin_moe_wna16/marlin_template.h"
+    )
+    original = header_path.read_text()
+    namespace = "marlin_shared_probe_" + args.boundary
+    source = (
+        f"#define MARLIN_NAMESPACE_NAME {namespace}\n"
+        + isolated_source(original, args.boundary)
+        + WRAPPER
+    )
+    build_dir = args.build_dir / args.boundary
+    build_dir.mkdir(parents=True, exist_ok=True)
+    extension = load_inline(
+        name=namespace,
+        cpp_sources=DECL,
+        cuda_sources=source,
+        functions=["run"],
+        build_directory=str(build_dir),
+        extra_include_paths=[str(root / "csrc")],
+        extra_cflags=["-O3", "-std=c++20", "-fvisibility=hidden"],
+        extra_cuda_cflags=[
+            "-O3",
+            "-std=c++20",
+            "-lineinfo",
+            "--expt-relaxed-constexpr",
+            "--expt-extended-lambda",
+            "-static-global-template-stub=false",
+            "-gencode=arch=compute_120f,code=sm_120f",
+            "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+            "-Xcompiler=-fvisibility=hidden",
+        ],
+        with_cuda=True,
+        verbose=True,
+    )
+    return extension, hashlib.sha256(original.encode()).hexdigest()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--build-dir", type=Path, required=True)
+    parser.add_argument(
+        "--source-header",
+        type=Path,
+        help="Archived header for reproducing the original after a serving fix",
+    )
+    parser.add_argument(
+        "--boundary",
+        choices=["original", "compute", "output", "both"],
+        default="original",
+    )
+    parser.add_argument("--build-only", action="store_true")
+    parser.add_argument("--model", type=Path)
+    parser.add_argument("--journal", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--batch", type=int, nargs="+", default=[1])
+    parser.add_argument("--replays", type=int, default=3)
+    args = parser.parse_args()
+    if args.replays < 1 or any(not 1 <= batch <= 16 for batch in args.batch):
+        parser.error("positive replays and batches 1..16 required")
+    if not args.build_only and (
+        args.model is None
+        or args.journal is None
+        or args.output is None
+        or args.output.exists()
+    ):
+        parser.error("run requires model, journal and new output")
+    if not args.build_only:
+        active = subprocess.check_output(
+            ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"],
+            text=True,
+        ).strip()
+        if active:
+            parser.error(f"GPUs already have compute processes: {active}")
+    extension, header_hash = build(args)
+    if args.build_only:
+        return
+
+    def gemm(*pos, **kw):
+        # Only the two observed M8 schedules, no auto heuristic in this wrapper.
+        tk, tn, b = kw["thread_k"], kw["thread_n"], kw["blocks_per_sm"]
+        if tk == -1:
+            tk, tn, b = (128, 64, 2) if kw["top_k"] == 8 else (64, 128, 3)
+        extension.run(
+            pos[0],
+            pos[1],
+            pos[2],
+            pos[4],
+            pos[6],
+            pos[10],
+            pos[11],
+            pos[12],
+            pos[13],
+            pos[14],
+            kw["top_k"],
+            kw["mul_topk_weights"],
+            tk,
+            tn,
+            b,
+        )
+        return pos[1]
+
+    result = {
+        "status": "running",
+        "boundary": args.boundary,
+        "header_sha256": header_hash,
+        "source_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        "torch": torch.__version__,
+        "cases": [],
+    }
+    with args.output.open("x") as stream:
+        json.dump(result, stream, indent=2)
+
+    def save():
+        args.output.write_text(json.dumps(result, indent=2) + "\n")
+
+    try:
+        torch.manual_seed(127)
+        weights, _ = load_layer(args.model, 3, 0)
+        for batch, record in route_cases(args.journal, args.batch, 1):
+            reference = prepare_case(weights, batch, record, 3)
+            probe = prepare_case(weights, batch, record, 3, gemm=gemm)
+            for config in (((128, 64, 2), (64, 128, 3)), ((128, 64, 1), (64, 128, 2))):
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph):
+                    probe["call"]("moe", config)
+                for replay in range(args.replays):
+                    reference["input"].normal_()
+                    probe["input"].copy_(reference["input"])
+                    expected = reference["call"]("moe", config).clone()
+                    graph.replay()
+                    got = probe["outputs"]["moe"]
+                    torch.cuda.synchronize()
+                    row = {
+                        "batch": batch,
+                        "config": config,
+                        "replay": replay,
+                        "exact": torch.equal(got, expected),
+                        "max_abs": (got.float() - expected.float()).abs().max().item(),
+                    }
+                    result["cases"].append(row)
+                    save()
+                    torch.testing.assert_close(got, expected, rtol=0, atol=0)
+                    print(json.dumps(row), flush=True)
+        result["status"] = "complete"
+    except Exception as error:
+        result.update(status="failed", error=repr(error))
+        save()
+        raise
+    save()
+
+
+if __name__ == "__main__":
+    main()

--- a/cmake/external_projects/deepgemm.cmake
+++ b/cmake/external_projects/deepgemm.cmake
@@ -84,6 +84,16 @@ endif()
 cuda_archs_loose_intersection(DEEPGEMM_ARCHS
   "${DEEPGEMM_SUPPORT_ARCHS}" "${CUDA_ARCHS}")
 
+# The per-Python builder (tools/build_deepgemm_C.py) was dropped with the
+# other-platform build scaffolding; without it the target cannot be built on
+# any arch, so treat it like an unsupported arch instead of failing ninja.
+# A100 (8.0) never reached this branch; sm_120 (12.0f) does.
+if(DEEPGEMM_ARCHS AND NOT EXISTS "${CMAKE_SOURCE_DIR}/tools/build_deepgemm_C.py")
+  message(STATUS "DeepGEMM will not compile: "
+    "tools/build_deepgemm_C.py is absent (arch ${DEEPGEMM_ARCHS})")
+  set(DEEPGEMM_ARCHS "")
+endif()
+
 if(DEEPGEMM_ARCHS)
   message(STATUS "DeepGEMM CUDA architectures: ${DEEPGEMM_ARCHS}")
 

--- a/csrc/libtorch_stable/moe/marlin_moe_wna16/glm53_sm120_prefill.cu
+++ b/csrc/libtorch_stable/moe/marlin_moe_wna16/glm53_sm120_prefill.cu
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// GLM53 NVFP4/BF16 TP4 prefill: all eight warps span N, with no cross-warp
+// K reduction. Three prefetch stages keep the 64x512 tile within SM120's
+// 100 KiB shared-memory budget. Decode keeps the existing Marlin schedules.
+#include "kernel.h"
+#include "marlin_template.h"
+
+namespace MARLIN_NAMESPACE_NAME {
+
+cudaError_t launch_glm53_sm120_prefill(MARLIN_KERNEL_PARAMS, int sms,
+                                      cudaStream_t stream) {
+  // Shared layout from marlin_template.h: max(B/reduction,bias overlay),
+  // BF16 A stages, byte-wide FP8 scales, and padded assignment metadata.
+  // The kernel also has 1024 bytes of static shared memory.
+  constexpr int smem = 64 * (512 + 8) * 2 + 3 * 64 * 64 * 2 +
+                       3 * (64 / 16) * 512 + 64 * 16;
+  static_assert(smem == 98304 && smem + 1024 <= 102400);
+  auto kernel = Marlin<vllm::kBFloat16.id(), vllm::kFE2M1f.id(),
+                       vllm::kBFloat16.id(), vllm::kFE4M3fn.id(),
+                       256, 4, 32, 4, false, 3, 1, false>;
+  auto error = cudaFuncSetAttribute(
+      kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+  if (error != cudaSuccess) return error;
+  kernel<<<sms, 256, smem, stream>>>(
+      A, B, C, C_tmp, b_bias_ptr, a_scales_ptr, scales_ptr, global_scale_ptr,
+      zp_ptr, g_idx, sorted_token_ids_ptr, expert_ids_ptr,
+      num_tokens_past_padded_ptr, topk_weights_ptr, top_k, mul_topk_weights,
+      num_groups, prob_m, prob_n, prob_k, locks, has_bias, use_atomic_add,
+      use_fp32_reduce);
+  return cudaGetLastError();
+}
+
+}  // namespace MARLIN_NAMESPACE_NAME

--- a/csrc/libtorch_stable/moe/marlin_moe_wna16/marlin_template.h
+++ b/csrc/libtorch_stable/moe/marlin_moe_wna16/marlin_template.h
@@ -1537,6 +1537,10 @@ __global__ void Marlin(
   // multiple warps that accumulate their partial sums of the same output
   // location; which we have to reduce over in the end. We do in shared memory.
   auto thread_block_reduce = [&]() {
+    // sh_red aliases sh_b. Every warp must finish reading the staged weight
+    // tiles before any warp overwrites that storage with reduction results.
+    // The preceding cp_async_wait only waits for the calling thread's copies.
+    __syncthreads();
     constexpr int red_off = threads / b_sh_stride_threads / 2;
     if (red_off >= 1) {
       auto red_idx = threadIdx.x / b_sh_stride_threads;

--- a/csrc/libtorch_stable/moe/marlin_moe_wna16/ops.cu
+++ b/csrc/libtorch_stable/moe/marlin_moe_wna16/ops.cu
@@ -25,6 +25,9 @@
 
 #include "kernel.h"
 
+#include <cstdlib>
+#include <cstring>
+
 #include <torch/csrc/stable/accelerator.h>
 #include <torch/csrc/stable/library.h>
 #include <torch/csrc/stable/ops.h>
@@ -44,6 +47,11 @@ namespace MARLIN_NAMESPACE_NAME {
 __global__ void MarlinDefault(MARLIN_KERNEL_PARAMS){};
 
 using MarlinFuncPtr = void (*)(MARLIN_KERNEL_PARAMS);
+
+#ifdef VLLM_BUILD_GLM53_SM120_PREFILL
+cudaError_t launch_glm53_sm120_prefill(MARLIN_KERNEL_PARAMS, int sms,
+                                      cudaStream_t stream);
+#endif
 
 // For a given "a" of size [M,K] performs a permutation of the K columns based
 // on the given "perm" indices.
@@ -460,6 +468,39 @@ void marlin_mm(const void* A, const void* B, void* C, void* C_tmp, void* b_bias,
         "Marlin W4A8-FP8 only support SM89 or SM12x device (It is slower than "
         "Marlin W4A16 on other devices).");
   }
+
+#ifdef VLLM_BUILD_GLM53_SM120_PREFILL
+  // Opt-in until real-profile qualification. Preserve explicit schedules and
+  // every non-target dtype, shape, quantization, and reduction policy.
+  static const bool wide_glm53_prefill = [] {
+    const char* value = std::getenv("VLLM_GLM53_MARLIN_PREFILL_WIDE");
+    return value != nullptr && std::strcmp(value, "1") == 0;
+  }();
+  const bool glm53_gate_up = prob_n == 1024 && prob_k == 4096 && top_k == 8 &&
+      !mul_topk_weights && prob_m >= 2048 && prob_m <= 8192;
+  const bool glm53_down = prob_n == 4096 && prob_k == 512 && top_k == 1 &&
+      mul_topk_weights && prob_m >= 2048 * 8 && prob_m <= 8192 * 8;
+  if (wide_glm53_prefill && major_capability == 12 && minor_capability == 0 &&
+      a_type == vllm::kBFloat16 && c_type == vllm::kBFloat16 &&
+      b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn &&
+      group_size == 16 && num_experts == 288 && moe_block_size == 64 &&
+      !has_bias && !has_act_order && !has_zp && is_k_full && g_s != nullptr &&
+      !use_atomic_add && use_fp32_reduce && thread_k == -1 && thread_n == -1 &&
+      blocks_per_sm == -1 && max_shared_mem >= 98304 &&
+      (glm53_gate_up || glm53_down)) {
+    // Existing C_tmp capacity is >= sms*4*64*256 floats (or all output rows),
+    // sufficient for sms blocks of the wider 64*512 tile. No new weight copy.
+    auto error = launch_glm53_sm120_prefill(
+        A_ptr, B_ptr, C_ptr, C_tmp_ptr, bias_ptr, a_s_ptr, b_s_ptr, g_s_ptr,
+        zp_ptr, g_idx_ptr, sorted_token_ids_ptr, expert_ids_ptr,
+        num_tokens_past_padded_ptr, topk_weights_ptr, top_k, mul_topk_weights,
+        num_groups, prob_m, prob_n, prob_k, locks, has_bias, use_atomic_add,
+        use_fp32_reduce, sms, stream);
+    STD_TORCH_CHECK(error == cudaSuccess, "GLM53 SM120 prefill launch: ",
+                    cudaGetErrorString(error));
+    return;
+  }
+#endif
 
   // Set thread config
   exec_config_t exec_cfg;

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -327,6 +327,16 @@ void top_k_per_row_prefill(const torch::stable::Tensor& logits,
                            torch::stable::Tensor& indices, int64_t numRows,
                            int64_t stride0, int64_t stride1, int64_t topK);
 
+void glm53_top_k_per_row_prefill(
+    const torch::stable::Tensor& logits, const torch::stable::Tensor& starts,
+    const torch::stable::Tensor& ends, torch::stable::Tensor& indices,
+    int64_t numRows, int64_t stride0, int64_t stride1, int64_t topK);
+
+void glm53_top_k_per_row_ordered(
+    const torch::stable::Tensor& logits, const torch::stable::Tensor& starts,
+    const torch::stable::Tensor& ends, torch::stable::Tensor& indices,
+    int64_t numRows, int64_t stride0, int64_t stride1, int64_t topK);
+
 void top_k_per_row_decode(const torch::stable::Tensor& logits, int64_t next_n,
                           const torch::stable::Tensor& seqLens,
                           torch::stable::Tensor& indices,

--- a/csrc/libtorch_stable/sampler.cu
+++ b/csrc/libtorch_stable/sampler.cu
@@ -1,4 +1,5 @@
 #include <climits>
+#include <torch/headeronly/macros/Macros.h>
 
 #include "../cuda_compat.h"
 #include "dispatch_utils.h"
@@ -154,7 +155,8 @@ __device__ void vectorized_process(size_t thread_rank, size_t num_threads,
 }
 
 template <int step, int kNumThreadsPerBlock, int kNumBins, int kNumFinalItems,
-          bool multipleBlocksPerRow, bool mergeBlocks, typename SmemFinalType,
+          bool multipleBlocksPerRow, bool mergeBlocks, bool canonicalTies,
+          typename SmemFinalType,
           typename SmemOutputType>
 __device__ bool processHistogramStep(
     const int* indices, const float* logits, int rowEnd, uint32_t& logitPattern,
@@ -181,6 +183,10 @@ __device__ bool processHistogramStep(
   }
 
   auto distributeToBins = [&](float logit, int /* idx */ = 0) {
+    if constexpr (canonicalTies) {
+      // Signed zeros compare equal; put both in the same histogram bin.
+      logit = logit == 0.0f ? 0.0f : logit;
+    }
     if (isPartialMatch<patternShift>(logit, logitPattern)) {
       uint32_t binIdx = extractBinIdx<step>(logit);
       atomicAdd(&smemFinal.histo.data[binIdx], 1);
@@ -256,6 +262,9 @@ __device__ bool processHistogramStep(
   thresholdBinIdx = smemThresholdBinIdx[0];
 
   auto processBins = [&](float logit, int idx) {
+    if constexpr (canonicalTies) {
+      logit = logit == 0.0f ? 0.0f : logit;
+    }
     if (isPartialMatch<patternShift>(logit, logitPattern)) {
       uint32_t binIdx = extractBinIdx<step>(logit);
       // Only write elements with binIdx < thresholdBinIdx when:
@@ -292,17 +301,17 @@ __device__ bool processHistogramStep(
           }
         }
       } else {
-        if (binIdx == thresholdBinIdx) {
+        if (binIdx == thresholdBinIdx && !canonicalTies) {
           // The elements in the threshold bin share the same 32 bits at step 3
           // -- identical logits -- so which of them survive is decided by the
           // order threads win this atomic, and it differs between launches.
           // Measured on gfx942 at seq 32768 with 800 non-zero indexer logits:
           // the selected set repeated on 2 of 8 launches, Jaccard >= 0.91, and
           // every difference was among positions scoring exactly 0.0. No
-          // above-threshold token is ever dropped, so this costs bitwise
-          // reproducibility at long context, not selection quality. Making it
-          // canonical means ranking ties by index, which is a scan over the
-          // whole bin in the decode hot path.
+          // above-threshold token is dropped. This preserves the top-k SCORE
+          // set, not the downstream model output: equal indexer scores can
+          // refer to different attention values. The opt-in GLM prefill path
+          // ranks these ties by pool ID in the bounded scan below.
           int dstIdx = atomicAdd(&smemFinal.histo.data[binIdx], 1);
           if (dstIdx < topK) {
             if constexpr (mergeBlocks) {
@@ -333,17 +342,48 @@ __device__ bool processHistogramStep(
   // Make sure the elements are in shared memory.
   __syncthreads();
 
+  if constexpr (canonicalTies && step == 3) {
+    static_assert(!multipleBlocksPerRow && !mergeBlocks);
+    // The histogram already gives the output offset for the exact cutoff bin.
+    // Fill only its remaining slots, scanning pool IDs in increasing order.
+    // Reuse scan storage after all histogram/above-cutoff accesses complete.
+    int base = smemFinal.histo.data[thresholdBinIdx];
+    using Scan = cub::BlockScan<int, kNumThreadsPerBlock>;
+    for (int begin = rowStart; begin < rowEnd && base < topK;
+         begin += kNumThreadsPerBlock) {
+      const int idx = begin + threadIdx.x;
+      bool selected = false;
+      if (idx < rowEnd) {
+        float logit = logits[idx * stride1];
+        logit = logit == 0.0f ? 0.0f : logit;
+        selected = isPartialMatch<patternShift>(logit, logitPattern) &&
+                   extractBinIdx<step>(logit) == thresholdBinIdx;
+      }
+      int offset, count;
+      Scan(smemFinal.histo.scan).ExclusiveSum(int(selected), offset, count);
+      if (selected && base + offset < topK) {
+        smemOutput[base + offset] = idx - rowStart;
+      }
+      base += count;
+      __syncthreads();
+    }
+  }
+
   // Check if we should continue to next step
   return smemFinalBinSize[0] > kNumFinalItems;
 }
 
 // Follows half - 11 - 11 - 10 bit iterations
 template <int kNumThreadsPerBlock, int kNumBins, bool useRadixSort,
-          bool multipleBlocksPerRow = false, bool mergeBlocks = false>
+          bool multipleBlocksPerRow = false, bool mergeBlocks = false,
+          bool canonicalTies = false, bool canonicalOrder = false>
 static __device__ void topKPerRowJob(const int* indices, const float* logits,
                                      int rowStart, int rowEnd, int* outIndices,
                                      float* outLogits, int stride1, int topK) {
   // The number of slots for the final pass.
+  static_assert(!canonicalTies || (!useRadixSort && !multipleBlocksPerRow &&
+                                  !mergeBlocks));
+  static_assert(!canonicalOrder || (canonicalTies && kNumThreadsPerBlock == 512));
   static constexpr int kNumFinalItems = 2048;
   // The number of elements per thread for the final sort.
   static constexpr int kNumFinalItemsPerThread =
@@ -452,7 +492,7 @@ static __device__ void topKPerRowJob(const int* indices, const float* logits,
   // Step 0: Process first 11 bits of half representation
   bool continueToNextStep =
       processHistogramStep<0, kNumThreadsPerBlock, kNumBins, kNumFinalItems,
-                           multipleBlocksPerRow, mergeBlocks>(
+                           multipleBlocksPerRow, mergeBlocks, canonicalTies>(
           indices, logits, rowEnd, logitPattern, thresholdBinIdx, smemOutput,
           smemThresholdBinIdx, smemFinalDstIdx, smemFinalBinSize,
           smemFoundTopKValues, smemFinal, stride1, rowStart, topK);
@@ -461,7 +501,7 @@ static __device__ void topKPerRowJob(const int* indices, const float* logits,
     // Step 1: Process next 11 bits
     continueToNextStep =
         processHistogramStep<1, kNumThreadsPerBlock, kNumBins, kNumFinalItems,
-                             multipleBlocksPerRow, mergeBlocks>(
+                             multipleBlocksPerRow, mergeBlocks, canonicalTies>(
             indices, logits, rowEnd, logitPattern, thresholdBinIdx, smemOutput,
             smemThresholdBinIdx, smemFinalDstIdx, smemFinalBinSize,
             smemFoundTopKValues, smemFinal, stride1, rowStart, topK);
@@ -471,7 +511,7 @@ static __device__ void topKPerRowJob(const int* indices, const float* logits,
     // Step 2: Process next 11 bits
     continueToNextStep =
         processHistogramStep<2, kNumThreadsPerBlock, kNumBins, kNumFinalItems,
-                             multipleBlocksPerRow, mergeBlocks>(
+                             multipleBlocksPerRow, mergeBlocks, canonicalTies>(
             indices, logits, rowEnd, logitPattern, thresholdBinIdx, smemOutput,
             smemThresholdBinIdx, smemFinalDstIdx, smemFinalBinSize,
             smemFoundTopKValues, smemFinal, stride1, rowStart, topK);
@@ -480,7 +520,7 @@ static __device__ void topKPerRowJob(const int* indices, const float* logits,
   if (continueToNextStep) {
     // Step 3: Process last 10 bits
     processHistogramStep<3, kNumThreadsPerBlock, kNumBins, kNumFinalItems,
-                         multipleBlocksPerRow, mergeBlocks>(
+                         multipleBlocksPerRow, mergeBlocks, canonicalTies>(
         indices, logits, rowEnd, logitPattern, thresholdBinIdx, smemOutput,
         smemThresholdBinIdx, smemFinalDstIdx, smemFinalBinSize,
         smemFoundTopKValues, smemFinal, stride1, rowStart, topK);
@@ -540,9 +580,12 @@ static __device__ void topKPerRowJob(const int* indices, const float* logits,
            i += kNumThreadsPerBlock) {
         int outIndex = 0;
         auto logit = smemFinal.items.logits[i];
+        const int pool = canonicalTies ? smemFinal.items.indices[i] : 0;
         for (int j = 0; j < smemFinalDstIdx[0]; j++) {
           auto otherLogit = smemFinal.items.logits[j];
-          if (logit < otherLogit || (logit == otherLogit && i < j)) {
+          const bool tiePrecedes = canonicalTies
+              ? pool > smemFinal.items.indices[j] : i < j;
+          if (logit < otherLogit || (logit == otherLogit && tiePrecedes)) {
             outIndex++;
           }
         }
@@ -559,18 +602,49 @@ static __device__ void topKPerRowJob(const int* indices, const float* logits,
     __syncthreads();
   }
 
-  // Store to global memory.
-  for (int i = threadIdx.x; i < topK; i += kNumThreadsPerBlock) {
-    if constexpr (multipleBlocksPerRow) {
-      outIndices[i] = smemOutput[i];
-      outLogits[i] = reinterpret_cast<float*>(smemOutput + topK)[i];
-    } else {
-      if (stride1 == 1) {
-        // stride1 == 1 will use vectorized_process, which indexes already skip
-        // the rowStart.
+  if constexpr (canonicalOrder) {
+    // Selection and every read of FinalItems/Histogram have completed. Reuse
+    // their storage; this needs neither an extra launch nor a global workspace.
+    // The <=512 shortcut above is already in ascending pool-ID order.
+    int pool = smemOutput[threadIdx.x];
+    pool = pool < 0 ? INT_MAX : pool;
+    __syncthreads();
+    // One integer per thread. Warp-local exchanges stay in registers; only
+    // the ten cross-warp compare stages use shared memory. This replaces the
+    // rejected radix candidate, not an additional serving implementation.
+#pragma unroll
+    for (int size = 2; size <= 512; size *= 2) {
+#pragma unroll
+      for (int distance = size / 2; distance > 0; distance /= 2) {
+        int other;
+        if (distance < 32) {
+          other = VLLM_SHFL_XOR_SYNC_WIDTH(pool, distance, 32);
+        } else {
+          smemFinal.items.indices[threadIdx.x] = pool;
+          __syncthreads();
+          other = smemFinal.items.indices[threadIdx.x ^ distance];
+          __syncthreads();
+        }
+        const bool takeMin = ((threadIdx.x & size) == 0) ==
+                             ((threadIdx.x & distance) == 0);
+        pool = takeMin ? min(pool, other) : max(pool, other);
+      }
+    }
+    outIndices[threadIdx.x] = pool == INT_MAX ? -1 : pool;
+  } else {
+    // Store to global memory.
+    for (int i = threadIdx.x; i < topK; i += kNumThreadsPerBlock) {
+      if constexpr (multipleBlocksPerRow) {
         outIndices[i] = smemOutput[i];
+        outLogits[i] = reinterpret_cast<float*>(smemOutput + topK)[i];
       } else {
-        outIndices[i] = smemOutput[i] - rowStart;
+        if (stride1 == 1) {
+          // stride1 == 1 will use vectorized_process, which indexes already skip
+          // the rowStart.
+          outIndices[i] = smemOutput[i];
+        } else {
+          outIndices[i] = smemOutput[i] - rowStart;
+        }
       }
     }
   }
@@ -646,6 +720,29 @@ static __global__ __launch_bounds__(kNumThreadsPerBlock) void topKPerRowDecode(
   topKPerRowJob<kNumThreadsPerBlock, kNumBins, useRadixSort,
                 multipleBlocksPerRow, mergeBlocks>(
       indices, logits, rowStart, rowEnd, outIndices, outLogits, stride1, topK);
+}
+
+// Separate entry preserves the generic prefill/decode kernels and defaults.
+// Only membership ties change; output order is still unspecified here.
+static __global__ __launch_bounds__(512) void glm53TopKPerRowPrefill(
+    const float* logits, const int* starts, const int* ends, int* indices,
+    int columns) {
+  const int row = blockIdx.x;
+  CUDA_KERNEL_ASSERT(starts[row] == 0 && ends[row] >= 0 && ends[row] <= columns);
+  topKPerRowJob<512, 2048, false, false, false, true>(
+      nullptr, logits + int64_t(row) * columns, 0, ends[row],
+      indices + int64_t(row) * 512, nullptr, 1, 512);
+}
+
+// Diagnostic fusion candidate: identical tie policy, ascending selected IDs.
+static __global__ __launch_bounds__(512) void glm53TopKPerRowOrdered(
+    const float* logits, const int* starts, const int* ends, int* indices,
+    int columns) {
+  const int row = blockIdx.x;
+  CUDA_KERNEL_ASSERT(starts[row] == 0 && ends[row] >= 0 && ends[row] <= columns);
+  topKPerRowJob<512, 2048, false, false, false, true, true>(
+      nullptr, logits + int64_t(row) * columns, 0, ends[row],
+      indices + int64_t(row) * 512, nullptr, 1, 512);
 }
 
 }  // namespace vllm
@@ -795,4 +892,63 @@ void top_k_per_row_prefill(const torch::stable::Tensor& logits,
             static_cast<int>(stride0), static_cast<int>(stride1),
             static_cast<int>(topK), kSortingAlgorithmThreshold);
   }
+}
+
+template <bool canonicalOrder>
+static void glm53_top_k_per_row_impl(
+    const torch::stable::Tensor& logits,
+    const torch::stable::Tensor& starts,
+    const torch::stable::Tensor& ends, torch::stable::Tensor& indices,
+    int64_t numRows, int64_t stride0, int64_t stride1, int64_t topK) {
+  using Scalar = torch::headeronly::ScalarType;
+  STD_TORCH_CHECK(logits.is_cuda() && logits.scalar_type() == Scalar::Float &&
+                  logits.dim() == 2 && logits.is_contiguous(),
+                  "GLM pool selector requires contiguous CUDA FP32 logits");
+  STD_TORCH_CHECK(numRows >= 1 && numRows <= 8192 &&
+                  logits.size(0) == numRows && logits.size(1) >= 1 &&
+                  logits.size(1) <= 262144 && stride0 == logits.size(1) &&
+                  stride1 == 1 && topK == 512,
+                  "GLM pool selector geometry changed");
+  const torch::stable::Tensor* buffers[] = {&starts, &ends, &indices};
+  for (const auto* value : buffers) {
+    STD_TORCH_CHECK(value->is_cuda() && value->scalar_type() == Scalar::Int &&
+                    value->is_contiguous() &&
+                    value->get_device_index() == logits.get_device_index(),
+                    "GLM pool selector requires same-device contiguous int32 buffers");
+  }
+  STD_TORCH_CHECK(starts.dim() == 1 && ends.dim() == 1 &&
+                  starts.size(0) == numRows && ends.size(0) == numRows &&
+                  indices.dim() == 2 && indices.size(0) == numRows &&
+                  indices.size(1) == 512, "GLM pool selector buffer shape changed");
+  const torch::stable::accelerator::DeviceGuard guard(logits.get_device_index());
+  if constexpr (canonicalOrder) {
+    vllm::glm53TopKPerRowOrdered<<<numRows, 512, 512 * sizeof(int32_t),
+                                  get_current_cuda_stream()>>>(
+        logits.const_data_ptr<float>(), starts.const_data_ptr<int>(),
+        ends.const_data_ptr<int>(), indices.mutable_data_ptr<int>(), int(stride0));
+  } else {
+    vllm::glm53TopKPerRowPrefill<<<numRows, 512, 512 * sizeof(int32_t),
+                               get_current_cuda_stream()>>>(
+      logits.const_data_ptr<float>(), starts.const_data_ptr<int>(),
+      ends.const_data_ptr<int>(), indices.mutable_data_ptr<int>(), int(stride0));
+  }
+  const cudaError_t error = cudaGetLastError();
+  STD_TORCH_CHECK(error == cudaSuccess, "GLM pool selector launch failed: ",
+                  cudaGetErrorString(error));
+}
+
+void glm53_top_k_per_row_prefill(
+    const torch::stable::Tensor& logits, const torch::stable::Tensor& starts,
+    const torch::stable::Tensor& ends, torch::stable::Tensor& indices,
+    int64_t numRows, int64_t stride0, int64_t stride1, int64_t topK) {
+  glm53_top_k_per_row_impl<false>(logits, starts, ends, indices, numRows,
+                                stride0, stride1, topK);
+}
+
+void glm53_top_k_per_row_ordered(
+    const torch::stable::Tensor& logits, const torch::stable::Tensor& starts,
+    const torch::stable::Tensor& ends, torch::stable::Tensor& indices,
+    int64_t numRows, int64_t stride0, int64_t stride1, int64_t topK) {
+  glm53_top_k_per_row_impl<true>(logits, starts, ends, indices, numRows,
+                               stride0, stride1, topK);
 }

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -480,6 +480,14 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "int stride1, int topK) -> ()");
 
   ops.def(
+      "glm53_top_k_per_row_prefill(Tensor logits, Tensor rowStarts, Tensor rowEnds, "
+      "Tensor! indices, int numRows, int stride0, int stride1, int topK) -> ()");
+
+  ops.def(
+      "glm53_top_k_per_row_ordered(Tensor logits, Tensor rowStarts, Tensor rowEnds, "
+      "Tensor! indices, int numRows, int stride0, int stride1, int topK) -> ()");
+
+  ops.def(
       "top_k_per_row_decode(Tensor logits, int next_n, "
       "Tensor seq_lens, Tensor! indices, Tensor! workspace, "
       "int numRows, int stride0, int stride1, int topK) -> ()");
@@ -835,6 +843,8 @@ STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
   ops.impl("apply_repetition_penalties_",
            TORCH_BOX(&apply_repetition_penalties_));
   ops.impl("top_k_per_row_prefill", TORCH_BOX(&top_k_per_row_prefill));
+  ops.impl("glm53_top_k_per_row_prefill", TORCH_BOX(&glm53_top_k_per_row_prefill));
+  ops.impl("glm53_top_k_per_row_ordered", TORCH_BOX(&glm53_top_k_per_row_ordered));
   ops.impl("top_k_per_row_decode", TORCH_BOX(&top_k_per_row_decode));
   ops.impl("persistent_topk", TORCH_BOX(&persistent_topk));
 #ifdef VLLM_ENABLE_COOPERATIVE_TOPK

--- a/csrc/quixicore/serving/bf16_decode_gemm.cuh
+++ b/csrc/quixicore/serving/bf16_decode_gemm.cuh
@@ -1,0 +1,234 @@
+#pragma once
+// bf16 decode GEMM for M <= 16 tokens on tensor cores: out[M, N] = x[M, K] . W[N, K]^T,
+// fp32 accumulation, bf16 or fp32 output, optional bias. Written for the GLM-5.3-Flash
+// backbone projections on sm_120 (4x RTX PRO 6000), where cuBLAS runs the decode
+// shapes at 59-89% of the ~1.6 TB/s streaming ceiling and the row-per-block fp32
+// GEMV (dsv4_projection_ampere.cuh) falls back to cuBLAS speed at M >= 8 because it
+// re-reads x per token.
+//
+// Block = NT weight rows x the whole K. Each K chunk (KCHUNK values of every row of
+// the tile plus the 16 padded token rows of x) is staged through shared memory with
+// cp.async, STAGES deep; ldmatrix hands the m16n8k16 fragments to mma.sync. The
+// WARPS warps split the k16 steps of a chunk (warp w takes steps w, w+WARPS, ...),
+// so the per-warp partial accumulators are reduced through shared memory once at
+// the end. x rows >= M are zero-filled by cp.async (src-size 0); the tile's rows
+// beyond N are clamped for the load and skipped for the store.
+// Requirements: K % KCHUNK == 0, KCHUNK % (16 * WARPS) == 0, 16-byte aligned rows.
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+#include <stdexcept>
+
+namespace tms::decode_gemm {
+
+constexpr int MT = 16;        // token rows per mma; M is padded to this
+constexpr int PAD = 8;        // elements of padding per smem row (16 B): conflict-free ldmatrix
+
+inline void check_cuda_status(cudaError_t status) {
+    if (status != cudaSuccess) throw std::runtime_error(cudaGetErrorString(status));
+}
+
+__device__ __forceinline__ uint32_t smem_u32(const void* p) {
+    return uint32_t(__cvta_generic_to_shared(p));
+}
+__device__ __forceinline__ void cp_async16(uint32_t dst, const void* src, bool valid) {
+    const int bytes = valid ? 16 : 0;   // 0 -> zero-fill, nothing is read
+    asm volatile("cp.async.cg.shared.global [%0], [%1], 16, %2;\n" ::"r"(dst), "l"(src), "r"(bytes));
+}
+__device__ __forceinline__ void cp_async_commit() { asm volatile("cp.async.commit_group;\n" ::); }
+template <int N>
+__device__ __forceinline__ void cp_async_wait() { asm volatile("cp.async.wait_group %0;\n" ::"n"(N)); }
+
+__device__ __forceinline__ void ldmatrix_x4(uint32_t (&r)[4], uint32_t addr) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];\n"
+                 : "=r"(r[0]), "=r"(r[1]), "=r"(r[2]), "=r"(r[3]) : "r"(addr));
+}
+__device__ __forceinline__ void ldmatrix_x2(uint32_t (&r)[2], uint32_t addr) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0,%1}, [%2];\n"
+                 : "=r"(r[0]), "=r"(r[1]) : "r"(addr));
+}
+__device__ __forceinline__ void mma_bf16_16816(float (&d)[4], const uint32_t (&a)[4], uint32_t b0, uint32_t b1) {
+    asm volatile(
+        "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
+        "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
+        : "+f"(d[0]), "+f"(d[1]), "+f"(d[2]), "+f"(d[3])
+        : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b0), "r"(b1));
+}
+
+template <typename OutT> __device__ __forceinline__ OutT to_out(float v);
+template <> __device__ __forceinline__ float to_out<float>(float v) { return v; }
+template <> __device__ __forceinline__ __nv_bfloat16 to_out<__nv_bfloat16>(float v) { return __float2bfloat16_rn(v); }
+
+template <int NT, int WARPS, int KCHUNK, int STAGES>
+struct Cfg {
+    static constexpr int THREADS = WARPS * 32;
+    static constexpr int ROW = KCHUNK + PAD;              // smem row stride, elements
+    static constexpr int X_TILE = MT * ROW;               // elements
+    static constexpr int W_TILE = NT * ROW;
+    static constexpr int STAGE = X_TILE + W_TILE;
+    static constexpr int SMEM_BYTES = STAGES * STAGE * 2;
+    static constexpr int KSTEPS = KCHUNK / 16;            // k16 steps per chunk
+    static constexpr int NTILES = NT / 8;                 // n8 tiles per block
+    static constexpr int KVEC = KCHUNK / 8;               // 16-byte vectors per row per chunk
+    static constexpr int RED_BYTES = WARPS * MT * NT * 4; // cross-warp reduction scratch
+    static_assert(KSTEPS % WARPS == 0, "warps split the k16 steps of a chunk evenly");
+    static_assert(NT % 8 == 0 && NT >= 8, "NT is a multiple of the n8 tile");
+    static_assert(STAGES >= 2, "double buffering at least");
+    static_assert(RED_BYTES <= SMEM_BYTES, "reduction scratch reuses the stage buffers");
+};
+
+template <int NT, int WARPS, int KCHUNK, int STAGES, typename OutT>
+__global__ void __launch_bounds__(WARPS * 32) bf16_decode_gemm_kernel(
+        const __nv_bfloat16* __restrict__ x,     // [M, K]
+        const __nv_bfloat16* __restrict__ w,     // [N, K]
+        const float* __restrict__ bias,          // [N] or nullptr
+        OutT* __restrict__ out,                  // [M, N]
+        int M, int N, int K) {
+    using C = Cfg<NT, WARPS, KCHUNK, STAGES>;
+    extern __shared__ __align__(16) unsigned char smem_raw[];
+    __nv_bfloat16* smem = reinterpret_cast<__nv_bfloat16*>(smem_raw);
+
+    const int tid = threadIdx.x, lane = tid & 31, warp = tid >> 5;
+    const int n0 = blockIdx.x * NT;
+    const int nchunks = K / KCHUNK;
+
+    auto stage_x = [&](int s) { return smem + s * C::STAGE; };
+    auto stage_w = [&](int s) { return smem + s * C::STAGE + C::X_TILE; };
+
+    // Issue the cp.async loads of chunk c into stage s.
+    auto load_chunk = [&](int c, int s) {
+        const int k0 = c * KCHUNK;
+        __nv_bfloat16* xs = stage_x(s);
+        __nv_bfloat16* ws = stage_w(s);
+        for (int i = tid; i < MT * C::KVEC; i += C::THREADS) {
+            const int m = i / C::KVEC, v = i - m * C::KVEC;
+            const bool valid = m < M;
+            const __nv_bfloat16* src = x + size_t(valid ? m : 0) * K + k0 + v * 8;
+            cp_async16(smem_u32(xs + m * C::ROW + v * 8), src, valid);
+        }
+        for (int i = tid; i < NT * C::KVEC; i += C::THREADS) {
+            const int r = i / C::KVEC, v = i - r * C::KVEC;
+            const int n = min(n0 + r, N - 1);
+            cp_async16(smem_u32(ws + r * C::ROW + v * 8), w + size_t(n) * K + k0 + v * 8, true);
+        }
+    };
+
+    float acc[C::NTILES][4];
+#pragma unroll
+    for (int j = 0; j < C::NTILES; ++j)
+#pragma unroll
+        for (int e = 0; e < 4; ++e) acc[j][e] = 0.0f;
+
+    // ldmatrix addressing: lane supplies the row address of matrix (lane / 8).
+    const int mat = lane >> 3, mrow = lane & 7;
+    // A (x) tile: a0 = rows 0-7 / k 0-7, a1 = rows 8-15 / k 0-7, a2 = rows 0-7 / k 8-15, a3 = rows 8-15 / k 8-15.
+    const int a_row = mrow + 8 * (mat & 1), a_col = 8 * (mat >> 1);
+    // B (w) tile pair: r0 = tile 2p k 0-7, r1 = tile 2p k 8-15, r2 = tile 2p+1 k 0-7, r3 = tile 2p+1 k 8-15.
+    const int b_row = mrow + 8 * (mat >> 1), b_col = 8 * (mat & 1);
+
+    // Prologue: STAGES-1 chunks in flight.
+#pragma unroll
+    for (int c = 0; c < STAGES - 1; ++c) {
+        if (c < nchunks) load_chunk(c, c);
+        cp_async_commit();
+    }
+
+    for (int c = 0; c < nchunks; ++c) {
+        cp_async_wait<STAGES - 2>();
+        __syncthreads();   // chunk c landed for everyone; stage (c-1)%STAGES is free
+        {
+            const int cn = c + STAGES - 1;
+            if (cn < nchunks) load_chunk(cn, cn % STAGES);
+            cp_async_commit();
+        }
+        const int s = c % STAGES;
+        const uint32_t xs = smem_u32(stage_x(s));
+        const uint32_t ws = smem_u32(stage_w(s));
+#pragma unroll
+        for (int step = warp; step < C::KSTEPS; step += WARPS) {
+            const int k0 = step * 16;
+            uint32_t a[4];
+            ldmatrix_x4(a, xs + (a_row * C::ROW + k0 + a_col) * 2);
+#pragma unroll
+            for (int p = 0; p < C::NTILES / 2; ++p) {
+                uint32_t b[4];
+                ldmatrix_x4(b, ws + ((16 * p + b_row) * C::ROW + k0 + b_col) * 2);
+                mma_bf16_16816(acc[2 * p], a, b[0], b[1]);
+                mma_bf16_16816(acc[2 * p + 1], a, b[2], b[3]);
+            }
+            if constexpr (C::NTILES % 2 == 1) {
+                // Last single n8 tile: x2 with lanes 0-15 addressing (k 0-7, k 8-15).
+                uint32_t b[2];
+                const int r = mrow, col = 8 * (mat & 1);
+                ldmatrix_x2(b, ws + ((16 * (C::NTILES / 2) + r) * C::ROW + k0 + col) * 2);
+                mma_bf16_16816(acc[C::NTILES - 1], a, b[0], b[1]);
+            }
+        }
+    }
+
+    // Cross-warp reduction of the K partials through shared memory.
+    cp_async_wait<0>();
+    __syncthreads();
+    float* red = reinterpret_cast<float*>(smem_raw);   // [WARPS][MT][NT]
+    {
+        float* mine = red + warp * (MT * NT);
+        const int r0 = lane >> 2, cc = (lane & 3) * 2;
+#pragma unroll
+        for (int j = 0; j < C::NTILES; ++j) {
+            const int n = 8 * j + cc;
+            mine[r0 * NT + n] = acc[j][0];
+            mine[r0 * NT + n + 1] = acc[j][1];
+            mine[(r0 + 8) * NT + n] = acc[j][2];
+            mine[(r0 + 8) * NT + n + 1] = acc[j][3];
+        }
+    }
+    __syncthreads();
+    for (int i = tid; i < MT * NT; i += C::THREADS) {
+        const int m = i / NT, n = i - m * NT;
+        if (m >= M || n0 + n >= N) continue;
+        float v = 0.0f;
+#pragma unroll
+        for (int wv = 0; wv < WARPS; ++wv) v += red[wv * (MT * NT) + i];
+        if (bias != nullptr) v += bias[n0 + n];
+        out[size_t(m) * N + n0 + n] = to_out<OutT>(v);
+    }
+}
+
+template <int NT, int WARPS, int KCHUNK, int STAGES, typename OutT>
+static inline void launch(const __nv_bfloat16* x, const __nv_bfloat16* w, const float* bias, OutT* out,
+                   int M, int N, int K, cudaStream_t stream) {
+    using C = Cfg<NT, WARPS, KCHUNK, STAGES>;
+    auto kern = bf16_decode_gemm_kernel<NT, WARPS, KCHUNK, STAGES, OutT>;
+    // Internal linkage keeps this state local to its CUDA module, not an ELF
+    // GNU_UNIQUE flag shared by separately loaded probe/serving libraries.
+    // Attributes are device-specific; thread-local state also avoids host races.
+    static thread_local int configured_device = -1;
+    int device = -1;
+    check_cuda_status(cudaGetDevice(&device));
+    if (configured_device != device) {
+        check_cuda_status(cudaFuncSetAttribute(
+            kern, cudaFuncAttributeMaxDynamicSharedMemorySize, C::SMEM_BYTES));
+        configured_device = device;
+    }
+    const int blocks = (N + NT - 1) / NT;
+    kern<<<blocks, C::THREADS, C::SMEM_BYTES, stream>>>(x, w, bias, out, M, N, K);
+}
+
+// Production configs (microbench 2026-09-07, gemm16_bench.py on RTX PRO 6000): 32 rows /
+// 3 stages for N >= 4096 (o_proj, q_b, in_proj, dense, shared down at 1.38-1.53 TB/s),
+// 16 rows / 6 stages below that (fused_qkv_a 2048 x 4096 at 1.39-1.41 TB/s). Deeper
+// pipelines and 256-wide chunks changed nothing: the 10-25 us kernels sit ~1.5 us above
+// the streaming ceiling from launch ramp and tail, which no staging depth recovers.
+template <typename OutT>
+inline void launch_auto(const __nv_bfloat16* x, const __nv_bfloat16* w, const float* bias, OutT* out,
+                        int M, int N, int K, cudaStream_t stream) {
+    if (N >= 4096) launch<32, 8, 128, 3>(x, w, bias, out, M, N, K, stream);
+    else launch<16, 8, 128, 6>(x, w, bias, out, M, N, K, stream);
+}
+
+// Shapes the kernel serves: what the microbench showed it beating cuBLAS at every M.
+inline bool supports(int M, int N, int K) {
+    return M >= 1 && M <= MT && K % 128 == 0 && K >= 512 && N >= 2048 && N <= 16384;
+}
+
+}  // namespace tms::decode_gemm

--- a/csrc/quixicore/serving/fp8_decode_gemm.cuh
+++ b/csrc/quixicore/serving/fp8_decode_gemm.cuh
@@ -1,0 +1,212 @@
+#pragma once
+// FP8 block-scaled weights (e4m3 with 128x128 fp32 scales), bf16 activations, M <= 16 tokens, on
+// tensor cores: out[M, N] = x[M, K] . dequant(W)[N, K]^T with
+//   dequant(W)[n][k] = bf16(scale[n/128][k/128] * W[n][k]),
+// i.e. the weights the mma multiplies are bit-for-bit the BF16 tensors a dequantizing checkpoint
+// conversion would store, at half the bytes. Same pipeline as bf16_decode_gemm.cuh (cp.async staged
+// K chunks, warps splitting the k16 steps of a chunk, one shared-memory reduction). The B fragments
+// come from two 16-bit shared loads per n8 tile (the two e4m3 pairs a lane needs: k = 2q, 2q+1 and
+// 2q+8, 2q+9), converted through f16x2 (exact for e4m3) and scaled in fp32. One K chunk is one scale
+// block and a block's NT rows sit inside one 128-row scale group, so a chunk has a single scale.
+// Requirements: K % 128 == 0 (16-byte aligned rows follow), rows beyond N clamped for the load and
+// skipped for the store.
+#include <cuda_fp16.h>
+#include "bf16_decode_gemm.cuh"
+
+namespace tms::decode_gemm_fp8 {
+using tms::decode_gemm::MT;
+using tms::decode_gemm::PAD;
+using tms::decode_gemm::smem_u32;
+using tms::decode_gemm::cp_async16;
+using tms::decode_gemm::cp_async_commit;
+using tms::decode_gemm::cp_async_wait;
+using tms::decode_gemm::ldmatrix_x4;
+using tms::decode_gemm::mma_bf16_16816;
+using tms::decode_gemm::to_out;
+using tms::decode_gemm::check_cuda_status;
+
+constexpr int SB = 128;     // scale block: 128 rows x 128 k
+constexpr int WPAD = 16;    // bytes of padding per fp8 weight row in smem (conflict-free 16-bit loads)
+
+// Two e4m3 values (packed low/high) -> bf16x2 of scale * value. e4m3 -> f16 is exact; the only
+// rounding is the final bf16 of the fp32 product, the same rounding a checkpoint dequant applies.
+__device__ __forceinline__ uint32_t e4m3x2_scaled_to_bf16x2(uint16_t packed, float s) {
+    uint32_t h2;
+    asm("cvt.rn.f16x2.e4m3x2 %0, %1;\n" : "=r"(h2) : "h"(packed));
+    const float2 f = __half22float2(*reinterpret_cast<const __half2*>(&h2));
+    const __nv_bfloat162 b = __floats2bfloat162_rn(f.x * s, f.y * s);
+    return *reinterpret_cast<const uint32_t*>(&b);
+}
+
+template <int NT, int WARPS, int KCHUNK, int STAGES>
+struct Cfg {
+    static constexpr int THREADS = WARPS * 32;
+    static constexpr int XROW = KCHUNK + PAD;          // bf16 elements per x row in smem
+    static constexpr int X_BYTES = MT * XROW * 2;
+    static constexpr int WROW = KCHUNK + WPAD;         // bytes per weight row in smem
+    static constexpr int W_BYTES = NT * WROW;
+    static constexpr int STAGE_BYTES = X_BYTES + W_BYTES;
+    static constexpr int RED_BYTES = WARPS * MT * NT * 4;
+    static constexpr int SMEM_BYTES = STAGES * STAGE_BYTES > RED_BYTES ? STAGES * STAGE_BYTES : RED_BYTES;
+    static constexpr int KSTEPS = KCHUNK / 16;
+    static constexpr int NTILES = NT / 8;
+    static constexpr int XVEC = KCHUNK / 8;            // 16-byte vectors per x row per chunk
+    static constexpr int WVEC = KCHUNK / 16;           // 16-byte vectors per w row per chunk
+    static_assert(KCHUNK == SB, "one K chunk is one scale block");
+    static_assert(SB % NT == 0, "a block's rows lie inside one scale row group");
+    static_assert(KSTEPS % WARPS == 0, "warps split the k16 steps of a chunk evenly");
+    static_assert(NT % 8 == 0, "NT is a multiple of the n8 tile");
+    static_assert(STAGES >= 2, "double buffering at least");
+    static_assert(STAGE_BYTES % 16 == 0 && WROW % 16 == 0, "16-byte aligned stages and rows");
+};
+
+template <int NT, int WARPS, int KCHUNK, int STAGES, typename OutT>
+__global__ void __launch_bounds__(WARPS * 32) fp8_decode_gemm_kernel(
+        const __nv_bfloat16* __restrict__ x,     // [M, K]
+        const uint8_t* __restrict__ w,           // [N, K] e4m3
+        const float* __restrict__ scale,         // [ceil(N/128), K/128]
+        const float* __restrict__ bias,          // [N] or nullptr
+        OutT* __restrict__ out,                  // [M, N]
+        int M, int N, int K) {
+    using C = Cfg<NT, WARPS, KCHUNK, STAGES>;
+    extern __shared__ __align__(16) unsigned char smem_raw[];
+    const int tid = threadIdx.x, lane = tid & 31, warp = tid >> 5;
+    const int n0 = blockIdx.x * NT;
+    const int nchunks = K / KCHUNK;
+    const float* srow = scale + size_t(n0 / SB) * nchunks;   // this block's scale row: one value per chunk
+
+    auto stage_x = [&](int s) { return smem_raw + s * C::STAGE_BYTES; };
+    auto stage_w = [&](int s) { return smem_raw + s * C::STAGE_BYTES + C::X_BYTES; };
+
+    auto load_chunk = [&](int c, int s) {
+        const int k0 = c * KCHUNK;
+        unsigned char* xs = stage_x(s);
+        unsigned char* ws = stage_w(s);
+        for (int i = tid; i < MT * C::XVEC; i += C::THREADS) {
+            const int m = i / C::XVEC, v = i - m * C::XVEC;
+            const bool valid = m < M;
+            const __nv_bfloat16* src = x + size_t(valid ? m : 0) * K + k0 + v * 8;
+            cp_async16(smem_u32(xs + (m * C::XROW + v * 8) * 2), src, valid);
+        }
+        for (int i = tid; i < NT * C::WVEC; i += C::THREADS) {
+            const int r = i / C::WVEC, v = i - r * C::WVEC;
+            const int n = min(n0 + r, N - 1);
+            cp_async16(smem_u32(ws + r * C::WROW + v * 16), w + size_t(n) * K + k0 + v * 16, true);
+        }
+    };
+
+    float acc[C::NTILES][4];
+#pragma unroll
+    for (int j = 0; j < C::NTILES; ++j)
+#pragma unroll
+        for (int e = 0; e < 4; ++e) acc[j][e] = 0.0f;
+
+    const int mat = lane >> 3, mrow = lane & 7;
+    const int a_row = mrow + 8 * (mat & 1), a_col = 8 * (mat >> 1);   // ldmatrix.x4 A addressing
+    const int bn = lane >> 2, bk = (lane & 3) * 2;                     // B fragment: row bn of each n8 tile, k pairs bk, bk+8
+
+#pragma unroll
+    for (int c = 0; c < STAGES - 1; ++c) {
+        if (c < nchunks) load_chunk(c, c);
+        cp_async_commit();
+    }
+
+    for (int c = 0; c < nchunks; ++c) {
+        cp_async_wait<STAGES - 2>();
+        __syncthreads();
+        {
+            const int cn = c + STAGES - 1;
+            if (cn < nchunks) load_chunk(cn, cn % STAGES);
+            cp_async_commit();
+        }
+        const int s = c % STAGES;
+        const uint32_t xs = smem_u32(stage_x(s));
+        const unsigned char* ws = stage_w(s);
+        const float sc = __ldg(srow + c);
+#pragma unroll
+        for (int step = warp; step < C::KSTEPS; step += WARPS) {
+            const int k0 = step * 16;
+            uint32_t a[4];
+            ldmatrix_x4(a, xs + (a_row * C::XROW + k0 + a_col) * 2);
+#pragma unroll
+            for (int j = 0; j < C::NTILES; ++j) {
+                const unsigned char* p = ws + (8 * j + bn) * C::WROW + k0 + bk;
+                const uint16_t lo = *reinterpret_cast<const uint16_t*>(p);
+                const uint16_t hi = *reinterpret_cast<const uint16_t*>(p + 8);
+                mma_bf16_16816(acc[j], a, e4m3x2_scaled_to_bf16x2(lo, sc), e4m3x2_scaled_to_bf16x2(hi, sc));
+            }
+        }
+    }
+
+    cp_async_wait<0>();
+    __syncthreads();
+    float* red = reinterpret_cast<float*>(smem_raw);   // [WARPS][MT][NT]
+    {
+        float* mine = red + warp * (MT * NT);
+        const int r0 = lane >> 2, cc = (lane & 3) * 2;
+#pragma unroll
+        for (int j = 0; j < C::NTILES; ++j) {
+            const int n = 8 * j + cc;
+            mine[r0 * NT + n] = acc[j][0];
+            mine[r0 * NT + n + 1] = acc[j][1];
+            mine[(r0 + 8) * NT + n] = acc[j][2];
+            mine[(r0 + 8) * NT + n + 1] = acc[j][3];
+        }
+    }
+    __syncthreads();
+    for (int i = tid; i < MT * NT; i += C::THREADS) {
+        const int m = i / NT, n = i - m * NT;
+        if (m >= M || n0 + n >= N) continue;
+        float v = 0.0f;
+#pragma unroll
+        for (int wv = 0; wv < WARPS; ++wv) v += red[wv * (MT * NT) + i];
+        if (bias != nullptr) v += bias[n0 + n];
+        out[size_t(m) * N + n0 + n] = to_out<OutT>(v);
+    }
+}
+
+template <int NT, int WARPS, int KCHUNK, int STAGES, typename OutT>
+static inline void launch(const __nv_bfloat16* x, const uint8_t* w, const float* scale, const float* bias, OutT* out,
+                   int M, int N, int K, cudaStream_t stream) {
+    using C = Cfg<NT, WARPS, KCHUNK, STAGES>;
+    auto kern = fp8_decode_gemm_kernel<NT, WARPS, KCHUNK, STAGES, OutT>;
+    // The cache belongs to this module's kernel and the current device.
+    // An external inline function's GNU_UNIQUE flag can be coalesced across
+    // DSOs even though their CUDA kernel handles require separate setup.
+    static thread_local int configured_device = -1;
+    int device = -1;
+    check_cuda_status(cudaGetDevice(&device));
+    if (configured_device != device) {
+        check_cuda_status(cudaFuncSetAttribute(
+            kern, cudaFuncAttributeMaxDynamicSharedMemorySize, C::SMEM_BYTES));
+        configured_device = device;
+    }
+    const int blocks = (N + NT - 1) / NT;
+    kern<<<blocks, C::THREADS, C::SMEM_BYTES, stream>>>(x, w, scale, bias, out, M, N, K);
+}
+
+// Retained configs (fp8_gemm16_bench.py, 2026-09-07, RTX PRO 6000): 32 rows /
+// 4 stages for N >= 2048 (dense gate_up 17 us = 1.45 TB/s, dense down 10, DSA o_proj 12, DSA q_b 5, shared
+// down 2.1-2.9 us in that historical sweep). Its ROT24 was only 96/48 MiB for shared gate/up/down,
+// below this GPU's 128 MiB L2. The 2026-09-08 actual-weight cache control measures higher latency
+// with >3 L2 capacities; the old sweep does NOT establish cold-memory configuration optimality.
+// At N = 1024 (the shared-expert gate_up, which runs
+// on the aux stream underneath the Marlin routed-expert kernels) the grid is the limit, so 8 rows (128 blocks)
+// up to M = 8 and 16 rows above, where the 8-row tile re-streams the 16-row x tile too often. The stage count
+// there is chosen under contention, not in isolation: in isolation 4 stages is best (4.5-5.7 us vs cuBLAS
+// bf16 6.8-8.5), but in the serving trace the 4-stage kernel takes 20-23 us next to Marlin where the 8-stage
+// one takes 7-8 us (notebook 2026-09-07, swap-set part 2 follow-up); deeper prefetch keeps more bytes in
+// flight while the SMs are shared. The 16-row branch follows by analogy pending a profiled c16 round.
+template <typename OutT>
+inline void launch_auto(const __nv_bfloat16* x, const uint8_t* w, const float* scale, const float* bias, OutT* out,
+                        int M, int N, int K, cudaStream_t stream) {
+    if (N >= 2048) launch<32, 8, 128, 4>(x, w, scale, bias, out, M, N, K, stream);
+    else if (M <= 8) launch<8, 8, 128, 8>(x, w, scale, bias, out, M, N, K, stream);
+    else launch<16, 8, 128, 8>(x, w, scale, bias, out, M, N, K, stream);
+}
+
+inline bool supports(int M, int N, int K) {
+    return M >= 1 && M <= MT && K % 128 == 0 && K >= 512 && N % 8 == 0 && N >= 1024 && N <= 16384;
+}
+
+}  // namespace tms::decode_gemm_fp8

--- a/csrc/quixicore/serving/glm53_mhc_prefill_tc.cuh
+++ b/csrc/quixicore/serving/glm53_mhc_prefill_tc.cuh
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+// Qualified GLM53 SM120 BF16 prefill partials. This is the unchanged kernel
+// from mhc_prefill_tc_probe SHA45d5e817; only its namespace is different.
+// FP32 dot accumulation order differs from scalar partials. See the independent
+// accuracy contract and full census before changing its arithmetic.
+#include "mhc_ampere.cuh"
+#include "bf16_decode_gemm.cuh"
+
+namespace tms::glm53_mhc_prefill_tc {
+using namespace tms::dsv4_mhc;
+using namespace tms::decode_gemm;
+constexpr int H = 4096, FLATS = 512, ROW = 520, TILE = 32;
+constexpr int BYTES = (MIXES + TILE) * ROW * sizeof(__nv_bfloat16);
+static_assert(HC == 4 && SPLITS == 32 && MIXES == 24);
+static_assert(ROW % 8 == 0 && BYTES < 64 * 1024);
+
+template <bool FUSED>
+__global__ void __launch_bounds__(256) partials_tc(
+    const __nv_bfloat16* __restrict__ x,
+    const __nv_bfloat16* __restrict__ residual,
+    const float* __restrict__ post,
+    const float* __restrict__ comb,
+    const __nv_bfloat16* __restrict__ fn,
+    __nv_bfloat16* __restrict__ residual_out,
+    float* __restrict__ partial, int tokens) {
+    extern __shared__ __align__(16) unsigned char raw[];
+    auto* ft = reinterpret_cast<__nv_bfloat16*>(raw);
+    auto* vt = ft + MIXES * ROW;
+    const int split = blockIdx.x, first = blockIdx.y * TILE;
+    const int tid = threadIdx.x, lane = tid & 31, warp = tid >> 5;
+    const int dim_split = split * 128;
+
+    // Stage the original four stream slices without a persistent repack.
+    for (int vec = tid; vec < MIXES * FLATS / 8; vec += 256) {
+        const int output = vec / (FLATS / 8);
+        const int flat = (vec % (FLATS / 8)) * 8;
+        const int stream = flat / 128, dim = dim_split + flat % 128;
+        cp_async16(smem_u32(ft + output * ROW + flat),
+                   fn + output * (HC * H) + stream * H + dim, true);
+    }
+    cp_async_commit();
+
+    // The same vectorized fused post-mix expression/order as partials_prefill.
+    // Eight threads per token, two 8-wide chunks per thread/stream. Invalid
+    // token rows are explicitly zeroed because warp MMA reads full tiles.
+    const int t = tid >> 3, g = tid & 7, token = first + t;
+    auto* vr = vt + t * ROW;
+    if (token < tokens) {
+        if constexpr (FUSED) {
+            float pm[HC], cm[HC * HC];
+#pragma unroll
+            for (int i = 0; i < HC; ++i) pm[i] = post[token * HC + i];
+#pragma unroll
+            for (int i = 0; i < HC * HC; ++i) cm[i] = comb[token * HC * HC + i];
+#pragma unroll
+            for (int c = 0; c < 2; ++c) {
+                const int dim = dim_split + g * 16 + c * 8;
+                const uint4 xv = *reinterpret_cast<const uint4*>(x + size_t(token) * H + dim);
+                uint4 rv[HC];
+#pragma unroll
+                for (int i = 0; i < HC; ++i)
+                    rv[i] = *reinterpret_cast<const uint4*>(
+                        residual + (size_t(token) * HC + i) * H + dim);
+                const auto* xb = reinterpret_cast<const __nv_bfloat16*>(&xv);
+#pragma unroll
+                for (int out_stream = 0; out_stream < HC; ++out_stream) {
+                    __align__(16) __nv_bfloat16 rounded[8];
+#pragma unroll
+                    for (int j = 0; j < 8; ++j) {
+                        float value = pm[out_stream] * float(xb[j]);
+#pragma unroll
+                        for (int in_stream = 0; in_stream < HC; ++in_stream) {
+                            const auto* rb = reinterpret_cast<const __nv_bfloat16*>(&rv[in_stream]);
+                            value += cm[in_stream * HC + out_stream] * float(rb[j]);
+                        }
+                        rounded[j] = __float2bfloat16_rn(value);
+                    }
+                    *reinterpret_cast<uint4*>(
+                        residual_out + (size_t(token) * HC + out_stream) * H + dim) =
+                        *reinterpret_cast<const uint4*>(rounded);
+                    *reinterpret_cast<uint4*>(vr + out_stream * 128 + g * 16 + c * 8) =
+                        *reinterpret_cast<const uint4*>(rounded);
+                }
+            }
+        } else {
+#pragma unroll
+            for (int stream = 0; stream < HC; ++stream) {
+#pragma unroll
+                for (int c = 0; c < 2; ++c) {
+                    const int dim = dim_split + g * 16 + c * 8;
+                    *reinterpret_cast<uint4*>(vr + stream * 128 + g * 16 + c * 8) =
+                        *reinterpret_cast<const uint4*>(
+                            residual + (size_t(token) * HC + stream) * H + dim);
+                }
+            }
+        }
+    } else {
+#pragma unroll
+        for (int stream = 0; stream < HC; ++stream) {
+#pragma unroll
+            for (int c = 0; c < 2; ++c)
+                *reinterpret_cast<uint4*>(vr + stream * 128 + g * 16 + c * 8) =
+                    make_uint4(0, 0, 0, 0);
+        }
+    }
+    cp_async_wait<0>();
+    __syncthreads();
+
+    // Six warps cover 2 token tiles x 3 mix tiles. Use the proven BF16
+    // decode-GEMM fragment mapping; 520-element rows align every ldmatrix
+    // address to 16 bytes. The seventh warp preserves the old square-sum
+    // order; no BF16-rounded norm or approximate reduction is introduced.
+    if (warp < 6) {
+        const int m0 = (warp / 3) * 16, n0 = (warp % 3) * 8;
+        const int mat = lane >> 3, row = lane & 7;
+        float acc[4] = {};
+#pragma unroll 4
+        for (int k = 0; k < FLATS; k += 16) {
+            uint32_t a[4], b[2];
+            ldmatrix_x4(a, smem_u32(vt + (m0 + row + 8 * (mat & 1)) * ROW + k + 8 * (mat >> 1)));
+            ldmatrix_x2(b, smem_u32(ft + (n0 + row) * ROW + k + 8 * (mat & 1)));
+            mma_bf16_16816(acc, a, b[0], b[1]);
+        }
+        const int r0 = first + m0 + (lane >> 2), col = n0 + (lane & 3) * 2;
+        if (r0 < tokens) {
+            float* dst = partial + (size_t(r0) * SPLITS + split) * (MIXES + 1);
+            dst[col] = acc[0];
+            dst[col + 1] = acc[1];
+        }
+        if (r0 + 8 < tokens) {
+            float* dst = partial + (size_t(r0 + 8) * SPLITS + split) * (MIXES + 1);
+            dst[col] = acc[2];
+            dst[col + 1] = acc[3];
+        }
+    } else if (warp == 6) {
+        float sum = 0.0f;
+        const auto* src = vt + lane * ROW;
+#pragma unroll 8
+        for (int k = 0; k < FLATS; k += 2) {
+            const float2 v = __bfloat1622float2(
+                *reinterpret_cast<const __nv_bfloat162*>(src + k));
+            sum += v.x * v.x;
+            sum += v.y * v.y;
+        }
+        if (first + lane < tokens)
+            partial[(size_t(first + lane) * SPLITS + split) * (MIXES + 1) + MIXES] = sum;
+    }
+}
+}  // namespace tms::glm53_mhc_prefill_tc

--- a/csrc/quixicore/serving/glm53_sparse_swapab.cuh
+++ b/csrc/quixicore/serving/glm53_sparse_swapab.cuh
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+// SM120 GLM53 BF16 sparse MLA candidate. Mechanism precedent: FlashInfer
+// #4751/#4802 candidates-on-M / register-resident Q, adapted to our BF16 KV
+// and FP16 probability/value product. No FP8 conversions or cache changes.
+namespace slimserve::glm53_swapab {
+using BF = __nv_bfloat16;
+// The selected checkpoint has 64 attention heads, sharded over TP4.
+constexpr int HEADS = 16, DIM = 512, KEYS = 32;
+constexpr int MATH_WARPS = HEADS / 8, MATH_THREADS = MATH_WARPS * 32;
+constexpr int THREADS = MATH_THREADS + 32;
+// A 512-element row aliases every QK row onto the same four shared banks.
+// Rotate each row by four banks, preserving the bulk copy's 16-byte alignment.
+constexpr int SHARED_DIM = DIM + 8;
+
+struct alignas(128) Shared {
+  BF kv[2][KEYS][SHARED_DIM];
+  int valid[2][KEYS];
+  half prob[MATH_WARPS][KEYS][8];
+  alignas(8) unsigned long long ready[2], released[2];
+};
+
+__device__ __forceinline__ unsigned smem_addr(const void* p) {
+  return unsigned(__cvta_generic_to_shared(p));
+}
+__device__ __forceinline__ void init_bar(unsigned long long* p, unsigned count) {
+  asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;" ::
+               "r"(smem_addr(p)), "r"(count) : "memory");
+}
+__device__ __forceinline__ void wait_bar(unsigned long long* p, unsigned phase) {
+  asm volatile("{ .reg .pred done; wait_loop: "
+               "mbarrier.try_wait.parity.shared::cta.b64 done, [%0], %1; "
+               "@!done bra wait_loop; }" ::
+               "r"(smem_addr(p)), "r"(phase) : "memory");
+}
+__device__ __forceinline__ void release_bar(unsigned long long* p) {
+  asm volatile("mbarrier.arrive.shared::cta.b64 _, [%0];" ::
+               "r"(smem_addr(p)) : "memory");
+}
+__device__ __forceinline__ void expect_bytes(unsigned long long* p) {
+  asm volatile("mbarrier.arrive.expect_tx.shared::cta.b64 _, [%0], %1;" ::
+               "r"(smem_addr(p)), "r"(KEYS * DIM * 2) : "memory");
+}
+__device__ __forceinline__ void copy_row(BF* dst, const BF* src,
+                                          unsigned long long* bar) {
+  asm volatile("cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes "
+               "[%0], [%1], 1024, [%2];" ::
+               "r"(smem_addr(dst)), "l"(src), "r"(smem_addr(bar)) : "memory");
+}
+
+template <bool BF16>
+__device__ __forceinline__ void mma(unsigned a0, unsigned a1, unsigned a2,
+                                    unsigned a3, unsigned b0, unsigned b1, float* c) {
+#define MMA(SCALAR) asm volatile( \
+    "mma.sync.aligned.m16n8k16.row.col.f32." SCALAR "." SCALAR ".f32 " \
+    "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};" \
+    : "+f"(c[0]), "+f"(c[1]), "+f"(c[2]), "+f"(c[3]) \
+    : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1))
+  if constexpr (BF16) { MMA("bf16"); } else { MMA("f16"); }
+#undef MMA
+}
+
+__device__ __forceinline__ unsigned pack_half(float lo, float hi) {
+  half2 value = __floats2half2_rn(lo, hi);
+  return reinterpret_cast<unsigned&>(value);
+}
+__device__ __forceinline__ unsigned load_pair(const BF* p) {
+  return *reinterpret_cast<const unsigned*>(p);
+}
+__device__ __forceinline__ unsigned bf_pair_to_half(unsigned value) {
+  const auto floats = __bfloat1622float2(
+      *reinterpret_cast<const __nv_bfloat162*>(&value));
+  return pack_half(floats.x, floats.y);
+}
+__device__ __forceinline__ void load_value_matrix(const BF* address, unsigned* a) {
+  // The four 8x8 matrices form V^T's 16x16 MMA A fragment. Convert after
+  // the collective transpose, retaining the existing FP16 value boundary.
+  asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 "
+               "{%0,%1,%2,%3}, [%4];" :
+               "=r"(a[0]), "=r"(a[1]), "=r"(a[2]), "=r"(a[3]) :
+               "r"(smem_addr(address)));
+#pragma unroll
+  for (int i = 0; i < 4; i++) a[i] = bf_pair_to_half(a[i]);
+}
+__device__ __forceinline__ float warp8_sum(float value) {
+  value += __shfl_xor_sync(0xffffffff, value, 4);
+  value += __shfl_xor_sync(0xffffffff, value, 8);
+  value += __shfl_xor_sync(0xffffffff, value, 16);
+  return value;
+}
+__device__ __forceinline__ float warp8_max(float value) {
+  value = fmaxf(value, __shfl_xor_sync(0xffffffff, value, 4));
+  value = fmaxf(value, __shfl_xor_sync(0xffffffff, value, 8));
+  value = fmaxf(value, __shfl_xor_sync(0xffffffff, value, 16));
+  return value;
+}
+
+__global__ __launch_bounds__(THREADS, 1) void sparse_nope(
+    const BF* __restrict__ query, const BF* __restrict__ cache,
+    const int* __restrict__ tables, const int* __restrict__ indices,
+    const int* __restrict__ lengths, BF* __restrict__ output,
+    int topk, int table_stride, int block_size, int64_t page_stride, float scale) {
+  extern __shared__ __align__(128) unsigned char storage[];
+  auto& sm = *reinterpret_cast<Shared*>(storage);
+  const int token = blockIdx.x, warp = threadIdx.x / 32, lane = threadIdx.x % 32;
+  const int length = min(max(lengths[token], 0), topk);
+  const int tiles = (length + KEYS - 1) / KEYS;
+  if (threadIdx.x == 0) {
+    init_bar(&sm.ready[0], 1); init_bar(&sm.ready[1], 1);
+    init_bar(&sm.released[0], MATH_THREADS);
+    init_bar(&sm.released[1], MATH_THREADS);
+  }
+  asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+  __syncthreads();
+  if (warp == MATH_WARPS) {
+    // One IO lane owns each selected latent. Real request-local pages and
+    // strides are preserved; invalid slots copy page0 but remain masked.
+    for (int tile = 0; tile < tiles; tile++) {
+      const int buf = tile & 1;
+      wait_bar(&sm.released[buf], 1 ^ ((tile / 2) & 1));
+      const int pos = tile * KEYS + lane;
+      const int selected = pos < length ? indices[int64_t(token) * topk + pos] : -1;
+      const int col = selected >= 0 ? selected / block_size : -1;
+      const int block = col >= 0 && col < table_stride
+                            ? tables[int64_t(token) * table_stride + col] : -1;
+      sm.valid[buf][lane] = block >= 0;
+      const int64_t address = block >= 0
+          ? int64_t(block) * page_stride + int64_t(selected % block_size) * DIM : 0;
+      __syncwarp();
+      if (lane == 0) expect_bytes(&sm.ready[buf]);
+      __syncwarp();
+      copy_row(sm.kv[buf][lane], cache + address, &sm.ready[buf]);
+    }
+    return;
+  }
+
+  const int gid = lane / 4, tid = lane % 4;
+  const BF* q = query + (int64_t(token) * HEADS + warp * 8 + gid) * DIM;
+  unsigned q_frag[DIM / 16][2];
+#pragma unroll
+  for (int k = 0; k < DIM / 16; k++) {
+    q_frag[k][0] = load_pair(q + k * 16 + tid * 2);
+    q_frag[k][1] = load_pair(q + k * 16 + tid * 2 + 8);
+  }
+  float acc[DIM / 16][4] = {};
+  float maxima[2] = {-1e30f, -1e30f}, sums[2] = {};
+  for (int tile = 0; tile < tiles; tile++) {
+    const int buf = tile & 1;
+    wait_bar(&sm.ready[buf], (tile / 2) & 1);
+    float score[2][4] = {};
+#pragma unroll
+    for (int k = 0; k < DIM / 16; k++) {
+#pragma unroll
+      for (int m = 0; m < 2; m++) {
+        const BF* r0 = sm.kv[buf][m * 16 + gid] + k * 16 + tid * 2;
+        const BF* r1 = r0 + 8 * SHARED_DIM;
+        mma<true>(load_pair(r0), load_pair(r1), load_pair(r0 + 8),
+                  load_pair(r1 + 8), q_frag[k][0], q_frag[k][1], score[m]);
+      }
+    }
+    float alpha[2];
+#pragma unroll
+    for (int h = 0; h < 2; h++) {
+      float maximum = -1e30f;
+#pragma unroll
+      for (int m = 0; m < 2; m++) {
+        score[m][h] = sm.valid[buf][m * 16 + gid] ? score[m][h] * scale : -INFINITY;
+        score[m][2 + h] = sm.valid[buf][m * 16 + gid + 8]
+                             ? score[m][2 + h] * scale : -INFINITY;
+        maximum = fmaxf(maximum, fmaxf(score[m][h], score[m][2 + h]));
+      }
+      maximum = fmaxf(maxima[h], warp8_max(maximum));
+      alpha[h] = __expf(maxima[h] - maximum);
+      maxima[h] = maximum;
+      float subtotal = 0;
+#pragma unroll
+      for (int m = 0; m < 2; m++) {
+        score[m][h] = __expf(score[m][h] - maximum);
+        score[m][2 + h] = __expf(score[m][2 + h] - maximum);
+        subtotal += score[m][h] + score[m][2 + h];
+        sm.prob[warp][m * 16 + gid][tid * 2 + h] = __float2half_rn(score[m][h]);
+        sm.prob[warp][m * 16 + gid + 8][tid * 2 + h] = __float2half_rn(score[m][2 + h]);
+      }
+      sums[h] = sums[h] * alpha[h] + warp8_sum(subtotal);
+    }
+    __syncwarp();
+    unsigned p_frag[2][2];
+#pragma unroll
+    for (int k = 0; k < 2; k++) {
+      p_frag[k][0] = pack_half(__half2float(sm.prob[warp][k * 16 + tid * 2][gid]),
+                              __half2float(sm.prob[warp][k * 16 + tid * 2 + 1][gid]));
+      p_frag[k][1] = pack_half(__half2float(sm.prob[warp][k * 16 + tid * 2 + 8][gid]),
+                              __half2float(sm.prob[warp][k * 16 + tid * 2 + 9][gid]));
+    }
+#pragma unroll
+    for (int m = 0; m < DIM / 16; m++) {
+      float pv[4] = {};
+#pragma unroll
+      for (int k = 0; k < 2; k++) {
+        const int r = k * 16 + lane % 8 + (lane / 16) * 8;
+        const int d = m * 16 + ((lane / 8) % 2) * 8;
+        unsigned values[4];
+        load_value_matrix(&sm.kv[buf][r][d], values);
+        mma<false>(values[0], values[1], values[2], values[3],
+                   p_frag[k][0], p_frag[k][1], pv);
+      }
+#pragma unroll
+      for (int i = 0; i < 4; i++) acc[m][i] = acc[m][i] * alpha[i % 2] + pv[i];
+    }
+    // Every shared-memory reader participates in release. Do not delegate
+    // arrival to lane0: buffer reuse must wait for every math thread.
+    release_bar(&sm.released[buf]);
+  }
+#pragma unroll
+  for (int m = 0; m < DIM / 16; m++) {
+#pragma unroll
+    for (int h = 0; h < 2; h++) {
+      const int64_t row = (int64_t(token) * HEADS + warp * 8 + tid * 2 + h) * DIM;
+      output[row + m * 16 + gid] = __float2bfloat16_rn(sums[h] > 0 ? acc[m][h] / sums[h] : 0);
+      output[row + m * 16 + gid + 8] = __float2bfloat16_rn(sums[h] > 0 ? acc[m][2 + h] / sums[h] : 0);
+    }
+  }
+}
+}  // namespace slimserve::glm53_swapab

--- a/csrc/quixicore/serving/glm_moe_combine.cuh
+++ b/csrc/quixicore/serving/glm_moe_combine.cuh
@@ -1,0 +1,78 @@
+#pragma once
+// Fused MoE combine for the Marlin path: out[t] = shared[t] + sum_k x[t, k] in one
+// launch, fp32 accumulation, a single bf16 rounding. Replaces the moe_sum kernel,
+// the finalize copy into the modular kernel's output buffer and the inductor add
+// of the shared-expert output: three launches per MoE layer at decode.
+// x is the per-assignment Marlin w2 output [T, topk, D] (D contiguous), shared
+// the shared-expert MLP output [T, D], out [T, D]; D is a multiple of 8 so every
+// thread moves 16-byte packs. TOPK > 0 unrolls the top-k loop, TOPK == 0 reads
+// the runtime top-k. The kernel is total: it indexes nothing beyond [T, topk, D].
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace tms::glm_moe_combine {
+
+constexpr int THREADS = 256;
+constexpr int VEC = 8;  // bf16 per 16-byte pack
+
+struct __align__(16) pack_t {
+    __nv_bfloat162 v[VEC / 2];
+};
+
+__device__ __forceinline__ void accumulate(float (&acc)[VEC], const __nv_bfloat16* p) {
+    const pack_t packed = *reinterpret_cast<const pack_t*>(p);
+#pragma unroll
+    for (int j = 0; j < VEC / 2; ++j) {
+        const float2 f = __bfloat1622float2(packed.v[j]);
+        acc[2 * j] += f.x;
+        acc[2 * j + 1] += f.y;
+    }
+}
+
+template <int TOPK>
+__global__ __launch_bounds__(THREADS) void moe_sum_add_kernel(
+        __nv_bfloat16* __restrict__ out,           // [T, D]
+        const __nv_bfloat16* __restrict__ x,       // [T, topk, D]
+        const __nv_bfloat16* __restrict__ shared,  // [T, D]
+        int64_t num_tokens, int d, int topk) {
+    const int64_t n_vec = d / VEC;
+    const int64_t total = num_tokens * n_vec;
+    const int k_count = TOPK > 0 ? TOPK : topk;
+    for (int64_t i = int64_t(blockIdx.x) * blockDim.x + threadIdx.x; i < total;
+         i += int64_t(gridDim.x) * blockDim.x) {
+        const int64_t token = i / n_vec;
+        const int64_t col = (i - token * n_vec) * VEC;
+        float acc[VEC];
+#pragma unroll
+        for (int j = 0; j < VEC; ++j) acc[j] = 0.0f;
+        accumulate(acc, shared + token * d + col);
+        const __nv_bfloat16* xt = x + token * int64_t(k_count) * d + col;
+        if constexpr (TOPK > 0) {
+#pragma unroll
+            for (int k = 0; k < TOPK; ++k) accumulate(acc, xt + int64_t(k) * d);
+        } else {
+            for (int k = 0; k < k_count; ++k) accumulate(acc, xt + int64_t(k) * d);
+        }
+        pack_t o;
+#pragma unroll
+        for (int j = 0; j < VEC / 2; ++j)
+            o.v[j] = __floats2bfloat162_rn(acc[2 * j], acc[2 * j + 1]);
+        *reinterpret_cast<pack_t*>(out + token * d + col) = o;
+    }
+}
+
+// Host-side launch shared by the native binding and the dev build.
+inline void launch_moe_sum_add(__nv_bfloat16* out, const __nv_bfloat16* x,
+                               const __nv_bfloat16* shared, int64_t num_tokens,
+                               int d, int topk, cudaStream_t stream) {
+    if (num_tokens == 0) return;
+    const int64_t total = num_tokens * (d / VEC);
+    const int blocks = int(std::min<int64_t>((total + THREADS - 1) / THREADS, 16384));
+    if (topk == 8)
+        moe_sum_add_kernel<8><<<blocks, THREADS, 0, stream>>>(out, x, shared, num_tokens, d, topk);
+    else
+        moe_sum_add_kernel<0><<<blocks, THREADS, 0, stream>>>(out, x, shared, num_tokens, d, topk);
+}
+
+}  // namespace tms::glm_moe_combine

--- a/csrc/quixicore/serving/glm_moe_combine.cuh
+++ b/csrc/quixicore/serving/glm_moe_combine.cuh
@@ -7,6 +7,8 @@
 // the shared-expert MLP output [T, D], out [T, D]; D is a multiple of 8 so every
 // thread moves 16-byte packs. TOPK > 0 unrolls the top-k loop, TOPK == 0 reads
 // the runtime top-k. The kernel is total: it indexes nothing beyond [T, topk, D].
+// All three base pointers must also be 16-byte aligned (checked by the binding).
+#include <algorithm>
 #include <cuda_bf16.h>
 #include <cuda_runtime.h>
 #include <cstdint>

--- a/csrc/quixicore/serving/glm_moe_routing.cuh
+++ b/csrc/quixicore/serving/glm_moe_routing.cuh
@@ -1,0 +1,173 @@
+#pragma once
+// Fused small-M MoE routing for GLM-5.3-Flash: sigmoid (or sqrt-softplus) scores,
+// bias-only top-k selection (noaux_tc / grouped_topk with one expert group),
+// renormalize + scaling, and the Marlin block alignment (moe_align_block_size
+// semantics) in ONE block, for M x TOPK <= 128 assignments and E <= 512 experts.
+// Replaces grouped_topk + moe_align_block_size (2 blocks) + count_and_sort + the
+// fill kernel, four launches per MoE layer at decode. Developed and measured on
+// sm_120 (2026-09-04): ids / weights / alignment identical to the reference path,
+// 6.3 -> 3.7 us per layer at M=1, 6.8 -> 4.8 at M=8.
+//
+// The selection is total over non-finite inputs (2026-09-07): vLLM's dummy runs
+// (graph-capture warmups, the sampler warmup) feed NaN activations, so a NaN
+// score ranks below every finite score, a selected expert is marked -inf, and
+// ties go to the lowest index. Every expert id is therefore in [0, E) and the
+// block layout is valid (valid entries first, then padding) whatever the input.
+// Before that, NaN logits produced the index E, aliased the shared counters and
+// scattered assignments after padding; Marlin takes the first num_valid entries
+// of a block as tokens, so it read the padding value numel as a row and touched
+// one row past the activations (illegal address when that page was unmapped,
+// silent corruption of the neighbouring buffer otherwise).
+#include <cuda_runtime.h>
+#include <cub/cub.cuh>
+#include <cfloat>
+#include <cstdint>
+
+namespace tms::glm_route {
+
+constexpr int THREADS = 512;
+constexpr int MAX_TOKENS = 16;
+
+enum Scoring : int { SIGMOID = 0, SQRT_SOFTPLUS = 1 };
+
+__device__ __forceinline__ float apply_scoring(float x, int scoring) {
+    if (scoring == SIGMOID) return 1.0f / (1.0f + expf(-x));
+    // torch.nn.functional.softplus with beta=1, threshold=20, then sqrt.
+    const float sp = x > 20.0f ? x : log1pf(expf(x));
+    return sqrtf(sp);
+}
+
+// STABLE_ALIGNMENT is a separately qualified opt-in candidate. The existing
+// serving instantiation keeps its atomic scatter until serving qualification.
+template <int E, int TOPK, bool STABLE_ALIGNMENT = false>
+__global__ __launch_bounds__(THREADS) void route_align_kernel(
+        const float* __restrict__ logits,      // [M, E]
+        const float* __restrict__ bias,        // [E]
+        float* __restrict__ topk_weights,      // [M, TOPK]
+        int32_t* __restrict__ topk_ids,        // [M, TOPK]
+        int32_t* __restrict__ sorted_token_ids,// [max_padded]
+        int32_t* __restrict__ expert_ids,      // [max_blocks]
+        int32_t* __restrict__ num_tokens_post_pad,
+        int M, int scoring, float scaling, bool renormalize, int block_size,
+        int max_padded, int max_blocks) {
+    static_assert(E <= THREADS, "one thread per expert for the scan");
+    static_assert((E + 31) / 32 > TOPK, "every lane must keep an unselected candidate");
+    __shared__ float choice[MAX_TOKENS][E];   // biased scores, -inf once selected
+    __shared__ float score[MAX_TOKENS][E];    // unbiased scores (weights)
+    constexpr int ASSIGNMENT_WARPS = (MAX_TOKENS * TOPK + 31) / 32;
+    __shared__ int counts[STABLE_ALIGNMENT ? ASSIGNMENT_WARPS * E : E];
+    __shared__ int cursor[STABLE_ALIGNMENT ? 1 : E];
+    __shared__ int cumsum[E + 1];
+    __shared__ int sel[MAX_TOKENS][TOPK];      // selected experts, always < E
+    __shared__ typename cub::BlockScan<int, THREADS>::TempStorage scan_tmp;
+    const int tid = threadIdx.x, lane = tid & 31, warp = tid >> 5;
+    const int numel = M * TOPK;
+
+    // A. scores for every (token, expert); a NaN choice ranks below every
+    // finite one (-FLT_MAX) but above a selected expert (-inf).
+    for (int idx = tid; idx < M * E; idx += THREADS) {
+        const int m = idx / E, e = idx - m * E;
+        const float s = apply_scoring(logits[idx], scoring);
+        score[m][e] = s;
+        const float c = s + bias[e];
+        choice[m][e] = (c == c) ? c : -FLT_MAX;
+    }
+    if constexpr (STABLE_ALIGNMENT) {
+        for (int i = tid; i < ASSIGNMENT_WARPS * E; i += THREADS) counts[i] = 0;
+    } else {
+        if (tid < E) { counts[tid] = 0; cursor[tid] = 0; }
+    }
+    __syncthreads();
+
+    // B. top-k per token, one warp per token: TOPK rounds of warp argmax.
+    // Each lane scans 9 experts of which at most TOPK are selected (-inf), so
+    // every round has a candidate >= -FLT_MAX and yields an index in [0, E).
+    if (warp < M) {
+        const int m = warp;
+        float wsum = 0.0f;
+#pragma unroll
+        for (int k = 0; k < TOPK; ++k) {
+            float best = -INFINITY; int best_e = E;
+            for (int e = lane; e < E; e += 32) {
+                const float v = choice[m][e];
+                if (v > best || (v == best && e < best_e)) { best = v; best_e = e; }
+            }
+#pragma unroll
+            for (int off = 16; off > 0; off >>= 1) {
+                const float ov = __shfl_xor_sync(0xffffffffu, best, off);
+                const int oe = __shfl_xor_sync(0xffffffffu, best_e, off);
+                if (ov > best || (ov == best && oe < best_e)) { best = ov; best_e = oe; }
+            }
+            // Shuffle synchronization does not order shared-memory accesses.
+            // Finish every lane's choice reads before lane0 marks the winner;
+            // the following sync then publishes that write for the next round.
+            __syncwarp();
+            if (lane == 0) { choice[m][best_e] = -INFINITY; sel[m][k] = best_e; }
+            __syncwarp();
+            wsum += score[m][best_e];
+        }
+        if (lane == 0) {
+            const float inv = renormalize ? 1.0f / fmaxf(wsum, 1e-20f) : 1.0f;
+#pragma unroll
+            for (int k = 0; k < TOPK; ++k) {
+                const int e = sel[m][k];
+                topk_ids[m * TOPK + k] = e;
+                topk_weights[m * TOPK + k] = score[m][e] * inv * scaling;
+                // Group by the warp of the flattened assignment, NOT the
+                // scoring warp (one warp/token). TOPK=8 gives four tokens per
+                // assignment warp. These integer histogram sums are exact.
+                const int bucket = STABLE_ALIGNMENT ? (m * TOPK + k) / 32 : 0;
+                atomicAdd(&counts[bucket * E + e], 1);
+            }
+        }
+    }
+    __syncthreads();
+
+    // C. alignment: per-expert padded counts, exclusive scan, block expert ids.
+    int padded = 0;
+    if (tid < E) {
+        int count = counts[tid];
+        if constexpr (STABLE_ALIGNMENT) {
+#pragma unroll
+            for (int w = 1; w < ASSIGNMENT_WARPS; ++w) count += counts[w * E + tid];
+        }
+        padded = ((count + block_size - 1) / block_size) * block_size;
+    }
+    int excl = 0, total = 0;
+    cub::BlockScan<int, THREADS>(scan_tmp).ExclusiveSum(padded, excl, total);
+    if (tid < E) cumsum[tid] = excl;
+    if (tid == 0) { cumsum[E] = total; num_tokens_post_pad[0] = total; }
+    __syncthreads();
+    for (int i = tid; i < max_padded; i += THREADS) sorted_token_ids[i] = numel;
+    if (tid < E) {
+        for (int i = cumsum[tid]; i < cumsum[tid + 1]; i += block_size) expert_ids[i / block_size] = tid;
+    }
+    for (int b = total / block_size + tid; b < max_blocks; b += THREADS) expert_ids[b] = -1;
+    __syncthreads();
+    // Scatter assignments into their expert's range. Stable rank counts only
+    // earlier flattened IDs: all earlier assignment warps plus matching lower
+    // lanes. A ballot mask handles partial warps without reading uninitialized
+    // sel entries. No new global workspace, launch, or CTA barrier is needed.
+    if constexpr (STABLE_ALIGNMENT) {
+        static_assert(MAX_TOKENS * TOPK <= THREADS);
+        const unsigned valid = __ballot_sync(0xffffffffu, tid < numel);
+        if (tid < numel) {
+            const int e = sel[tid / TOPK][tid % TOPK];
+            const unsigned peers = __match_any_sync(valid, e);
+            int rank = __popc(peers & ((1u << lane) - 1u));
+#pragma unroll
+            for (int w = 0; w < ASSIGNMENT_WARPS; ++w) {
+                if (w < warp) rank += counts[w * E + e];
+            }
+            sorted_token_ids[cumsum[e] + rank] = tid;
+        }
+    } else {
+        for (int a = tid; a < numel; a += THREADS) {
+            const int e = sel[a / TOPK][a - (a / TOPK) * TOPK];
+            const int pos = cumsum[e] + atomicAdd(&cursor[e], 1);
+            sorted_token_ids[pos] = a;
+        }
+    }
+}
+
+}  // namespace tms::glm_route

--- a/csrc/quixicore/serving/glm_moe_stable_align.cuh
+++ b/csrc/quixicore/serving/glm_moe_stable_align.cuh
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// GLM53 SM120 stable alignment. Native dispatch instantiates only the qualified
+// small/count256 and large/direct1024 policies; other variants are probe-only.
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cub/block/block_scan.cuh>
+
+namespace tms::glm_stable_align {
+
+constexpr int EXPERTS = 288;
+constexpr int THREADS = 256;
+constexpr int MAX_WORDS = 8192 * 8 / 32;
+
+// Integer histograms determine the same padded expert ranges as Marlin's
+// alignment. A second CTA initializes all sorted capacity, including tails.
+template<int COUNT_THREADS, bool AGGREGATE = true>
+__global__ void count_prefix(const int* ids, int* sorted, int* experts,
+                             int* padded, int* offsets, int numel, int block,
+                             int capacity, int max_blocks) {
+    static_assert(COUNT_THREADS == 256 || COUNT_THREADS == 1024);
+    constexpr int WARPS = COUNT_THREADS / 32;
+    constexpr int ITEMS = (EXPERTS + COUNT_THREADS - 1) / COUNT_THREADS;
+    const int tid = threadIdx.x;
+    if (blockIdx.x == 1) {
+        for (int i = tid; i < capacity; i += COUNT_THREADS) sorted[i] = numel;
+        return;
+    }
+    __shared__ int histogram[WARPS * EXPERTS];
+    using Scan = cub::BlockScan<int, COUNT_THREADS>;
+    __shared__ typename Scan::TempStorage scan;
+    for (int i = tid; i < WARPS * EXPERTS; i += COUNT_THREADS) histogram[i] = 0;
+    __syncthreads();
+
+    const int lane = tid % 32, warp = tid / 32;
+    // All lanes execute every match, including a partially populated last tile.
+    for (int base = 0; base < numel; base += COUNT_THREADS) {
+        const int i = base + tid;
+        const int expert = i < numel ? ids[i] : -1;
+        if constexpr (AGGREGATE) {
+            const unsigned peers = __match_any_sync(0xffffffffu, expert);
+            if (expert >= 0 && expert < EXPERTS && lane == __ffs(peers) - 1) {
+                atomicAdd(histogram + warp * EXPERTS + expert, __popc(peers));
+            }
+        } else {
+            if (expert >= 0 && expert < EXPERTS) {
+                atomicAdd(histogram + warp * EXPERTS + expert, 1);
+            }
+        }
+    }
+    __syncthreads();
+
+    int counts[ITEMS], starts[ITEMS];
+    #pragma unroll
+    for (int j = 0; j < ITEMS; ++j) {
+        const int expert = ITEMS * tid + j;
+        int count = 0;
+        if (expert < EXPERTS) {
+            #pragma unroll
+            for (int w = 0; w < WARPS; ++w) count += histogram[w * EXPERTS + expert];
+        }
+        counts[j] = (count + block - 1) / block * block;
+    }
+    Scan(scan).ExclusiveSum(counts, starts);
+    #pragma unroll
+    for (int j = 0; j < ITEMS; ++j) {
+        const int expert = ITEMS * tid + j;
+        if (expert <= EXPERTS) offsets[expert] = starts[j];
+        if (expert < EXPERTS) {
+            for (int i = 0; i < counts[j]; i += block) {
+                experts[(starts[j] + i) / block] = expert;
+            }
+        } else if (expert == EXPERTS) {
+            *padded = starts[j];
+            for (int i = starts[j] / block; i < max_blocks; ++i) experts[i] = -1;
+        }
+    }
+}
+
+// One CTA per expert. Ballots encode membership in flattened assignment order;
+// scanning popcounts gives stable output positions without atomics or a sort.
+// At the largest shape all CTAs collectively read 72 MiB of route IDs. This
+// deliberate L2-traffic tradeoff must be measured; it is not a bandwidth claim.
+template<int SCATTER_THREADS>
+__global__ void scatter_bitmap(const int* ids, int* sorted, const int* offsets,
+                               int numel) {
+    static_assert(SCATTER_THREADS == 256 || SCATTER_THREADS == 512);
+    const int expert = blockIdx.x, tid = threadIdx.x;
+    if (offsets[expert] == offsets[expert + 1]) return;  // CTA-uniform
+    __shared__ unsigned bitmap[MAX_WORDS];
+    using Scan = cub::BlockScan<int, SCATTER_THREADS>;
+    __shared__ typename Scan::TempStorage scan;
+    const int words = (numel + 31) / 32;
+    for (int base = 0; base < numel; base += SCATTER_THREADS) {
+        const int i = base + tid;
+        const bool selected = i < numel && ids[i] == expert;
+        const unsigned mask = __ballot_sync(0xffffffffu, selected);
+        if (tid % 32 == 0 && i / 32 < words) bitmap[i / 32] = mask;
+    }
+    __syncthreads();
+
+    constexpr int ITEMS = MAX_WORDS / SCATTER_THREADS;
+    int counts[ITEMS], starts[ITEMS];
+    unsigned masks[ITEMS];
+    #pragma unroll
+    for (int j = 0; j < ITEMS; ++j) {
+        const int word = tid * ITEMS + j;
+        masks[j] = word < words ? bitmap[word] : 0;
+        counts[j] = __popc(masks[j]);
+    }
+    Scan(scan).ExclusiveSum(counts, starts);
+    const int begin = offsets[expert];
+    #pragma unroll
+    for (int j = 0; j < ITEMS; ++j) {
+        unsigned mask = masks[j];
+        int out = begin + starts[j];
+        while (mask) {
+            sorted[out++] = (tid * ITEMS + j) * 32 + __ffs(mask) - 1;
+            mask &= mask - 1;
+        }
+    }
+}
+
+}  // namespace tms::glm_stable_align

--- a/csrc/quixicore/serving/glm_moe_stable_align.cuh
+++ b/csrc/quixicore/serving/glm_moe_stable_align.cuh
@@ -11,6 +11,8 @@ namespace tms::glm_stable_align {
 constexpr int EXPERTS = 288;
 constexpr int THREADS = 256;
 constexpr int MAX_WORDS = 8192 * 8 / 32;
+// Both host launchers enforce ids [17..8192, 8] before narrowing numel;
+// scatter_bitmap therefore never receives more than MAX_WORDS bitmap words.
 
 // Integer histograms determine the same padded expert ranges as Marlin's
 // alignment. A second CTA initializes all sorted capacity, including tails.

--- a/csrc/quixicore/serving/mhc_ampere.cuh
+++ b/csrc/quixicore/serving/mhc_ampere.cuh
@@ -5,6 +5,7 @@
 #include <cuda_runtime.h>
 #include <cub/cub.cuh>
 #include <cuda/std/functional>
+#include <type_traits>
 
 namespace tms::dsv4_mhc {
 
@@ -112,6 +113,204 @@ __global__ void partials(
                 block_sum += warp_partials[source_warp][output];
             }
             partial[(token * SPLITS + split) * (NOUT + 1) + output] = block_sum;
+        }
+    }
+}
+
+// Prefill-shaped partials for the split path. `partials` above is shaped
+// for decode: 32 x T blocks, two residual elements per thread, 24 fn loads
+// and 24 FMAs per element and a 125-shuffle reduction per warp per token;
+// at T = 7000 it runs the residual streams at 7% of HBM bandwidth. Here a
+// block owns one split of one 32-token tile, where split s is the 128-dim
+// slice [s * 128, s * 128 + 128) of all four streams (512 flats): the
+// split's fn values are staged in shared memory once per tile, the tile's
+// residual rows once (for the fused post-mix, each input element is read
+// once and yields all four output streams), and each lane then runs whole
+// 512-long dot products for one token and three mix rows. Same partial
+// layout ([T][SPLITS][MIXES + 1]; the flat-to-split assignment differs from
+// the strided one above), so finalize_pre_mix / apply_pre_mix are unchanged.
+// residual_out is bit-identical to `partials` (same expression, same
+// order); the mix sums differ only in fp32 summation order.
+constexpr int PREFILL_TILE = 32;
+constexpr int PREFILL_FLATS = 2 * THREADS;
+constexpr int PREFILL_FN_STRIDE = PREFILL_FLATS;
+constexpr int PREFILL_V_STRIDE = PREFILL_FLATS + 2;
+constexpr size_t PREFILL_SMEM =
+    size_t(MIXES) * PREFILL_FN_STRIDE * sizeof(float) +
+    size_t(PREFILL_TILE) * PREFILL_V_STRIDE * sizeof(__nv_bfloat16);
+
+template <bool FUSED_POST, int HIDDEN_SIZE, typename FnT, bool PAIRED_FN = false>
+__global__ void __launch_bounds__(THREADS) partials_prefill(
+    const __nv_bfloat16* __restrict__ x,
+    const __nv_bfloat16* __restrict__ residual,
+    const float* __restrict__ post,
+    const float* __restrict__ comb,
+    const FnT* __restrict__ fn,
+    __nv_bfloat16* __restrict__ residual_out,
+    float* __restrict__ partial,
+    int num_tokens) {
+    constexpr int TOTAL = HC * HIDDEN_SIZE;
+    constexpr int DIMS = HIDDEN_SIZE / SPLITS;
+    static_assert(HC * DIMS == PREFILL_FLATS,
+                  "partials_prefill: 32 splits of 4 x 128 flats");
+    static_assert(DIMS % 64 == 0, "partials_prefill: 8-wide chunks per thread");
+    static_assert(PREFILL_TILE == 32 && THREADS == 8 * 32 && MIXES == 24,
+                  "partials_prefill: lane = token, warp = 3 mix rows");
+    extern __shared__ __align__(16) unsigned char prefill_smem[];
+    float* fn_tile = reinterpret_cast<float*>(prefill_smem);
+    __nv_bfloat16* v_tile = reinterpret_cast<__nv_bfloat16*>(
+        fn_tile + MIXES * PREFILL_FN_STRIDE);
+
+    const int split = blockIdx.x;
+    const int token0 = blockIdx.y * PREFILL_TILE;
+    const int tid = threadIdx.x;
+    const int lane = tid & 31;
+    const int warp = tid >> 5;
+    const int dim_split = split * DIMS;
+
+    // Local flat l in [0, 512): stream l / 128, dim dim_split + l % 128.
+    // The serving dispatcher enables paired staging only for aligned BF16 fn
+    // on SM120. Other dtypes/devices and odd BF16 storage offsets stay scalar.
+    // Pair adjacent BF16 loads and exact FP32 conversions without changing the
+    // shared layout, arithmetic or reduction order. DIMS/strides and the
+    // 16-byte shared base make every source pair and float2 store aligned.
+    if constexpr (PAIRED_FN && std::is_same_v<FnT, __nv_bfloat16>) {
+        static_assert(PREFILL_FN_STRIDE % 2 == 0 && DIMS % 2 == 0);
+        for (int pair = tid; pair < MIXES * PREFILL_FLATS / 2; pair += THREADS) {
+            const int i = 2 * pair;
+            const int output = i / PREFILL_FLATS;
+            const int l = i - output * PREFILL_FLATS;
+            const int stream = l / DIMS;
+            const auto packed = *reinterpret_cast<const __nv_bfloat162*>(
+                fn + output * TOTAL + stream * HIDDEN_SIZE + dim_split + (l - stream * DIMS));
+            *reinterpret_cast<float2*>(fn_tile + output * PREFILL_FN_STRIDE + l) =
+                __bfloat1622float2(packed);
+        }
+    } else {
+        for (int i = tid; i < MIXES * PREFILL_FLATS; i += THREADS) {
+            const int output = i / PREFILL_FLATS;
+            const int l = i - output * PREFILL_FLATS;
+            const int stream = l / DIMS;
+            fn_tile[output * PREFILL_FN_STRIDE + l] =
+                float(fn[output * TOTAL + stream * HIDDEN_SIZE + dim_split + (l - stream * DIMS)]);
+        }
+    }
+    // Staging: thread (t = tid / 8, g = tid % 8) owns token t and dims
+    // dim_split + g * 16 .. + 16 as two 8-wide chunks; 16-byte loads, all of
+    // a chunk's inputs in flight together. With the fused post-mix the five
+    // input rows are read once and produce the four output streams.
+    {
+        constexpr int CHUNKS = DIMS / 64;
+        const int t = tid >> 3;
+        const int g = tid & 7;
+        const int token = token0 + t;
+        if (token < num_tokens) {
+            __nv_bfloat16* v_row = v_tile + t * PREFILL_V_STRIDE;
+            if constexpr (FUSED_POST) {
+                float post_mix[HC];
+                float comb_mix[HC * HC];
+#pragma unroll
+                for (int output_stream = 0; output_stream < HC; ++output_stream) {
+                    post_mix[output_stream] = post[token * HC + output_stream];
+                }
+#pragma unroll
+                for (int i = 0; i < HC * HC; ++i) {
+                    comb_mix[i] = comb[token * HC * HC + i];
+                }
+#pragma unroll
+                for (int c = 0; c < CHUNKS; ++c) {
+                    const int dim = dim_split + g * (8 * CHUNKS) + c * 8;
+                    const uint4 xv = *reinterpret_cast<const uint4*>(
+                        x + size_t(token) * HIDDEN_SIZE + dim);
+                    uint4 rv[HC];
+#pragma unroll
+                    for (int input_stream = 0; input_stream < HC; ++input_stream) {
+                        rv[input_stream] = *reinterpret_cast<const uint4*>(
+                            residual + (size_t(token) * HC + input_stream) * HIDDEN_SIZE + dim);
+                    }
+                    const __nv_bfloat16* xb = reinterpret_cast<const __nv_bfloat16*>(&xv);
+#pragma unroll
+                    for (int output_stream = 0; output_stream < HC; ++output_stream) {
+                        __align__(16) __nv_bfloat16 rounded[8];
+#pragma unroll
+                        for (int j = 0; j < 8; ++j) {
+                            float value = post_mix[output_stream] * float(xb[j]);
+#pragma unroll
+                            for (int input_stream = 0; input_stream < HC; ++input_stream) {
+                                const __nv_bfloat16* rb =
+                                    reinterpret_cast<const __nv_bfloat16*>(&rv[input_stream]);
+                                value += comb_mix[input_stream * HC + output_stream] * float(rb[j]);
+                            }
+                            rounded[j] = __float2bfloat16_rn(value);
+                        }
+                        *reinterpret_cast<uint4*>(
+                            residual_out + (size_t(token) * HC + output_stream) * HIDDEN_SIZE + dim) =
+                            *reinterpret_cast<const uint4*>(rounded);
+                        __nv_bfloat16* v_dst =
+                            v_row + output_stream * DIMS + g * (8 * CHUNKS) + c * 8;
+#pragma unroll
+                        for (int j = 0; j < 8; j += 2) {
+                            *reinterpret_cast<__nv_bfloat162*>(v_dst + j) =
+                                *reinterpret_cast<const __nv_bfloat162*>(rounded + j);
+                        }
+                    }
+                }
+            } else {
+#pragma unroll
+                for (int stream = 0; stream < HC; ++stream) {
+#pragma unroll
+                    for (int c = 0; c < CHUNKS; ++c) {
+                        const int dim = dim_split + g * (8 * CHUNKS) + c * 8;
+                        const uint4 rv = *reinterpret_cast<const uint4*>(
+                            residual + (size_t(token) * HC + stream) * HIDDEN_SIZE + dim);
+                        const __nv_bfloat16* rb = reinterpret_cast<const __nv_bfloat16*>(&rv);
+                        __nv_bfloat16* v_dst = v_row + stream * DIMS + g * (8 * CHUNKS) + c * 8;
+#pragma unroll
+                        for (int j = 0; j < 8; j += 2) {
+                            *reinterpret_cast<__nv_bfloat162*>(v_dst + j) =
+                                *reinterpret_cast<const __nv_bfloat162*>(rb + j);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    __syncthreads();
+
+    // lane = token of the tile; warp w = mix rows w, w + 8, w + 16; warp 0
+    // also the square sum. v rows are padded by one word so the 32 lanes hit
+    // 32 banks; the fn reads are warp-uniform broadcasts (no pad needed).
+    const __nv_bfloat16* v_row = v_tile + lane * PREFILL_V_STRIDE;
+    const float* fn0 = fn_tile + warp * PREFILL_FN_STRIDE;
+    const float* fn1 = fn_tile + (warp + 8) * PREFILL_FN_STRIDE;
+    const float* fn2 = fn_tile + (warp + 16) * PREFILL_FN_STRIDE;
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, square_sum = 0.0f;
+#pragma unroll 8
+    for (int f = 0; f < PREFILL_FLATS; f += 2) {
+        const float2 v = __bfloat1622float2(
+            *reinterpret_cast<const __nv_bfloat162*>(v_row + f));
+        const float2 c0 = *reinterpret_cast<const float2*>(fn0 + f);
+        const float2 c1 = *reinterpret_cast<const float2*>(fn1 + f);
+        const float2 c2 = *reinterpret_cast<const float2*>(fn2 + f);
+        acc0 += v.x * c0.x;
+        acc0 += v.y * c0.y;
+        acc1 += v.x * c1.x;
+        acc1 += v.y * c1.y;
+        acc2 += v.x * c2.x;
+        acc2 += v.y * c2.y;
+        if (warp == 0) {
+            square_sum += v.x * v.x;
+            square_sum += v.y * v.y;
+        }
+    }
+    const int token = token0 + lane;
+    if (token < num_tokens) {
+        float* out = partial + (token * SPLITS + split) * (MIXES + 1);
+        out[warp] = acc0;
+        out[warp + 8] = acc1;
+        out[warp + 16] = acc2;
+        if (warp == 0) {
+            out[MIXES] = square_sum;
         }
     }
 }
@@ -292,9 +491,10 @@ __global__ void apply_pre_mix_rms_norm(
     }
 }
 
-template <bool FUSED_POST, bool RMS_NORM, int HIDDEN_SIZE = 4096,
-          int NSPLITS = SPLITS, typename FnT = float>
-__global__ void fused_pre_transition(
+// Phase 1 of the fused pre-transition: one block's slice of the 24 mix
+// partials (and the fused post-mix residual write when FUSED_POST).
+template <bool FUSED_POST, int HIDDEN_SIZE, int NSPLITS, typename FnT>
+__device__ __forceinline__ void pre_transition_partials(
     const __nv_bfloat16* x,
     const __nv_bfloat16* residual,
     const float* post_mix,
@@ -302,23 +502,9 @@ __global__ void fused_pre_transition(
     const FnT* fn,
     __nv_bfloat16* residual_out,
     float* partial,
-    const float* scale,
-    const float* base,
-    float* next_post,
-    float* next_comb,
-    __nv_bfloat16* layer_input,
-    const __nv_bfloat16* norm_weight,
-    float rms_eps,
-    float pre_eps,
-    float sinkhorn_eps,
-    float post_multiplier,
-    int sinkhorn_repeat,
-    float norm_eps) {
-    static_assert(HIDDEN_SIZE % THREADS == 0);
+    int split,
+    int token) {
     constexpr int NOUT = MIXES;
-    constexpr int VALUES = HIDDEN_SIZE / THREADS;
-    const int split = blockIdx.x;
-    const int token = blockIdx.y;
     const int tid = threadIdx.x;
     const int lane = tid & 31;
     const int warp = tid >> 5;
@@ -384,9 +570,33 @@ __global__ void fused_pre_transition(
                 block_sum;
         }
     }
+}
 
-    cooperative_groups::this_grid().sync();
-    if (split != 0) return;
+// Phase 2, one block per token: finalize the mixes (Sinkhorn), apply the
+// pre-mix to the (post-mixed) residual and write the layer input.
+template <bool FUSED_POST, bool RMS_NORM, int HIDDEN_SIZE, int NSPLITS>
+__device__ __forceinline__ void pre_transition_tail(
+    const __nv_bfloat16* residual,
+    const __nv_bfloat16* residual_out,
+    float* partial,
+    const float* scale,
+    const float* base,
+    float* next_post,
+    float* next_comb,
+    __nv_bfloat16* layer_input,
+    const __nv_bfloat16* norm_weight,
+    float rms_eps,
+    float pre_eps,
+    float sinkhorn_eps,
+    float post_multiplier,
+    int sinkhorn_repeat,
+    float norm_eps,
+    int token) {
+    constexpr int NOUT = MIXES;
+    constexpr int VALUES = HIDDEN_SIZE / THREADS;
+    const int tid = threadIdx.x;
+    const int lane = tid & 31;
+    const int warp = tid >> 5;
 
     finalize_pre_mix_block<NSPLITS>(
         partial, scale, base, next_post, next_comb, token, HIDDEN_SIZE,
@@ -444,6 +654,103 @@ __global__ void fused_pre_transition(
             layer_input[token * HIDDEN_SIZE + dim] = values[i];
         }
     }
+}
+
+// Cooperative form: NSPLITS blocks per token, one grid sync, block 0 runs
+// the tail. Needs cudaLaunchCooperativeKernel.
+template <bool FUSED_POST, bool RMS_NORM, int HIDDEN_SIZE,
+          int NSPLITS = SPLITS, typename FnT = float>
+__global__ void fused_pre_transition(
+    const __nv_bfloat16* x,
+    const __nv_bfloat16* residual,
+    const float* post_mix,
+    const float* comb_mix,
+    const FnT* fn,
+    __nv_bfloat16* residual_out,
+    float* partial,
+    const float* scale,
+    const float* base,
+    float* next_post,
+    float* next_comb,
+    __nv_bfloat16* layer_input,
+    const __nv_bfloat16* norm_weight,
+    float rms_eps,
+    float pre_eps,
+    float sinkhorn_eps,
+    float post_multiplier,
+    int sinkhorn_repeat,
+    float norm_eps) {
+    static_assert(HIDDEN_SIZE % THREADS == 0);
+    const int split = blockIdx.x;
+    const int token = blockIdx.y;
+    pre_transition_partials<FUSED_POST, HIDDEN_SIZE, NSPLITS, FnT>(
+        x, residual, post_mix, comb_mix, fn, residual_out, partial, split,
+        token);
+
+    cooperative_groups::this_grid().sync();
+    if (split != 0) return;
+
+    pre_transition_tail<FUSED_POST, RMS_NORM, HIDDEN_SIZE, NSPLITS>(
+        residual, residual_out, partial, scale, base, next_post, next_comb,
+        layer_input, norm_weight, rms_eps, pre_eps, sinkhorn_eps,
+        post_multiplier, sinkhorn_repeat, norm_eps, token);
+}
+
+// Last-block form (2026-09-07, rtx6000): the same math with a regular
+// launch. Every block publishes its partials, fences, and bumps `counter`;
+// the block that observes NSPLITS - 1 is the last one, so the partials of
+// all others are visible to it (threadFenceReduction pattern), and it runs
+// the tail and resets the counter for the next launch on the stream. One
+// token per launch (grid NSPLITS x 1); the counter is a persistent device
+// int owned by the launcher. Removes the cooperative-launch requirement and
+// the grid-wide barrier, which is what the 8.5 us per site was made of.
+template <bool FUSED_POST, bool RMS_NORM, int HIDDEN_SIZE,
+          int NSPLITS = SPLITS, typename FnT = float>
+__global__ void fused_pre_transition_lastblock(
+    const __nv_bfloat16* x,
+    const __nv_bfloat16* residual,
+    const float* post_mix,
+    const float* comb_mix,
+    const FnT* fn,
+    __nv_bfloat16* residual_out,
+    float* partial,
+    const float* scale,
+    const float* base,
+    float* next_post,
+    float* next_comb,
+    __nv_bfloat16* layer_input,
+    const __nv_bfloat16* norm_weight,
+    float rms_eps,
+    float pre_eps,
+    float sinkhorn_eps,
+    float post_multiplier,
+    int sinkhorn_repeat,
+    float norm_eps,
+    int* counter) {
+    static_assert(HIDDEN_SIZE % THREADS == 0);
+    const int split = blockIdx.x;
+    constexpr int token = 0;
+    pre_transition_partials<FUSED_POST, HIDDEN_SIZE, NSPLITS, FnT>(
+        x, residual, post_mix, comb_mix, fn, residual_out, partial, split,
+        token);
+
+    // Every writer fences its own partials, the block joins, then one thread
+    // takes the ticket: the last block observes all NSPLITS partials.
+    __shared__ int is_last;
+    __threadfence();
+    __syncthreads();
+    if (threadIdx.x == 0) {
+        is_last = atomicAdd(counter, 1) == NSPLITS - 1;
+    }
+    __syncthreads();
+    if (!is_last) return;
+    __threadfence();
+    if (threadIdx.x == 0) *counter = 0;
+
+    pre_transition_tail<FUSED_POST, RMS_NORM, HIDDEN_SIZE, NSPLITS>(
+        residual, residual_out, partial, scale, base, next_post, next_comb,
+        layer_input, norm_weight, rms_eps, pre_eps, sinkhorn_eps,
+        post_multiplier, sinkhorn_repeat, norm_eps, token);
 }
 
 __global__ void post(

--- a/csrc/quixicore/serving/mhc_ampere.cuh
+++ b/csrc/quixicore/serving/mhc_ampere.cuh
@@ -131,6 +131,9 @@ __global__ void partials(
 // the strided one above), so finalize_pre_mix / apply_pre_mix are unchanged.
 // residual_out is bit-identical to `partials` (same expression, same
 // order); the mix sums differ only in fp32 summation order.
+// Supported builds target SM80+. This tile needs ~80 KiB/block, above the
+// 48 KiB default; the launcher opts in via MaxDynamicSharedMemorySize.
+// It requires a device with at least PREFILL_SMEM opt-in shared memory.
 constexpr int PREFILL_TILE = 32;
 constexpr int PREFILL_FLATS = 2 * THREADS;
 constexpr int PREFILL_FN_STRIDE = PREFILL_FLATS;

--- a/csrc/quixicore/serving/topk_sample.cuh
+++ b/csrc/quixicore/serving/topk_sample.cuh
@@ -1,0 +1,413 @@
+// Small-k sampling with unbounded cutoff ties. The candidate window only
+// finds the threshold: it NEVER caps the probability mass or sampled IDs.
+// Each partition carries the exact count of ties omitted from its window.
+// This is sufficient because there are at most k-1 values strictly above
+// the global k-th value, and every such value survives a local top-32.
+//
+// Four launches: local candidates + omitted-tie counts; global threshold and
+// nucleus cutoff; full-vocabulary noise/argmax per partition; final argmax.
+// Top-k retains all ties. Top-p uses ascending (logit, token ID) order and
+// drops cumulative mass <= 1-p, always retaining at least one token. This
+// deterministic tie order is a defined alternative to torch.sort's unstable
+// equal-key order. Noise is indexed by vocabulary ID, not candidate slot,
+// and retains the caller's float32 or float64 precision.
+// Preconditions: 1 <= k <= 32, 0 <= p <= 1, no NaN/+inf logits, and at
+// least one finite logit per row. -inf masks and signed zeros are supported.
+// Invalid non-finite rows have unspecified sampling semantics but always
+// return an in-range ID: model startup can exercise uninitialized logits.
+#pragma once
+#include <cuda_runtime.h>
+#include <cstdint>
+#include <cfloat>
+#include <climits>
+
+namespace tms::topk_sample {
+
+constexpr int K = 32;               // candidate window; every request's top_k <= K
+constexpr int NB = 16;              // blocks per row in the candidate pass
+constexpr int THREADS = 1024;       // candidate pass block
+constexpr int MERGE_THREADS = 512;  // merge pass block = NB * K candidates
+constexpr int RADIX_BITS = 11;
+constexpr int BINS = 1 << RADIX_BITS;
+
+// Order-preserving key: larger float -> larger key. NaN is not expected.
+__device__ __forceinline__ uint32_t key_of(float f) {
+    if (f == 0.0f) return 0x80000000u;  // Canonicalize signed zeros.
+    const uint32_t u = __float_as_uint(f);
+    return (u & 0x80000000u) ? ~u : (u | 0x80000000u);
+}
+
+__device__ __forceinline__ float value_of(uint32_t key) {
+    return __uint_as_float((key & 0x80000000u) ? (key & 0x7fffffffu) : ~key);
+}
+
+struct RowCutoff {
+    float maximum;
+    float value;
+    int first_id;   // First retained token ID when the cutoff is above kth.
+    int drop_ties;  // Number of lowest-ID kth ties to drop, or -1 for first_id.
+};
+
+// Bits of `key` selected by pass p (0..2): [31:21], [20:10], [9:0].
+__device__ __forceinline__ int pass_shift(int p) { return p == 0 ? 21 : (p == 1 ? 10 : 0); }
+__device__ __forceinline__ int pass_bits(int p) { return p == 2 ? 10 : RADIX_BITS; }
+
+// Block-wide: hist[BINS] holds counts; find the highest bin b such that the
+// count of elements in bins above b is < need <= that count + hist[b].
+// Returns b and leaves in *need the number still to take from bin b.
+// Bins are scanned from the top with an exclusive prefix over reversed order.
+template <int NT>
+__device__ __forceinline__ int select_bin(uint32_t* hist, int* need_io, int nbins,
+                                          int* scan_warp /* NT/32 */, int* scan_out) {
+    constexpr int ITEMS_MAX = BINS / NT;  // bins per thread in the widest pass
+    const int tid = threadIdx.x, lane = tid & 31, warp = tid >> 5;
+    const int items = nbins / NT;
+    // Thread t owns reversed bins [t*items, (t+1)*items): reversed r -> bin nbins-1-r.
+    uint32_t local[ITEMS_MAX];
+    uint32_t sum = 0;
+#pragma unroll
+    for (int i = 0; i < ITEMS_MAX; ++i) {
+        if (i < items) { local[i] = hist[nbins - 1 - (tid * items + i)]; sum += local[i]; }
+    }
+    // Inclusive warp scan of thread sums.
+    uint32_t incl = sum;
+#pragma unroll
+    for (int o = 1; o < 32; o <<= 1) {
+        const uint32_t v = __shfl_up_sync(0xffffffffu, incl, o);
+        if (lane >= o) incl += v;
+    }
+    if (lane == 31) scan_warp[warp] = int(incl);
+    __syncthreads();
+    if (warp == 0) {
+        int v = lane < NT / 32 ? scan_warp[lane] : 0;
+#pragma unroll
+        for (int o = 1; o < 32; o <<= 1) {
+            const int u = __shfl_up_sync(0xffffffffu, v, o);
+            if (lane >= o) v += u;
+        }
+        if (lane < NT / 32) scan_warp[lane] = v;  // inclusive over warps
+    }
+    __syncthreads();
+    const uint32_t warp_excl = warp == 0 ? 0u : uint32_t(scan_warp[warp - 1]);
+    uint32_t above = warp_excl + incl - sum;  // elements in reversed bins before this thread's first
+    const int need = *need_io;
+#pragma unroll
+    for (int i = 0; i < ITEMS_MAX; ++i) {
+        if (i < items) {
+            const uint32_t here = local[i];
+            if (above < uint32_t(need) && uint32_t(need) <= above + here) {
+                scan_out[0] = nbins - 1 - (tid * items + i);
+                scan_out[1] = need - int(above);
+            }
+            above += here;
+        }
+    }
+    __syncthreads();
+    const int bin = scan_out[0];
+    if (tid == 0) *need_io = scan_out[1];
+    __syncthreads();
+    return bin;
+}
+
+// Radix-select the K-th largest key among the elements yielded by acc(i) for
+// i in [0, n) (threads stride over i). Returns the threshold key; *need_out is
+// how many elements equal to it belong to the top K (ties beyond are cut).
+template <int NT, typename Acc>
+__device__ __forceinline__ uint32_t select_threshold(Acc acc, int n, int k, uint32_t* hist,
+                                                     int* need_sh, int* scan_warp, int* scan_out) {
+    const int tid = threadIdx.x;
+    uint32_t prefix = 0;  // selected high bits so far
+    int prefix_bits = 0;
+    if (tid == 0) *need_sh = k;
+    for (int p = 0; p < 3; ++p) {
+        const int shift = pass_shift(p), bits = pass_bits(p), nbins = 1 << bits;
+        for (int b = tid; b < nbins; b += NT) hist[b] = 0;
+        __syncthreads();
+        for (int i = tid; i < n; i += NT) {
+            const uint32_t key = acc(i);
+            if (prefix_bits == 0 || (key >> (shift + bits)) == prefix) {
+                atomicAdd(&hist[(key >> shift) & (nbins - 1)], 1u);
+            }
+        }
+        __syncthreads();
+        const int bin = select_bin<NT>(hist, need_sh, nbins, scan_warp, scan_out);
+        prefix = (prefix << bits) | uint32_t(bin);
+        prefix_bits += bits;
+        __syncthreads();
+    }
+    return prefix;
+}
+
+// Pass 1: NB blocks per row, each writes its slice's top K (value, index) into
+// cand_val / cand_idx [B, NB*K]. Slots past the slice's element count (never,
+// for V >= NB*K) are -inf / -1.
+__global__ void __launch_bounds__(THREADS) candidates_kernel(
+    const float* __restrict__ logits, long row_stride, int V,
+    float* __restrict__ cand_val, int* __restrict__ cand_idx,
+    float* __restrict__ part_threshold, int* __restrict__ part_omitted) {
+    __shared__ uint32_t hist[BINS];
+    __shared__ int need_sh, scan_warp[THREADS / 32], scan_out[2], out_count, tie_taken;
+    const int row = blockIdx.y, part = blockIdx.x, tid = threadIdx.x;
+    const int chunk = (V + NB - 1) / NB;
+    const int start = part * chunk, end = min(V, start + chunk), n = max(0, end - start);
+    const float* x = logits + long(row) * row_stride + start;
+    float* out_v = cand_val + (long(row) * NB + part) * K;
+    int* out_i = cand_idx + (long(row) * NB + part) * K;
+    if (tid == 0) { out_count = 0; tie_taken = 0; }
+    const int k = min(K, n);
+    uint32_t thresh = 0;
+    if (k > 0) {
+        thresh = select_threshold<THREADS>([&](int i) { return key_of(x[i]); }, n, k, hist,
+                                           &need_sh, scan_warp, scan_out);
+    }
+    __syncthreads();
+    const int need = need_sh;
+    for (int i = tid; i < n; i += THREADS) {
+        const float v = x[i];
+        const uint32_t key = key_of(v);
+        int slot = -1;
+        if (key > thresh) {
+            slot = atomicAdd(&out_count, 1);
+        } else if (key == thresh) {
+            if (atomicAdd(&tie_taken, 1) < need) slot = atomicAdd(&out_count, 1);
+        }
+        if (slot >= 0 && slot < K) { out_v[slot] = v; out_i[slot] = start + i; }
+    }
+    __syncthreads();
+    for (int s = out_count + tid; s < K; s += THREADS) { out_v[s] = -INFINITY; out_i[s] = -1; }
+    if (tid == 0) {
+        part_threshold[long(row) * NB + part] = value_of(thresh);
+        part_omitted[long(row) * NB + part] = tie_taken - need;
+    }
+}
+
+__device__ __forceinline__ double warp_sum(double v) {
+#pragma unroll
+    for (int o = 16; o > 0; o >>= 1) v += __shfl_xor_sync(0xffffffffu, v, o);
+    return v;
+}
+
+// Pass 2: find the global kth value. Account for every omitted local tie,
+// then determine the nucleus cutoff and its deterministic token-ID boundary.
+__global__ void __launch_bounds__(MERGE_THREADS) cutoff_kernel(
+    const float* __restrict__ cand_val, const int* __restrict__ cand_idx,
+    const float* __restrict__ part_threshold, const int* __restrict__ part_omitted,
+    const int* __restrict__ top_k, const float* __restrict__ top_p,
+    RowCutoff* __restrict__ cutoffs, int* __restrict__ tie_prefix) {
+    constexpr int N = NB * K;
+    static_assert(N == MERGE_THREADS, "one candidate per thread");
+    __shared__ uint32_t hist[BINS];
+    __shared__ float sv[N];
+    __shared__ int si[N];
+    __shared__ float tv[K];
+    __shared__ int ti[K];
+    __shared__ float kth_sh;
+    __shared__ int part_ties[NB];
+    __shared__ int need_sh, scan_warp[MERGE_THREADS / 32], scan_out[2], out_count, tie_taken;
+    const int row = blockIdx.x, tid = threadIdx.x, lane = tid & 31;
+    sv[tid] = cand_val[long(row) * N + tid];
+    si[tid] = cand_idx[long(row) * N + tid];
+    if (tid == 0) { out_count = 0; tie_taken = 0; }
+    __syncthreads();
+    const uint32_t thresh = select_threshold<MERGE_THREADS>(
+        [&](int i) { return key_of(sv[i]); }, N, K, hist, &need_sh, scan_warp, scan_out);
+    __syncthreads();
+    {
+        const uint32_t key = key_of(sv[tid]);
+        int slot = -1;
+        if (key > thresh) slot = atomicAdd(&out_count, 1);
+        else if (key == thresh && atomicAdd(&tie_taken, 1) < need_sh) slot = atomicAdd(&out_count, 1);
+        if (slot >= 0 && slot < K) { tv[slot] = sv[tid]; ti[slot] = si[tid]; }
+    }
+    __syncthreads();
+    if (tid < K) {
+        // Descending (value, ID), the reverse of the documented ascending
+        // nucleus ordering. All values strictly above kth are present.
+        float v = tv[lane];
+        int idx = ti[lane];
+        for (int size = 2; size <= K; size <<= 1) {
+            for (int stride = size >> 1; stride > 0; stride >>= 1) {
+                const float ov = __shfl_xor_sync(0xffffffffu, v, stride);
+                const int oi = __shfl_xor_sync(0xffffffffu, idx, stride);
+                const bool greater = ov > v || (ov == v && oi > idx);
+                const bool less = ov < v || (ov == v && oi < idx);
+                const bool upper = (lane & stride) != 0;
+                const bool descending = (lane & size) == 0;
+                if (descending ? (upper ? less : greater) : (upper ? greater : less)) {
+                    v = ov; idx = oi;
+                }
+            }
+        }
+        tv[lane] = v; ti[lane] = idx;
+        const int k = min(max(top_k[row], 1), K);
+        const float kth = __shfl_sync(0xffffffffu, v, k - 1);
+        if (lane == 0) kth_sh = kth;
+    }
+    __syncthreads();
+    // Each warp owns exactly one original partition's 32 candidate slots.
+    const int part = tid / K;
+    const unsigned eq = __ballot_sync(0xffffffffu, si[tid] >= 0 && sv[tid] == kth_sh);
+    if (lane == 0) {
+        part_ties[part] = __popc(eq) +
+            (part_threshold[long(row) * NB + part] == kth_sh
+                 ? part_omitted[long(row) * NB + part] : 0);
+    }
+    __syncthreads();
+    if (tid >= K) return;
+
+    int count = lane < NB ? part_ties[lane] : 0;
+    int inclusive = count;
+#pragma unroll
+    for (int offset = 1; offset < K; offset <<= 1) {
+        const int other = __shfl_up_sync(0xffffffffu, inclusive, offset);
+        if (lane >= offset) inclusive += other;
+    }
+    if (lane < NB) tie_prefix[long(row) * NB + lane] = inclusive - count;
+    const int ties = __shfl_sync(0xffffffffu, inclusive, K - 1);
+    const float v = tv[lane], kth = kth_sh, maximum = tv[0];
+    if (ties <= 0 || !isfinite(maximum)) {
+        // No probability distribution exists for this row. Avoid NaN-to-int
+        // conversion and undefined cutoff arithmetic. Pass 3's empty-set
+        // argmax returns token zero, safe for dummy startup consumers.
+        if (lane == 0) cutoffs[row] = {0.0f, __int_as_float(0x7fffffff), 0, -1};
+        return;
+    }
+    const bool above = v > kth;
+    const int n_above = __popc(__ballot_sync(0xffffffffu, above));
+    // Only this one-warp cutoff calculation needs FP64. With unbounded
+    // ties, rounding 1-p or a cumulative probability in FP32 can move the
+    // ID boundary by a whole token even for a uniform distribution.
+    const double e = above ? exp(double(v) - double(maximum)) : 0.0;
+    const double tie_e = exp(double(kth) - double(maximum));
+    const double tie_mass = double(ties) * tie_e;
+    const double z = warp_sum(e) + tie_mass;
+    const double p = top_p ? double(top_p[row]) : 1.0;
+    const double budget = (1.0 - p) * z;
+    int drop = tie_e > 0.0
+        ? int(fmin(double(ties), floor(budget / tie_e))) : ties;
+    drop = min(max(drop, 0), ties);
+    if (n_above == 0) drop = min(drop, ties - 1);  // Always retain a maximum.
+
+    RowCutoff result;
+    result.maximum = maximum;
+    if (drop < ties) {
+        result.value = kth;
+        result.drop_ties = drop;
+        result.first_id = 0;
+        if (n_above + ties <= K) {
+            // Common case: all cutoff IDs fit in the window. Avoid a full
+            // vocabulary prefix scan just to decide a tiny tie group.
+            const int last_kept = n_above + ties - drop - 1;
+            result.first_id = __shfl_sync(0xffffffffu, ti[lane], last_kept);
+            result.drop_ties = -1;
+        }
+    } else {
+        double asc = e;
+#pragma unroll
+        for (int offset = 1; offset < K; offset <<= 1) {
+            const double other = __shfl_down_sync(0xffffffffu, asc, offset);
+            if (lane + offset < K) asc += other;
+        }
+        const bool keep = above && (lane == 0 || (p > 0.0 && asc + tie_mass > budget));
+        const unsigned kept = __ballot_sync(0xffffffffu, keep);
+        const int last_kept = K - 1 - __clz(kept);
+        result.value = __shfl_sync(0xffffffffu, v, last_kept);
+        result.first_id = __shfl_sync(0xffffffffu, ti[lane], last_kept);
+        result.drop_ties = -1;
+    }
+    if (lane == 0) cutoffs[row] = result;
+}
+
+template <typename Score>
+__device__ __forceinline__ void warp_argmax(Score& score, int& id) {
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        const Score other = __shfl_down_sync(0xffffffffu, score, offset);
+        const int other_id = __shfl_down_sync(0xffffffffu, id, offset);
+        if ((threadIdx.x & 31) + offset < 32 &&
+            (other > score || (other == score && other_id < id))) {
+            score = other; id = other_id;
+        }
+    }
+}
+
+constexpr int SAMPLE_THREADS = 256;
+
+// Pass 3: sample every retained vocabulary token, including ties which did
+// not fit in either candidate window. A full tie prefix is needed only when
+// the nucleus partially drops a tie group larger than the window.
+template <typename Score>
+__global__ void __launch_bounds__(SAMPLE_THREADS) sample_partitions_kernel(
+    const float* __restrict__ logits, long row_stride, int V,
+    const Score* __restrict__ noise, const RowCutoff* __restrict__ cutoffs,
+    const int* __restrict__ tie_prefix, Score* __restrict__ part_score,
+    int* __restrict__ part_id) {
+    constexpr int WARPS = SAMPLE_THREADS / 32;
+    __shared__ int scan[WARPS];
+    __shared__ Score scores[WARPS];
+    __shared__ int ids[WARPS];
+    const int row = blockIdx.y, part = blockIdx.x, tid = threadIdx.x;
+    const int lane = tid & 31, warp = tid / 32;
+    const int chunk = (V + NB - 1) / NB;
+    const int start = part * chunk, end = min(V, start + chunk);
+    const RowCutoff cutoff = cutoffs[row];
+    int preceding = tie_prefix[long(row) * NB + part];
+    Score best = Score(-1);
+    int best_id = min(start + tid, V - 1);
+    for (int base = start; base < end; base += SAMPLE_THREADS) {
+        const int id = base + tid;
+        const bool valid = id < end;
+        const float v = valid ? logits[long(row) * row_stride + id] : -INFINITY;
+        bool keep = valid && (v > cutoff.value ||
+            (v == cutoff.value && (cutoff.drop_ties >= 0 || id >= cutoff.first_id)));
+        if (cutoff.drop_ties > 0) {
+            const unsigned eq = __ballot_sync(0xffffffffu, valid && v == cutoff.value);
+            const int local_rank = __popc(eq & ((1u << lane) - 1u));
+            if (lane == 0) scan[warp] = __popc(eq);
+            __syncthreads();
+            if (warp == 0) {
+                int incl = lane < WARPS ? scan[lane] : 0;
+#pragma unroll
+                for (int offset = 1; offset < WARPS; offset <<= 1) {
+                    const int other = __shfl_up_sync(0xffffffffu, incl, offset);
+                    if (lane >= offset) incl += other;
+                }
+                if (lane < WARPS) scan[lane] = incl;
+            }
+            __syncthreads();
+            const int rank = preceding + (warp ? scan[warp - 1] : 0) + local_rank;
+            if (v == cutoff.value && rank < cutoff.drop_ties) keep = false;
+            preceding += scan[WARPS - 1];
+            __syncthreads();
+        }
+        // Normalizing probabilities again would multiply every score by
+        // the same positive scalar and cannot change the sampled token.
+        const Score score = keep ? Score(__expf(v - cutoff.maximum)) / noise[long(row) * V + id] : Score(-1);
+        if (score > best || (score == best && id < best_id)) {
+            best = score; best_id = id;
+        }
+    }
+    warp_argmax(best, best_id);
+    if (lane == 0) { scores[warp] = best; ids[warp] = best_id; }
+    __syncthreads();
+    if (warp == 0) {
+        best = lane < WARPS ? scores[lane] : Score(-1);
+        best_id = lane < WARPS ? ids[lane] : INT_MAX;
+        warp_argmax(best, best_id);
+        if (lane == 0) {
+            part_score[long(row) * NB + part] = best;
+            part_id[long(row) * NB + part] = best_id;
+        }
+    }
+}
+
+template <typename Score>
+__global__ void finish_kernel(const Score* part_score, const int* part_id, long* out) {
+    const int row = blockIdx.x, lane = threadIdx.x;
+    Score best = lane < NB ? part_score[long(row) * NB + lane] : Score(-1);
+    int id = lane < NB ? part_id[long(row) * NB + lane] : INT_MAX;
+    warp_argmax(best, id);
+    if (lane == 0) out[row] = long(id);
+}
+
+}  // namespace tms::topk_sample

--- a/csrc/quixicore/tm_cuda/tm_cuda_ext.cu
+++ b/csrc/quixicore/tm_cuda/tm_cuda_ext.cu
@@ -324,6 +324,9 @@ void init_m4(pybind11::module_& m);            // tm_cuda_m4.cu
 void init_m5(pybind11::module_& m);            // tm_cuda_m5.cu
 void init_m6(pybind11::module_& m);            // tm_cuda_m6.cu
 void init_mf_followups(pybind11::module_& m);  // tm_cuda_mf_followups.cu
+#ifdef VLLM_BUILD_GLM53_SM120_SPARSE
+void init_glm53_sparse(pybind11::module_& m);
+#endif
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     init_serving(m);
@@ -334,6 +337,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     init_m5(m);
     init_m6(m);
     init_mf_followups(m);
+#ifdef VLLM_BUILD_GLM53_SM120_SPARSE
+    init_glm53_sparse(m);
+#endif
     m.def("qgemv", &py_qgemv, "D(N) = dequant(Wq) @ x, fp16 x");
     m.def("qgemm", &py_qgemm, "Y(M,N) = X(M,K) @ dequant(Wq)^T");
     m.def("qflux_gelu", &py_qflux_gelu, "gelu_tanh(X @ dequant(Wq)^T + bias)");

--- a/csrc/quixicore/tm_cuda/tm_cuda_glm53_sparse.cu
+++ b/csrc/quixicore/tm_cuda/tm_cuda_glm53_sparse.cu
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include <climits>
+#include <cmath>
+#include <mutex>
+#include <set>
+#include "glm53_sparse_swapab.cuh"
+
+namespace {
+torch::Tensor prefill(torch::Tensor q, torch::Tensor cache, torch::Tensor bt,
+                      torch::Tensor ids, torch::Tensor lengths,
+                      int64_t block_size, double scale, int64_t page_stride_bytes) {
+  TORCH_CHECK(q.is_cuda() && q.scalar_type() == at::kBFloat16,
+              "SM120 sparse prefill requires CUDA BF16 queries");
+  const c10::cuda::CUDAGuard guard(q.device());
+  const auto* props = at::cuda::getCurrentDeviceProperties();
+  TORCH_CHECK(props->major == 12 && props->minor == 0, "requires SM120");
+  for (const auto& t : {cache, bt, ids, lengths})
+    TORCH_CHECK(t.device() == q.device(), "all tensors must share a device");
+  TORCH_CHECK(q.dim() == 3 && q.size(1) == slimserve::glm53_swapab::HEADS &&
+              q.size(2) == 512 && q.is_contiguous() && q.size(0) <= INT_MAX,
+              "expected [B,16,512] Q");
+  TORCH_CHECK(reinterpret_cast<uintptr_t>(q.data_ptr()) % 4 == 0,
+              "queries must be 4-byte-aligned for paired BF16 loads");
+  TORCH_CHECK(block_size > 0 && block_size <= INT_MAX && std::isfinite(scale),
+              "invalid block size or attention scale");
+  TORCH_CHECK(cache.scalar_type() == at::kBFloat16 && cache.dim() == 3 &&
+              cache.size(0) > 0 && cache.size(0) <= INT_MAX &&
+              cache.size(1) == block_size && cache.size(2) == 512 &&
+              cache.stride(1) == 512 && cache.stride(2) == 1 &&
+              cache.stride(0) >= block_size * 512 && cache.stride(0) % 8 == 0 &&
+              reinterpret_cast<uintptr_t>(cache.data_ptr()) % 16 == 0,
+              "expected 16-byte-aligned BF16 cache pages with packed 512-wide rows");
+  TORCH_CHECK(page_stride_bytes == 0 || page_stride_bytes == cache.stride(0) * 2,
+              "page stride must match the cache view");
+  TORCH_CHECK(bt.scalar_type() == at::kInt && ids.scalar_type() == at::kInt &&
+              lengths.scalar_type() == at::kInt && bt.is_contiguous() &&
+              ids.is_contiguous() && lengths.is_contiguous() &&
+              bt.dim() == 2 && ids.dim() == 2 && lengths.dim() == 1 &&
+              bt.size(0) == q.size(0) && ids.size(0) == q.size(0) &&
+              lengths.size(0) == q.size(0) && bt.size(1) <= INT_MAX &&
+              ids.size(1) <= INT_MAX - 31,
+              "invalid sparse index/table/length metadata");
+  auto out = torch::empty_like(q);
+  if (q.size(0) == 0) return out;
+  namespace impl = slimserve::glm53_swapab;
+  auto kernel = impl::sparse_nope;
+  // Cache launch setup per device, not per process: CUDA function attributes
+  // belong to the current device's context. No setup on repeated graph calls.
+  static std::mutex mutex;
+  static std::set<int> configured;
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    if (!configured.count(q.get_device())) {
+      C10_CUDA_CHECK(cudaFuncSetAttribute(kernel,
+          cudaFuncAttributeMaxDynamicSharedMemorySize, sizeof(impl::Shared)));
+      configured.insert(q.get_device());
+    }
+  }
+  kernel<<<q.size(0), impl::THREADS, sizeof(impl::Shared),
+           at::cuda::getCurrentCUDAStream()>>>(
+      static_cast<const impl::BF*>(q.data_ptr()),
+      static_cast<const impl::BF*>(cache.data_ptr()), bt.data_ptr<int>(),
+      ids.data_ptr<int>(), lengths.data_ptr<int>(),
+      static_cast<impl::BF*>(out.data_ptr()), ids.size(1), bt.size(1),
+      block_size, cache.stride(0), float(scale));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return out;
+}
+}  // namespace
+
+void init_glm53_sparse(pybind11::module_& m) {
+  m.def("mla_prefill_bf16_sparse_nope_sm120", &prefill,
+        pybind11::arg("q"), pybind11::arg("cache"), pybind11::arg("block_table"),
+        pybind11::arg("indices"), pybind11::arg("lengths"),
+        pybind11::arg("block_size"), pybind11::arg("scale"),
+        pybind11::arg("page_stride_bytes") = 0);
+}

--- a/csrc/quixicore/tm_cuda/tm_cuda_serving.cu
+++ b/csrc/quixicore/tm_cuda/tm_cuda_serving.cu
@@ -273,6 +273,9 @@ static void py_glm_stable_align(
 
 static void py_moe_sum_add(torch::Tensor x, torch::Tensor shared, torch::Tensor out) {
     CK(x); CK(shared); CK(out);
+    TORCH_CHECK(shared.device() == x.device() && out.device() == x.device(),
+                "moe_sum_add: tensors must be on the same device");
+    const c10::cuda::CUDAGuard guard(x.device());
     TORCH_CHECK(x.scalar_type() == torch::kBFloat16 && shared.scalar_type() == torch::kBFloat16 &&
                     out.scalar_type() == torch::kBFloat16,
                 "moe_sum_add: bf16 tensors");
@@ -282,7 +285,12 @@ static void py_moe_sum_add(torch::Tensor x, torch::Tensor shared, torch::Tensor 
     TORCH_CHECK(shared.size(0) == T && shared.size(1) == d && out.size(0) == T && out.size(1) == d,
                 "moe_sum_add: shape mismatch");
     TORCH_CHECK(d % glm_moe_combine::VEC == 0, "moe_sum_add: D must be a multiple of 8");
+    TORCH_CHECK(reinterpret_cast<uintptr_t>(x.data_ptr()) % 16 == 0 &&
+                reinterpret_cast<uintptr_t>(shared.data_ptr()) % 16 == 0 &&
+                reinterpret_cast<uintptr_t>(out.data_ptr()) % 16 == 0,
+                "moe_sum_add: tensor pointers must be 16-byte aligned");
     glm_moe_combine::launch_moe_sum_add(bpm(out), bp(x), bp(shared), T, int(d), int(topk), stream());
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 static torch::Tensor py_decode_gemm(torch::Tensor x, torch::Tensor weight,
@@ -347,22 +355,27 @@ static torch::Tensor py_topk_sample(torch::Tensor logits, torch::Tensor top_k,
     candidates_kernel<<<dim3(NB, B), THREADS, 0, stream()>>>(
         logits.data_ptr<float>(), logits.stride(0), V, cand_val.data_ptr<float>(), cand_idx.data_ptr<int>(),
         thresholds.data_ptr<float>(), omitted.data_ptr<int>());
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
     cutoff_kernel<<<B, MERGE_THREADS, 0, stream()>>>(
         cand_val.data_ptr<float>(), cand_idx.data_ptr<int>(), thresholds.data_ptr<float>(),
         omitted.data_ptr<int>(), top_k.data_ptr<int>(), p_ptr, cutoffs, prefixes.data_ptr<int>());
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
     if (noise.scalar_type() == torch::kFloat64) {
         sample_partitions_kernel<double><<<dim3(NB, B), SAMPLE_THREADS, 0, stream()>>>(
             logits.data_ptr<float>(), logits.stride(0), V, noise.data_ptr<double>(), cutoffs,
             prefixes.data_ptr<int>(), part_score.data_ptr<double>(), part_id.data_ptr<int>());
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
         finish_kernel<double><<<B, 32, 0, stream()>>>(
             part_score.data_ptr<double>(), part_id.data_ptr<int>(), out.data_ptr<long>());
     } else {
         sample_partitions_kernel<float><<<dim3(NB, B), SAMPLE_THREADS, 0, stream()>>>(
             logits.data_ptr<float>(), logits.stride(0), V, noise.data_ptr<float>(), cutoffs,
             prefixes.data_ptr<int>(), part_score.data_ptr<float>(), part_id.data_ptr<int>());
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
         finish_kernel<float><<<B, 32, 0, stream()>>>(
             part_score.data_ptr<float>(), part_id.data_ptr<int>(), out.data_ptr<long>());
     }
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
     return out;
 }
 
@@ -469,21 +482,6 @@ static int dsv4_mhc_coop_max_t() {
     return value;
 }
 
-// Persistent device counter for the last-block kernel (one launch in flight
-// per stream; the last block resets it). Allocated on first use, which is an
-// eager call - vLLM warms every shape up before it captures graphs.
-static int* dsv4_mhc_counter() {
-    static int* counter = [] {
-        int* ptr = nullptr;
-        TORCH_CHECK(cudaMalloc(&ptr, sizeof(int)) == cudaSuccess,
-                    "dsv4 mHC counter: cudaMalloc failed");
-        TORCH_CHECK(cudaMemset(ptr, 0, sizeof(int)) == cudaSuccess,
-                    "dsv4 mHC counter: cudaMemset failed");
-        return ptr;
-    }();
-    return counter;
-}
-
 static int dsv4_mhc_splits() {
     static const int splits = [] {
         const char* value = std::getenv("VLLM_DSV4_MHC_SPLITS");
@@ -530,6 +528,10 @@ static void launch_dsv4_mhc_pre_transition(
     };
     const int T = residual.size(0);
     if (dsv4_mhc_mode() == 1 && T == 1) {
+        // Per-invocation state isolates devices, streams and independently
+        // captured graphs. Initialization is captured too; a per-stream cache
+        // would still alias graphs captured on one stream then replayed apart.
+        auto counter = torch::zeros({1}, residual.options().dtype(torch::kInt32));
         dsv4_mhc::fused_pre_transition_lastblock<FUSED_POST, RMS_NORM, 4096,
                                                  NSPLITS, FnT>
             <<<dim3(NSPLITS, 1), dim3(dsv4_mhc::THREADS), 0, stream()>>>(
@@ -537,18 +539,23 @@ static void launch_dsv4_mhc_pre_transition(
                 residual_out_ptr, partial_ptr, scale_ptr, base_ptr,
                 next_post_ptr, next_comb_ptr, layer_input_ptr, norm_ptr,
                 rms_eps, pre_eps, sinkhorn_eps, post_multiplier,
-                sinkhorn_repeat, norm_eps, dsv4_mhc_counter());
+                sinkhorn_repeat, norm_eps, counter.data_ptr<int>());
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
         return;
     }
     // All T x NSPLITS blocks must be co-resident for the grid barrier.
-    static const int max_coresident = [&] {
-        int device = 0, sms = 0, blocks_per_sm = 0;
-        cudaGetDevice(&device);
-        cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, device);
-        cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-            &blocks_per_sm, kernel, dsv4_mhc::THREADS, 0);
-        return blocks_per_sm * sms;
-    }();
+    static thread_local int configured_device = -1;
+    static thread_local int max_coresident = 0;
+    int device = -1;
+    C10_CUDA_CHECK(cudaGetDevice(&device));
+    if (configured_device != device) {
+        int sms = 0, blocks_per_sm = 0;
+        C10_CUDA_CHECK(cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, device));
+        C10_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+            &blocks_per_sm, kernel, dsv4_mhc::THREADS, 0));
+        max_coresident = blocks_per_sm * sms;
+        configured_device = device;
+    }
     TORCH_CHECK(T * NSPLITS <= max_coresident,
                 "DSV4 cooperative mHC: ", T * NSPLITS,
                 " blocks exceed the co-resident limit ", max_coresident,

--- a/csrc/quixicore/tm_cuda/tm_cuda_serving.cu
+++ b/csrc/quixicore/tm_cuda/tm_cuda_serving.cu
@@ -1,3 +1,4 @@
+#include <atomic>
 // tk_cuda serving/decode bindings: torch wrappers over the validated W4/W5
 // kernels (kernels/serving/*_kernels.cuh). Registered into the _C module by
 // init_serving(m), called from tm_cuda_ext.cu's PYBIND11_MODULE.
@@ -18,8 +19,18 @@
 #include "mhc_ampere.cuh"
 #include "dsv4_router_ampere.cuh"
 #include "dsv4_projection_ampere.cuh"
+#include "glm_moe_routing.cuh"
+#include "glm_moe_stable_align.cuh"
+#include "glm_moe_combine.cuh"
+#include "bf16_decode_gemm.cuh"
+#include "fp8_decode_gemm.cuh"
+#include "glm53_mhc_prefill_tc.cuh"
+#include "topk_sample.cuh"
 #include <torch/extension.h>
+#include <ATen/MemoryOverlap.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
@@ -165,6 +176,223 @@ static torch::Tensor py_dsv4_projection_gemv(torch::Tensor x,
     return output;
 }
 
+template <bool STABLE_ALIGNMENT>
+static std::vector<torch::Tensor> py_glm_route_align(
+        torch::Tensor logits, torch::Tensor bias, int64_t topk, int64_t scoring,
+        bool renormalize, double scaling, int64_t block_size, int64_t max_padded,
+        int64_t max_blocks) {
+    CK(logits); CK(bias);
+    TORCH_CHECK(logits.scalar_type() == torch::kFloat32 && logits.dim() == 2,
+                "glm_route_align expects fp32 [M, E] router logits");
+    TORCH_CHECK(bias.scalar_type() == torch::kFloat32 && bias.dim() == 1 &&
+                    bias.numel() == logits.size(1),
+                "glm_route_align expects an fp32 [E] correction bias");
+    TORCH_CHECK(bias.device() == logits.device(),
+                "glm_route_align bias must be on the logits device");
+    const int M = int(logits.size(0)), E = int(logits.size(1));
+    TORCH_CHECK(M >= 1 && M <= glm_route::MAX_TOKENS,
+                "glm_route_align handles 1..16 tokens");
+    TORCH_CHECK(E == 288 && topk == 8,
+                "glm_route_align is instantiated for E=288, topk=8");
+    TORCH_CHECK(scoring == 0 || scoring == 1,
+                "glm_route_align expects sigmoid or sqrt-softplus scoring");
+    TORCH_CHECK(block_size == 8 || block_size == 16 || block_size == 32 ||
+                    block_size == 48 || block_size == 64,
+                "glm_route_align unsupported block size");
+    const int64_t expected_capacity = std::min(
+        M * topk * block_size, M * topk + E * (block_size - 1));
+    TORCH_CHECK(max_padded == expected_capacity &&
+                    max_blocks == (expected_capacity + block_size - 1) / block_size,
+                "glm_route_align alignment capacity mismatch");
+    const c10::cuda::CUDAGuard guard(logits.device());
+    if constexpr (STABLE_ALIGNMENT) {
+        const auto* properties = at::cuda::getDeviceProperties(logits.get_device());
+        TORCH_CHECK(properties->major == 12 && properties->minor == 0,
+                    "stable GLM routing is qualified for SM120 only");
+    }
+    auto i32 = logits.options().dtype(torch::kInt32);
+    auto topk_weights = torch::empty({M, topk}, logits.options());
+    auto topk_ids = torch::empty({M, topk}, i32);
+    auto sorted = torch::empty({max_padded}, i32);
+    auto expert_ids = torch::empty({max_blocks}, i32);
+    auto post_pad = torch::empty({1}, i32);
+    glm_route::route_align_kernel<288, 8, STABLE_ALIGNMENT>
+        <<<1, glm_route::THREADS, 0, stream()>>>(
+            fp(logits), fp(bias), fpm(topk_weights),
+            topk_ids.data_ptr<int32_t>(), sorted.data_ptr<int32_t>(),
+            expert_ids.data_ptr<int32_t>(), post_pad.data_ptr<int32_t>(), M,
+            int(scoring), float(scaling), renormalize, int(block_size),
+            int(max_padded), int(max_blocks));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return {topk_weights, topk_ids, sorted, expert_ids, post_pad};
+}
+
+// Out-variant keeps allocations in the opaque Python custom op and permits
+// full-capacity/redzone tests of the exact serving entry. Off by default.
+static void py_glm_stable_align(
+        torch::Tensor ids, torch::Tensor sorted, torch::Tensor experts,
+        torch::Tensor padded, torch::Tensor offsets, int64_t block) {
+    CK(ids);
+    TORCH_CHECK(ids.scalar_type() == torch::kInt32 && ids.dim() == 2 &&
+                    ids.size(0) >= 17 && ids.size(0) <= 8192 && ids.size(1) == 8,
+                "glm_stable_align expects int32 [17..8192,8] IDs");
+    TORCH_CHECK(block == 8 || block == 16 || block == 32 || block == 48 || block == 64,
+                "glm_stable_align unsupported block size");
+    const int numel = int(ids.numel());
+    const int capacity = int(std::min(int64_t(numel) * block,
+                                    numel + 288 * (block - 1)));
+    const int blocks = int((capacity + block - 1) / block);
+    const std::vector<torch::Tensor> outputs{sorted, experts, padded, offsets};
+    const int sizes[] = {capacity, blocks, 1, 289};
+    for (int i = 0; i < 4; ++i) {
+        const auto& value = outputs[i];
+        TORCH_CHECK(value.device() == ids.device() && value.is_contiguous() &&
+                        value.scalar_type() == torch::kInt32 && value.dim() == 1 &&
+                        value.numel() == sizes[i],
+                    "glm_stable_align output contract mismatch at ", i);
+        at::assert_no_overlap(ids, value);
+        for (int j = 0; j < i; ++j) at::assert_no_overlap(outputs[j], value);
+    }
+    const c10::cuda::CUDAGuard guard(ids.device());
+    const auto* properties = at::cuda::getDeviceProperties(ids.get_device());
+    TORCH_CHECK(properties->major == 12 && properties->minor == 0,
+                "stable GLM alignment is qualified for SM120 only");
+    const bool small = ids.size(0) <= 32;
+    auto count = small ? glm_stable_align::count_prefix<256, true>
+                       : glm_stable_align::count_prefix<1024, false>;
+    count<<<2, small ? 256 : 1024, 0, stream()>>>(
+        ids.data_ptr<int>(), sorted.data_ptr<int>(), experts.data_ptr<int>(),
+        padded.data_ptr<int>(), offsets.data_ptr<int>(), numel, int(block), capacity, blocks);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    auto scatter = small ? glm_stable_align::scatter_bitmap<256>
+                         : glm_stable_align::scatter_bitmap<512>;
+    scatter<<<288, small ? 256 : 512, 0, stream()>>>(
+        ids.data_ptr<int>(), sorted.data_ptr<int>(), offsets.data_ptr<int>(), numel);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+static void py_moe_sum_add(torch::Tensor x, torch::Tensor shared, torch::Tensor out) {
+    CK(x); CK(shared); CK(out);
+    TORCH_CHECK(x.scalar_type() == torch::kBFloat16 && shared.scalar_type() == torch::kBFloat16 &&
+                    out.scalar_type() == torch::kBFloat16,
+                "moe_sum_add: bf16 tensors");
+    TORCH_CHECK(x.dim() == 3 && shared.dim() == 2 && out.dim() == 2,
+                "moe_sum_add: x [T, topk, D], shared/out [T, D]");
+    const int64_t T = x.size(0), topk = x.size(1), d = x.size(2);
+    TORCH_CHECK(shared.size(0) == T && shared.size(1) == d && out.size(0) == T && out.size(1) == d,
+                "moe_sum_add: shape mismatch");
+    TORCH_CHECK(d % glm_moe_combine::VEC == 0, "moe_sum_add: D must be a multiple of 8");
+    glm_moe_combine::launch_moe_sum_add(bpm(out), bp(x), bp(shared), T, int(d), int(topk), stream());
+}
+
+static torch::Tensor py_decode_gemm(torch::Tensor x, torch::Tensor weight,
+                                    c10::optional<torch::Tensor> bias, bool fp32_out) {
+    CK(x); CK(weight);
+    TORCH_CHECK(x.scalar_type() == torch::kBFloat16 && weight.scalar_type() == torch::kBFloat16,
+                "decode_gemm: bf16 x and weight");
+    TORCH_CHECK(x.dim() == 2 && weight.dim() == 2 && x.size(1) == weight.size(1),
+                "decode_gemm: x [M, K], weight [N, K]");
+    const int M = int(x.size(0)), K = int(x.size(1)), N = int(weight.size(0));
+    TORCH_CHECK(decode_gemm::supports(M, N, K), "decode_gemm: unsupported shape M=", M, " N=", N, " K=", K);
+    const float* bias_ptr = nullptr;
+    if (bias.has_value()) {
+        CK((*bias));
+        TORCH_CHECK(bias->scalar_type() == torch::kFloat32 && bias->numel() == N, "decode_gemm: fp32 bias [N]");
+        bias_ptr = bias->data_ptr<float>();
+    }
+    auto out = torch::empty({M, N}, x.options().dtype(fp32_out ? torch::kFloat32 : torch::kBFloat16));
+    if (fp32_out) decode_gemm::launch_auto(bp(x), bp(weight), bias_ptr, fpm(out), M, N, K, stream());
+    else decode_gemm::launch_auto(bp(x), bp(weight), bias_ptr, bpm(out), M, N, K, stream());
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return out;
+}
+
+// Small-k sampling with all kth-value ties retained and deterministic
+// ascending (value, token ID) nucleus ordering. Caller noise is [B, V]
+// float32/float64 and indexed by vocabulary ID. Returns int64 IDs [B].
+static torch::Tensor py_topk_sample(torch::Tensor logits, torch::Tensor top_k,
+                                    c10::optional<torch::Tensor> top_p, torch::Tensor noise) {
+    using namespace tms::topk_sample;
+    CK(top_k); CK(noise);
+    TORCH_CHECK(logits.is_cuda() && logits.dim() == 2 && logits.scalar_type() == torch::kFloat32 &&
+                logits.stride(1) == 1, "topk_sample: fp32 [B, V] logits with unit inner stride");
+    const c10::cuda::CUDAGuard guard(logits.device());
+    const int B = logits.size(0), V = logits.size(1);
+    TORCH_CHECK(V >= NB * K, "topk_sample: vocabulary smaller than the candidate window");
+    TORCH_CHECK(top_k.scalar_type() == torch::kInt32 && top_k.numel() == B, "topk_sample: int32 top_k [B]");
+    TORCH_CHECK((noise.scalar_type() == torch::kFloat32 || noise.scalar_type() == torch::kFloat64) &&
+                noise.dim() == 2 && noise.size(0) == B && noise.size(1) == V,
+                "topk_sample: fp32 or fp64 noise [B, V]");
+    TORCH_CHECK(top_k.device() == logits.device() && noise.device() == logits.device(),
+                "topk_sample: tensors must be on the logits device");
+    const float* p_ptr = nullptr;
+    if (top_p.has_value()) {
+        const torch::Tensor& p_t = *top_p;
+        CK(p_t);
+        TORCH_CHECK(p_t.scalar_type() == torch::kFloat32 && p_t.numel() == B, "topk_sample: fp32 top_p [B]");
+        TORCH_CHECK(p_t.device() == logits.device(), "topk_sample: top_p device mismatch");
+        p_ptr = p_t.data_ptr<float>();
+    }
+    auto cand_val = torch::empty({B, NB * K}, logits.options());
+    auto cand_idx = torch::empty({B, NB * K}, logits.options().dtype(torch::kInt32));
+    auto thresholds = torch::empty({B, NB}, logits.options());
+    auto omitted = torch::empty({B, NB}, cand_idx.options());
+    auto prefixes = torch::empty({B, NB}, cand_idx.options());
+    auto cutoff_storage = torch::empty({B, int64_t(sizeof(RowCutoff))}, logits.options().dtype(torch::kUInt8));
+    auto* cutoffs = reinterpret_cast<RowCutoff*>(cutoff_storage.data_ptr<uint8_t>());
+    auto part_score = torch::empty({B, NB}, noise.options());
+    auto part_id = torch::empty({B, NB}, cand_idx.options());
+    auto out = torch::empty({B}, logits.options().dtype(torch::kInt64));
+    if (B == 0) return out;
+    candidates_kernel<<<dim3(NB, B), THREADS, 0, stream()>>>(
+        logits.data_ptr<float>(), logits.stride(0), V, cand_val.data_ptr<float>(), cand_idx.data_ptr<int>(),
+        thresholds.data_ptr<float>(), omitted.data_ptr<int>());
+    cutoff_kernel<<<B, MERGE_THREADS, 0, stream()>>>(
+        cand_val.data_ptr<float>(), cand_idx.data_ptr<int>(), thresholds.data_ptr<float>(),
+        omitted.data_ptr<int>(), top_k.data_ptr<int>(), p_ptr, cutoffs, prefixes.data_ptr<int>());
+    if (noise.scalar_type() == torch::kFloat64) {
+        sample_partitions_kernel<double><<<dim3(NB, B), SAMPLE_THREADS, 0, stream()>>>(
+            logits.data_ptr<float>(), logits.stride(0), V, noise.data_ptr<double>(), cutoffs,
+            prefixes.data_ptr<int>(), part_score.data_ptr<double>(), part_id.data_ptr<int>());
+        finish_kernel<double><<<B, 32, 0, stream()>>>(
+            part_score.data_ptr<double>(), part_id.data_ptr<int>(), out.data_ptr<long>());
+    } else {
+        sample_partitions_kernel<float><<<dim3(NB, B), SAMPLE_THREADS, 0, stream()>>>(
+            logits.data_ptr<float>(), logits.stride(0), V, noise.data_ptr<float>(), cutoffs,
+            prefixes.data_ptr<int>(), part_score.data_ptr<float>(), part_id.data_ptr<int>());
+        finish_kernel<float><<<B, 32, 0, stream()>>>(
+            part_score.data_ptr<float>(), part_id.data_ptr<int>(), out.data_ptr<long>());
+    }
+    return out;
+}
+
+static torch::Tensor py_decode_gemm_fp8(torch::Tensor x, torch::Tensor weight, torch::Tensor scale,
+                                        c10::optional<torch::Tensor> bias, bool fp32_out) {
+    CK(x); CK(weight); CK(scale);
+    TORCH_CHECK(x.scalar_type() == torch::kBFloat16, "decode_gemm_fp8: bf16 x");
+    TORCH_CHECK(weight.scalar_type() == torch::kFloat8_e4m3fn, "decode_gemm_fp8: float8_e4m3fn weight");
+    TORCH_CHECK(scale.scalar_type() == torch::kFloat32, "decode_gemm_fp8: fp32 block scales");
+    TORCH_CHECK(x.dim() == 2 && weight.dim() == 2 && x.size(1) == weight.size(1),
+                "decode_gemm_fp8: x [M, K], weight [N, K]");
+    const int M = int(x.size(0)), K = int(x.size(1)), N = int(weight.size(0));
+    TORCH_CHECK(decode_gemm_fp8::supports(M, N, K), "decode_gemm_fp8: unsupported shape M=", M, " N=", N, " K=", K);
+    TORCH_CHECK(scale.dim() == 2 && scale.size(0) == (N + decode_gemm_fp8::SB - 1) / decode_gemm_fp8::SB
+                    && scale.size(1) == K / decode_gemm_fp8::SB,
+                "decode_gemm_fp8: scale [ceil(N/128), K/128]");
+    const float* bias_ptr = nullptr;
+    if (bias.has_value()) {
+        CK((*bias));
+        TORCH_CHECK(bias->scalar_type() == torch::kFloat32 && bias->numel() == N, "decode_gemm_fp8: fp32 bias [N]");
+        bias_ptr = bias->data_ptr<float>();
+    }
+    auto out = torch::empty({M, N}, x.options().dtype(fp32_out ? torch::kFloat32 : torch::kBFloat16));
+    const auto* wp = reinterpret_cast<const uint8_t*>(weight.data_ptr());
+    if (fp32_out) decode_gemm_fp8::launch_auto(bp(x), wp, scale.data_ptr<float>(), bias_ptr, fpm(out), M, N, K, stream());
+    else decode_gemm_fp8::launch_auto(bp(x), wp, scale.data_ptr<float>(), bias_ptr, bpm(out), M, N, K, stream());
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return out;
+}
+
 __global__ void fill_short_context_topk_indices_kernel(
         int* __restrict__ output, const int64_t* __restrict__ positions,
         int rows, int topk, int compress_ratio) {
@@ -198,12 +426,62 @@ static void py_fill_short_context_topk_indices(
 }
 
 // ---- DeepSeek-V4 mHC, decode-specialized for Ampere ----
-static bool dsv4_mhc_cooperative_enabled() {
-    static const bool enabled = [] {
-        const char* value = std::getenv("VLLM_DSV4_MHC_COOPERATIVE");
-        return value == nullptr || value[0] != '0';
+// T == 1 pre-transition launch mode: 0 = cooperative fused kernel (grid sync),
+// 1 = last-block fused kernel (regular launch, 2026-09-07 rtx6000), 2 = the
+// three-kernel split path. VLLM_DSV4_MHC_MODE sets it; the legacy
+// VLLM_DSV4_MHC_COOPERATIVE=0 still selects the split path. Settable at
+// runtime (set_dsv4_mhc_mode) so one process can compare the modes.
+static std::atomic<int> g_dsv4_mhc_mode{-1};
+
+static int dsv4_mhc_mode() {
+    int mode = g_dsv4_mhc_mode.load(std::memory_order_relaxed);
+    if (mode >= 0) return mode;
+    mode = 0;
+    if (const char* value = std::getenv("VLLM_DSV4_MHC_MODE")) {
+        const int parsed = std::atoi(value);
+        if (parsed >= 0 && parsed <= 2) mode = parsed;
+    } else if (const char* legacy = std::getenv("VLLM_DSV4_MHC_COOPERATIVE")) {
+        if (legacy[0] == '0') mode = 2;
+    }
+    g_dsv4_mhc_mode.store(mode, std::memory_order_relaxed);
+    return mode;
+}
+
+static void py_set_dsv4_mhc_mode(int64_t mode) {
+    TORCH_CHECK(mode >= 0 && mode <= 2, "dsv4 mHC mode must be 0, 1 or 2");
+    g_dsv4_mhc_mode.store(int(mode), std::memory_order_relaxed);
+}
+
+static int64_t py_get_dsv4_mhc_mode() { return dsv4_mhc_mode(); }
+
+// Largest token count the cooperative fused kernel takes (T x NSPLITS blocks
+// co-resident, one grid barrier); larger T goes through the split path.
+// Default 8: measured 2026-09-07 on glm53-nvfp4-4/rtx6000 (notebook "mHC
+// cooperative launch for T <= 8"), c8 +1.2% like-state, c1 and c16 (split
+// path) unchanged, bit-exact. VLLM_DSV4_MHC_COOP_MAX_T overrides (1 = the
+// previous behaviour). Read once per process.
+static int dsv4_mhc_coop_max_t() {
+    static const int value = [] {
+        const char* env = std::getenv("VLLM_DSV4_MHC_COOP_MAX_T");
+        const int parsed = env ? std::atoi(env) : 8;
+        return parsed < 1 ? 1 : (parsed > 16 ? 16 : parsed);
     }();
-    return enabled;
+    return value;
+}
+
+// Persistent device counter for the last-block kernel (one launch in flight
+// per stream; the last block resets it). Allocated on first use, which is an
+// eager call - vLLM warms every shape up before it captures graphs.
+static int* dsv4_mhc_counter() {
+    static int* counter = [] {
+        int* ptr = nullptr;
+        TORCH_CHECK(cudaMalloc(&ptr, sizeof(int)) == cudaSuccess,
+                    "dsv4 mHC counter: cudaMalloc failed");
+        TORCH_CHECK(cudaMemset(ptr, 0, sizeof(int)) == cudaSuccess,
+                    "dsv4 mHC counter: cudaMemset failed");
+        return ptr;
+    }();
+    return counter;
 }
 
 static int dsv4_mhc_splits() {
@@ -250,8 +528,33 @@ static void launch_dsv4_mhc_pre_transition(
         &rms_eps, &pre_eps, &sinkhorn_eps, &post_multiplier,
         &sinkhorn_repeat, &norm_eps,
     };
+    const int T = residual.size(0);
+    if (dsv4_mhc_mode() == 1 && T == 1) {
+        dsv4_mhc::fused_pre_transition_lastblock<FUSED_POST, RMS_NORM, 4096,
+                                                 NSPLITS, FnT>
+            <<<dim3(NSPLITS, 1), dim3(dsv4_mhc::THREADS), 0, stream()>>>(
+                x_ptr, residual_ptr, post_ptr, comb_ptr, fn_ptr,
+                residual_out_ptr, partial_ptr, scale_ptr, base_ptr,
+                next_post_ptr, next_comb_ptr, layer_input_ptr, norm_ptr,
+                rms_eps, pre_eps, sinkhorn_eps, post_multiplier,
+                sinkhorn_repeat, norm_eps, dsv4_mhc_counter());
+        return;
+    }
+    // All T x NSPLITS blocks must be co-resident for the grid barrier.
+    static const int max_coresident = [&] {
+        int device = 0, sms = 0, blocks_per_sm = 0;
+        cudaGetDevice(&device);
+        cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, device);
+        cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+            &blocks_per_sm, kernel, dsv4_mhc::THREADS, 0);
+        return blocks_per_sm * sms;
+    }();
+    TORCH_CHECK(T * NSPLITS <= max_coresident,
+                "DSV4 cooperative mHC: ", T * NSPLITS,
+                " blocks exceed the co-resident limit ", max_coresident,
+                "; lower VLLM_DSV4_MHC_COOP_MAX_T");
     const cudaError_t error = cudaLaunchCooperativeKernel(
-        reinterpret_cast<const void*>(kernel), dim3(NSPLITS, 1),
+        reinterpret_cast<const void*>(kernel), dim3(NSPLITS, T),
         dim3(dsv4_mhc::THREADS), args, 0, stream());
     TORCH_CHECK(error == cudaSuccess,
                 "DSV4 cooperative mHC launch failed: ",
@@ -279,6 +582,12 @@ static void launch_dsv4_mhc_pre_transition_selected(
         } else {
             LAUNCH_MHC_TYPED(half, 64);
         }
+    } else if (fn.scalar_type() == torch::kBFloat16) {
+        if (dsv4_mhc_splits() == 32) {
+            LAUNCH_MHC_TYPED(__nv_bfloat16, 32);
+        } else {
+            LAUNCH_MHC_TYPED(__nv_bfloat16, 64);
+        }
     } else if (dsv4_mhc_splits() == 32) {
         LAUNCH_MHC_TYPED(float, 32);
     } else {
@@ -287,6 +596,136 @@ static void launch_dsv4_mhc_pre_transition_selected(
 #undef LAUNCH_MHC_TYPED
 }
 
+// Prefill-shaped partials (mhc_ampere.cuh partials_prefill) for the split
+// path at T >= VLLM_DSV4_MHC_PREFILL_MIN_T (default 64: measured on
+// glm53-nvfp4-4/rtx6000, faster from T = 64 up and slower at T = 16;
+// 0 disables). Decode batches keep `partials`.
+// Runtime-settable (set_dsv4_mhc_prefill_min_t) so one process can compare
+// the two split-path partials kernels.
+static std::atomic<int> g_dsv4_mhc_prefill_min_t{-1};
+static int dsv4_mhc_prefill_min_t() {
+    int value = g_dsv4_mhc_prefill_min_t.load(std::memory_order_relaxed);
+    if (value >= 0) return value;
+    const char* env = std::getenv("VLLM_DSV4_MHC_PREFILL_MIN_T");
+    const int parsed = env ? std::atoi(env) : 64;
+    value = parsed < 0 ? 0 : parsed;
+    g_dsv4_mhc_prefill_min_t.store(value, std::memory_order_relaxed);
+    return value;
+}
+static void py_set_dsv4_mhc_prefill_min_t(int64_t min_t) {
+    TORCH_CHECK(min_t >= 0, "dsv4 mHC prefill min T must be >= 0");
+    g_dsv4_mhc_prefill_min_t.store(int(min_t), std::memory_order_relaxed);
+}
+static int64_t py_get_dsv4_mhc_prefill_min_t() {
+    return dsv4_mhc_prefill_min_t();
+}
+
+// Opt-in until fixed real-profile quality/performance qualification. This
+// changes only prefill dot summation order, never the stored model values.
+static std::atomic<int> g_glm53_mhc_prefill_tc{-1};
+static int64_t py_get_glm53_mhc_prefill_tc() {
+    int enabled = g_glm53_mhc_prefill_tc.load(std::memory_order_relaxed);
+    if (enabled >= 0) return enabled;
+    const char* value = std::getenv("VLLM_GLM5_MHC_PREFILL_TC");
+    TORCH_CHECK(value == nullptr ||
+                ((value[0] == '0' || value[0] == '1') && value[1] == '\0'),
+                "VLLM_GLM5_MHC_PREFILL_TC must be 0 or 1");
+    enabled = value != nullptr && value[0] == '1';
+    g_glm53_mhc_prefill_tc.store(enabled, std::memory_order_relaxed);
+    return enabled;
+}
+static void py_set_glm53_mhc_prefill_tc(int64_t enabled) {
+    TORCH_CHECK(enabled == 0 || enabled == 1, "mHC tensor-core switch must be 0 or 1");
+    g_glm53_mhc_prefill_tc.store(int(enabled), std::memory_order_relaxed);
+}
+template <bool FUSED_POST>
+static void launch_glm53_mhc_prefill_tc(
+        const __nv_bfloat16* x, const __nv_bfloat16* residual,
+        const float* post, const float* comb, const __nv_bfloat16* fn,
+        __nv_bfloat16* residual_out, float* partial, int T) {
+    auto kernel = glm53_mhc_prefill_tc::partials_tc<FUSED_POST>;
+    static thread_local int configured_device = -1;
+    int device = -1;
+    C10_CUDA_CHECK(cudaGetDevice(&device));
+    if (configured_device != device) {
+        C10_CUDA_CHECK(cudaFuncSetAttribute(
+            kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+            glm53_mhc_prefill_tc::BYTES));
+        configured_device = device;
+    }
+    kernel<<<dim3(dsv4_mhc::SPLITS, (T + 31) / 32), 256,
+             glm53_mhc_prefill_tc::BYTES, stream()>>>(
+        x, residual, post, comb, fn, residual_out, partial, T);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+template <bool FUSED_POST, typename FnT, bool PAIRED_FN = false>
+static void launch_dsv4_mhc_partials_prefill_typed(
+        const __nv_bfloat16* x, const __nv_bfloat16* residual,
+        const float* post, const float* comb, const FnT* fn,
+        __nv_bfloat16* residual_out, float* partial, int T) {
+    auto kernel = dsv4_mhc::partials_prefill<FUSED_POST, 4096, FnT, PAIRED_FN>;
+    // This helper is module-local, but CUDA attributes also belong to the
+    // active device. A once-per-process flag leaves later devices unconfigured.
+    static thread_local int configured_device = -1;
+    int device = -1;
+    C10_CUDA_CHECK(cudaGetDevice(&device));
+    if (configured_device != device) {
+        C10_CUDA_CHECK(cudaFuncSetAttribute(
+            kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+            int(dsv4_mhc::PREFILL_SMEM)));
+        configured_device = device;
+    }
+    const dim3 grid(dsv4_mhc::SPLITS,
+                    (T + dsv4_mhc::PREFILL_TILE - 1) / dsv4_mhc::PREFILL_TILE);
+    kernel<<<grid, dsv4_mhc::THREADS, dsv4_mhc::PREFILL_SMEM, stream()>>>(
+        x, residual, post, comb, fn, residual_out, partial, T);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+// Returns false when the split path must use `partials` (small T, H != 4096
+// or the kernel disabled).
+template <bool FUSED_POST>
+static bool launch_dsv4_mhc_partials_prefill(
+        const __nv_bfloat16* x, const __nv_bfloat16* residual,
+        const float* post, const float* comb, torch::Tensor fn,
+        __nv_bfloat16* residual_out, float* partial, int T, int H,
+        bool allow_tensor_core) {
+    const int min_t = dsv4_mhc_prefill_min_t();
+    if (min_t == 0 || T < min_t || H != 4096) return false;
+    if (fn.scalar_type() == torch::kHalf) {
+        launch_dsv4_mhc_partials_prefill_typed<FUSED_POST, half>(
+            x, residual, post, comb,
+            reinterpret_cast<const half*>(fn.data_ptr()), residual_out,
+            partial, T);
+    } else if (fn.scalar_type() == torch::kBFloat16) {
+        const auto* properties = at::cuda::getDeviceProperties(fn.get_device());
+        const bool sm120 = properties->major == 12 && properties->minor == 0;
+        if (allow_tensor_core && sm120 && T >= 64 && T <= 7616 &&
+                reinterpret_cast<uintptr_t>(fn.data_ptr()) % 16 == 0 &&
+                reinterpret_cast<uintptr_t>(residual) % 16 == 0 &&
+                (!FUSED_POST || (reinterpret_cast<uintptr_t>(x) % 16 == 0 &&
+                                reinterpret_cast<uintptr_t>(residual_out) % 16 == 0)) &&
+                py_get_glm53_mhc_prefill_tc()) {
+            launch_glm53_mhc_prefill_tc<FUSED_POST>(
+                x, residual, post, comb, bp(fn), residual_out, partial, T);
+            return true;
+        }
+        // Qualify this layout only on SM120. A contiguous tensor may still
+        // have an odd BF16 storage offset; preserve its valid scalar path.
+        const bool paired = sm120 &&
+                            reinterpret_cast<uintptr_t>(fn.data_ptr()) % 4 == 0;
+        if (paired) {
+            launch_dsv4_mhc_partials_prefill_typed<FUSED_POST, __nv_bfloat16, true>(
+                x, residual, post, comb, bp(fn), residual_out, partial, T);
+        } else {
+            launch_dsv4_mhc_partials_prefill_typed<FUSED_POST, __nv_bfloat16>(
+                x, residual, post, comb, bp(fn), residual_out, partial, T);
+        }
+    } else {
+        launch_dsv4_mhc_partials_prefill_typed<FUSED_POST, float>(
+            x, residual, post, comb, fp(fn), residual_out, partial, T);
+    }
+    return true;
+}
 template <int NOUT, bool FUSED_POST>
 static void launch_dsv4_mhc_partials(
         const __nv_bfloat16* x, const __nv_bfloat16* residual,
@@ -299,6 +738,11 @@ static void launch_dsv4_mhc_partials(
                 x, residual, post, comb,
                 reinterpret_cast<const half*>(fn.data_ptr()), residual_out,
                 partial, hidden_size);
+    } else if (fn.scalar_type() == torch::kBFloat16) {
+        dsv4_mhc::partials<NOUT, FUSED_POST, __nv_bfloat16>
+            <<<grid, dsv4_mhc::THREADS, 0, stream()>>>(
+                x, residual, post, comb, bp(fn), residual_out, partial,
+                hidden_size);
     } else {
         dsv4_mhc::partials<NOUT, FUSED_POST, float>
             <<<grid, dsv4_mhc::THREADS, 0, stream()>>>(
@@ -315,8 +759,9 @@ static std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> py_dsv4_mhc_pre(
     CK(residual); CK(fn); CK(hc_scale); CK(hc_base);
     TORCH_CHECK(residual.scalar_type() == torch::kBFloat16, "residual must be bf16");
     TORCH_CHECK(fn.scalar_type() == torch::kFloat32 ||
-                fn.scalar_type() == torch::kFloat16,
-                "fn must be float16 or float32");
+                fn.scalar_type() == torch::kFloat16 ||
+                fn.scalar_type() == torch::kBFloat16,
+                "fn must be bfloat16, float16 or float32");
     const int T = residual.size(0), H = residual.size(2);
     TORCH_CHECK(residual.size(1) == dsv4_mhc::HC && fn.size(0) == dsv4_mhc::MIXES,
                 "DSV4 mHC expects hc_mult=4 and 24 mix rows");
@@ -325,7 +770,7 @@ static std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> py_dsv4_mhc_pre(
     auto post = torch::empty({T, dsv4_mhc::HC}, float_options);
     auto comb = torch::empty({T, dsv4_mhc::HC, dsv4_mhc::HC}, float_options);
     auto layer_input = torch::empty({T, H}, residual.options());
-    if (dsv4_mhc_cooperative_enabled() && T == 1 && H == 4096) {
+    if (dsv4_mhc_mode() != 2 && T <= dsv4_mhc_coop_max_t() && H == 4096) {
         if (norm_weight) {
             launch_dsv4_mhc_pre_transition_selected<false, true>(
                 nullptr, residual, nullptr, nullptr, fn, nullptr, partial,
@@ -341,9 +786,15 @@ static std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> py_dsv4_mhc_pre(
         }
         return {post, comb, layer_input};
     }
-    launch_dsv4_mhc_partials<dsv4_mhc::MIXES, false>(
-        nullptr, bp(residual), nullptr, nullptr, fn, nullptr, fpm(partial), H,
-        dim3(dsv4_mhc::SPLITS, T));
+    if (!launch_dsv4_mhc_partials_prefill<false>(
+            nullptr, bp(residual), nullptr, nullptr, fn, nullptr,
+            fpm(partial), T, H,
+            !norm_weight && rms_eps == 1e-5 && pre_eps == 1e-6 &&
+            sinkhorn_eps == 1e-6 && post_multiplier == 2.0 && sinkhorn_repeat == 20)) {
+        launch_dsv4_mhc_partials<dsv4_mhc::MIXES, false>(
+            nullptr, bp(residual), nullptr, nullptr, fn, nullptr,
+            fpm(partial), H, dim3(dsv4_mhc::SPLITS, T));
+    }
     dsv4_mhc::finalize_pre_mix<<<T, 32, 0, stream()>>>(
         fpm(partial), fp(hc_scale), fp(hc_base), fpm(post),
         fpm(comb), H, float(rms_eps), float(pre_eps),
@@ -378,10 +829,11 @@ py_dsv4_mhc_fused_post_pre(
     TORCH_CHECK(x.scalar_type() == torch::kBFloat16 &&
                 residual.scalar_type() == torch::kBFloat16, "x/residual must be bf16");
     TORCH_CHECK((fn.scalar_type() == torch::kFloat32 ||
-                 fn.scalar_type() == torch::kFloat16) &&
+                 fn.scalar_type() == torch::kFloat16 ||
+                 fn.scalar_type() == torch::kBFloat16) &&
                 post_mix.scalar_type() == torch::kFloat32 &&
                 comb_mix.scalar_type() == torch::kFloat32,
-                "mHC fn must be float16/float32 and mixes must be float32");
+                "mHC fn must be bfloat16/float16/float32 and mixes must be float32");
     const int T = residual.size(0), H = residual.size(2);
     TORCH_CHECK(residual.size(1) == dsv4_mhc::HC && fn.size(0) == dsv4_mhc::MIXES,
                 "DSV4 mHC expects hc_mult=4 and 24 mix rows");
@@ -392,7 +844,7 @@ py_dsv4_mhc_fused_post_pre(
     auto next_comb = torch::empty(
         {T, dsv4_mhc::HC, dsv4_mhc::HC}, float_options);
     auto layer_input = torch::empty({T, H}, residual.options());
-    if (dsv4_mhc_cooperative_enabled() && T == 1 && H == 4096) {
+    if (dsv4_mhc_mode() != 2 && T <= dsv4_mhc_coop_max_t() && H == 4096) {
         if (norm_weight) {
             launch_dsv4_mhc_pre_transition_selected<true, true>(
                 &x, residual, &post_mix, &comb_mix, fn, &residual_out,
@@ -409,9 +861,15 @@ py_dsv4_mhc_fused_post_pre(
         }
         return {residual_out, next_post, next_comb, layer_input};
     }
-    launch_dsv4_mhc_partials<dsv4_mhc::MIXES, true>(
-        bp(x), bp(residual), fp(post_mix), fp(comb_mix), fn,
-        bpm(residual_out), fpm(partial), H, dim3(dsv4_mhc::SPLITS, T));
+    if (!launch_dsv4_mhc_partials_prefill<true>(
+            bp(x), bp(residual), fp(post_mix), fp(comb_mix), fn,
+            bpm(residual_out), fpm(partial), T, H,
+            !norm_weight && rms_eps == 1e-5 && pre_eps == 1e-6 &&
+            sinkhorn_eps == 1e-6 && post_multiplier == 2.0 && sinkhorn_repeat == 20)) {
+        launch_dsv4_mhc_partials<dsv4_mhc::MIXES, true>(
+            bp(x), bp(residual), fp(post_mix), fp(comb_mix), fn,
+            bpm(residual_out), fpm(partial), H, dim3(dsv4_mhc::SPLITS, T));
+    }
     dsv4_mhc::finalize_pre_mix<<<T, 32, 0, stream()>>>(
         fpm(partial), fp(hc_scale), fp(hc_base), fpm(next_post),
         fpm(next_comb), H, float(rms_eps), float(pre_eps),
@@ -1412,6 +1870,36 @@ static torch::Tensor py_mla_decode_bf16_sparse_glm(torch::Tensor q, torch::Tenso
 // GLM-5.3-Flash (glm5_next) NoPE MLA, bf16 cache. There is no rope segment:
 // q and each slot are 512 bf16 latents (1024 B/slot) and the whole width both
 // scores and accumulates, i.e. the same template at QW = VW = 512.
+// Reduce form for the partitioned sparse decode (VLLM_MLA_SPARSE_REDUCE, read
+// once per process): 0 = one warp per (head, token) walking the partitions
+// serially (the original; ~0.5 us per partition on sm_120, 9.6 us at the
+// served 17 partitions and linear beyond), 1 = paged_attention_reduce_multiwarp
+// with 8 warps (3.1-5.7 us), 2 = paged_attention_reduce_channels, one thread
+// per value channel (2.4-4.2 us at 17-65 partitions; default, measured
+// 2026-09-07 on glm53-nvfp4-4/rtx6000, notebook "Sparse MLA decode: partition
+// and reduce").
+static int mla_sparse_reduce_mode() {
+    static const int value = [] {
+        const char* env = std::getenv("VLLM_MLA_SPARSE_REDUCE");
+        const int parsed = env ? std::atoi(env) : 2;
+        return parsed < 0 ? 0 : (parsed > 2 ? 2 : parsed);
+    }();
+    return value;
+}
+static void launch_sparse_reduce_512(const float* tmp, const float* ml, const float* es,
+                                     __nv_bfloat16* out, int H, int B, int P) {
+    const int mode = mla_sparse_reduce_mode();
+    if (mode == 2) {
+        paged_attention_reduce_channels<__nv_bfloat16, 512>
+            <<<dim3(H, B), 512, P * sizeof(float), stream()>>>(tmp, ml, es, out, H, P);
+    } else if (mode == 1) {
+        paged_attention_reduce_multiwarp<__nv_bfloat16, 512, 8>
+            <<<dim3(H, B), 256, P * sizeof(float), stream()>>>(tmp, ml, es, out, H, P);
+    } else {
+        paged_attention_reduce<__nv_bfloat16, 512><<<dim3(H, B), 32, 0, stream()>>>(tmp, ml, es, out, H, P);
+    }
+}
+
 static torch::Tensor py_mla_decode_bf16_sparse_nope(torch::Tensor q, torch::Tensor kv,
         torch::Tensor bt, torch::Tensor indices, torch::Tensor topk_length,
         int64_t block_size, double scale, int64_t partition_size, int64_t page_stride_bytes) {
@@ -1445,8 +1933,7 @@ static torch::Tensor py_mla_decode_bf16_sparse_nope(torch::Tensor q, torch::Tens
         topk_length.data_ptr<int>(), max_topk, nullptr,
         tmp.data_ptr<float>(), ml.data_ptr<float>(), es.data_ptr<float>(),
         int(block_size), int(bt.size(1)), float(scale), H, P, int(partition_size), 1.0f, nullptr, 0, int(page_stride_bytes));
-    paged_attention_reduce<__nv_bfloat16, 512><<<dim3(H, B), 32, 0, stream()>>>(
-        tmp.data_ptr<float>(), ml.data_ptr<float>(), es.data_ptr<float>(), bpm(out), H, P);
+    launch_sparse_reduce_512(tmp.data_ptr<float>(), ml.data_ptr<float>(), es.data_ptr<float>(), bpm(out), H, B, P);
     return out;
 }
 
@@ -2053,6 +2540,41 @@ void init_serving(py::module_& m) {
     m.def("dsv4_hash_router_debug", &py_dsv4_hash_router_debug);
     m.def("dsv4_projection_gemv", &py_dsv4_projection_gemv, py::arg("x"),
           py::arg("weight"), py::arg("bf16_output") = false);
+    m.def("glm_route_align", &py_glm_route_align<false>, py::arg("logits"),
+          py::arg("bias"), py::arg("topk"), py::arg("scoring"),
+          py::arg("renormalize"), py::arg("scaling"), py::arg("block_size"),
+          py::arg("max_padded"), py::arg("max_blocks"),
+          "fused small-M routing: scored top-k with bias selection + Marlin block alignment");
+    m.def("glm_stable_align", &py_glm_stable_align, py::arg("ids"),
+          py::arg("sorted"), py::arg("experts"), py::arg("padded"),
+          py::arg("offsets"), py::arg("block"));
+    m.def("glm_route_align_stable", &py_glm_route_align<true>, py::arg("logits"),
+          py::arg("bias"), py::arg("topk"), py::arg("scoring"),
+          py::arg("renormalize"), py::arg("scaling"), py::arg("block_size"),
+          py::arg("max_padded"), py::arg("max_blocks"),
+          "opt-in SM120 small-M routing with stable within-expert assignment order");
+    m.def("decode_gemm", &py_decode_gemm, py::arg("x"), py::arg("weight"),
+          py::arg("bias") = py::none(), py::arg("fp32_out") = false,
+          "bf16 M<=16 GEMM on tensor cores: x @ weight^T (+ bias), fp32 accumulation");
+    m.def("set_dsv4_mhc_mode", &py_set_dsv4_mhc_mode,
+          "T == 1 mHC pre-transition launch mode: 0 cooperative, 1 last-block, 2 split kernels");
+    m.def("get_dsv4_mhc_mode", &py_get_dsv4_mhc_mode);
+    m.def("set_dsv4_mhc_prefill_min_t", &py_set_dsv4_mhc_prefill_min_t,
+          "smallest T the split path hands to the prefill-shaped partials kernel (0 = never)");
+    m.def("get_dsv4_mhc_prefill_min_t", &py_get_dsv4_mhc_prefill_min_t);
+    m.def("set_glm53_mhc_prefill_tc", &py_set_glm53_mhc_prefill_tc,
+          "opt-in SM120 BF16 mHC prefill tensor cores (0/1); affects eager and future captures only");
+    m.def("get_glm53_mhc_prefill_tc", &py_get_glm53_mhc_prefill_tc);
+    m.def("topk_sample", &py_topk_sample, py::arg("logits"), py::arg("top_k"),
+          py::arg("top_p") = py::none(), py::arg("noise"),
+          "top-k (<= 32, ties kept) / top-p sampling of fp32 logits rows with caller-drawn "
+          "fp32/fp64 exponential noise [B, V]; int64 token ids");
+    m.def("decode_gemm_fp8", &py_decode_gemm_fp8, py::arg("x"), py::arg("weight"), py::arg("scale"),
+          py::arg("bias") = py::none(), py::arg("fp32_out") = false,
+          "bf16 x FP8 block-scaled weights (e4m3, 128x128 fp32 scales), M<=16, tensor cores: "
+          "x @ dequant(weight)^T (+ bias), fp32 accumulation");
+    m.def("moe_sum_add", &py_moe_sum_add, py::arg("x"), py::arg("shared"), py::arg("out"),
+          "out[t] = shared[t] + sum_k x[t, k]: Marlin per-assignment sum + shared-expert add, one launch");
     m.def("fill_short_context_topk_indices",
           &py_fill_short_context_topk_indices, py::arg("output"),
           py::arg("positions"), py::arg("topk"),

--- a/slimserve/glm53_ordering.py
+++ b/slimserve/glm53_ordering.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Single opt-in native ordering policy for the fixed GLM53 SM120 recipe.
+
+This selects the full-model-qualified kernels without enabling observers:
+small fused stable routing, large stable alignment, and fused pool ordering
+with smaller-ID cutoff ties. It is not a blanket determinism guarantee.
+Legacy diagnostic switches remain separate controls and cannot be combined.
+"""
+
+import os
+
+FLAG = "SLIMSERVE_GLM53_NATIVE_ORDER"
+RECIPE = "glm53-redhatai-nvfp4-fp8-kda-tp4-v1"
+LEGACY_FLAGS = (
+    "SLIMSERVE_GLM53_CANONICAL_MOE",
+    "SLIMSERVE_GLM53_STABLE_ROUTE",
+    "SLIMSERVE_GLM53_STABLE_ALIGN",
+    "SLIMSERVE_GLM53_CANONICAL_INDEX_ORDER",
+    "SLIMSERVE_GLM53_CANONICAL_INDEX_TIES",
+    "SLIMSERVE_GLM53_CANONICAL_INDEX_FUSED",
+)
+
+
+def enabled() -> bool:
+    value = os.getenv(FLAG, "0")
+    if value not in ("0", "1"):
+        raise ValueError(f"{FLAG} must be 0 or 1")
+    if value == "1":
+        conflicts = [key for key in LEGACY_FLAGS if os.getenv(key, "0") != "0"]
+        if conflicts:
+            raise ValueError(
+                f"native ordering cannot combine with diagnostic flags: {conflicts}"
+            )
+        if os.getenv("SLIMSERVE_GLM_ROUTE_ALIGN", "1") == "0":
+            raise ValueError("native ordering requires fused small-M routing")
+    return value == "1"
+
+
+def cache_factor() -> str:
+    return f"glm53_native_order_v1={int(enabled())}"
+
+
+def validate_plan(plan) -> None:
+    if not enabled():
+        return
+    if not (
+        plan.profile_id in ("glm53-nvfp4-4", "glm53f-nvfp4-4")
+        and plan.platform == "rtx6000"
+        and plan.gpus == 4
+        and plan.quant.name == "NVFP4"
+        and (plan.weight_recipe or {}).get("id") == RECIPE
+        and plan.engine.get("tensor_parallel_size") == 4
+        and not plan.engine.get("enable_expert_parallel", False)
+        and not plan.speculative
+        and plan.engine.get("moe_backend") == "marlin"
+    ):
+        raise ValueError(
+            "native ordering requires glm53-nvfp4-4/rtx6000 recipe v1, "
+            "TP4, no speculation"
+        )

--- a/slimserve/model_journal.py
+++ b/slimserve/model_journal.py
@@ -14,6 +14,7 @@ from contextvars import ContextVar
 from functools import wraps
 
 from slimserve.glm53_ordering import enabled as native_order_enabled
+from slimserve.score_journal import private_open
 
 ACTIVE = ContextVar("slimserve_glm53_model_journal", default=None)
 OP_NAMES = ("glm5_mhc_pre", "glm5_mhc_fused_post_pre", "glm5_mhc_post")
@@ -59,7 +60,7 @@ class ModelJournal:
         self.moe_enabled = moe_enabled()
         self.moe_capture = None
         self.path = score_journal.path.with_name(f"model-{os.getpid()}.jsonl")
-        self.stream = self.path.open("x", buffering=1)
+        self.stream = private_open(self.path, buffering=1)
         self.write(
             {
                 "kind": "header",

--- a/slimserve/model_journal.py
+++ b/slimserve/model_journal.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in GLM53 forward fingerprints through existing opaque mHC operations.
+
+No new GPU operations or arithmetic. Disabled registration returns the original
+callables unchanged. Enabled copies deliberately synchronize execution and are
+not eligible for throughput comparisons.
+"""
+
+import hashlib
+import inspect
+import json
+import os
+from contextvars import ContextVar
+from functools import wraps
+
+from slimserve.glm53_ordering import enabled as native_order_enabled
+
+ACTIVE = ContextVar("slimserve_glm53_model_journal", default=None)
+OP_NAMES = ("glm5_mhc_pre", "glm5_mhc_fused_post_pre", "glm5_mhc_post")
+
+
+def enabled():
+    value = os.environ.get("SLIMSERVE_GLM53_MODEL_JOURNAL", "0")
+    if value not in ("0", "1"):
+        raise ValueError("SLIMSERVE_GLM53_MODEL_JOURNAL must be 0 or 1")
+    return value == "1"
+
+
+def instrument_mhc(function):
+    if not enabled():
+        return function
+    if function.__name__ not in OP_NAMES:
+        raise ValueError("unknown model-journal operation")
+    signature = inspect.signature(function)
+
+    @wraps(function)
+    def traced(*args, **kwargs):
+        journal = ACTIVE.get()
+        if journal is None:
+            return function(*args, **kwargs)
+        bound = signature.bind(*args, **kwargs)
+        bound.apply_defaults()
+        journal.before_op(function.__name__, bound.arguments)
+        result = function(*args, **kwargs)
+        journal.after_op(function.__name__, result)
+        return result
+
+    return traced
+
+
+class ModelJournal:
+    def __init__(self, score_journal):
+        from slimserve.moe_journal import enabled as moe_enabled
+
+        self.prompt_ids = score_journal.prompt_ids
+        self.limit = score_journal.limit
+        self.matches = self.operations = self.records = 0
+        self.active = self.pending = None
+        self.moe_enabled = moe_enabled()
+        self.moe_capture = None
+        self.path = score_journal.path.with_name(f"model-{os.getpid()}.jsonl")
+        self.stream = self.path.open("x", buffering=1)
+        self.write(
+            {
+                "kind": "header",
+                "schema": 1,
+                "diagnostic_only": True,
+                "pid": os.getpid(),
+                "max_matches": self.limit,
+                "max_tensor_bytes": 1024**3,
+                "max_tensor_records_per_match": 1024,
+                "expected_operations": 91,
+                "first_moe_snapshots": self.moe_enabled,
+                "small_route_order": (
+                    "canonical-native"
+                    if native_order_enabled()
+                    or os.getenv("SLIMSERVE_GLM53_STABLE_ROUTE", "0") == "1"
+                    else "atomic-native"
+                ),
+                "large_alignment_order": (
+                    "canonical-native"
+                    if native_order_enabled()
+                    or os.getenv("SLIMSERVE_GLM53_STABLE_ALIGN", "0") == "1"
+                    else "atomic-plus-sort"
+                    if os.getenv("SLIMSERVE_GLM53_CANONICAL_MOE", "0") == "1"
+                    else "atomic"
+                ),
+                "max_moe_dump_bytes_per_worker": 2 * 1024**3,
+                "score_journal": str(score_journal.path),
+                "score_header": json.loads(
+                    score_journal.path.read_text().splitlines()[0]
+                ),
+            }
+        )
+
+    def write(self, row):
+        self.stream.write(json.dumps(row, separators=(",", ":")) + "\n")
+
+    def record(self, stage, tensor):
+        import torch
+
+        if self.active is None or self.records >= 1024:
+            raise ValueError("model trace inactive or record bound exceeded")
+        nbytes = tensor.numel() * tensor.element_size()
+        if not 0 < nbytes <= 1024**3:
+            raise ValueError("model trace tensor byte bound exceeded")
+        host = tensor.detach().cpu().contiguous()
+        digest = hashlib.sha256(
+            memoryview(host.reshape(-1).view(torch.uint8).numpy())
+        ).hexdigest()
+        self.write(
+            {
+                "kind": "tensor",
+                "match": self.matches,
+                "stage": stage,
+                "device": str(tensor.device),
+                "shape": list(tensor.shape),
+                "stride": list(tensor.stride()),
+                "dtype": str(tensor.dtype),
+                "nbytes": nbytes,
+                "sha256": digest,
+            }
+        )
+        self.records += 1
+        return host
+
+    def begin(self, request_id):
+        if self.active is not None or self.matches >= self.limit:
+            raise ValueError("extra or overlapping model trace")
+        self.matches += 1
+        self.operations = self.records = 0
+        self.active = request_id
+        self.write({"kind": "begin", "match": self.matches, "request_id": request_id})
+
+    def before_op(self, name, arguments):
+        import torch
+
+        expected = OP_NAMES[
+            0 if self.operations == 0 else 1 if self.operations < 90 else 2
+        ]
+        if (
+            self.active is None
+            or self.pending is not None
+            or self.operations > 90
+            or name != expected
+        ):
+            raise ValueError("model trace operation order changed")
+        self.pending = name
+        self.write(
+            {
+                "kind": "operation",
+                "match": self.matches,
+                "site": self.operations,
+                "name": name,
+                "parameters": {
+                    k: v
+                    for k, v in arguments.items()
+                    if not isinstance(v, torch.Tensor)
+                },
+            }
+        )
+        for key, tensor in arguments.items():
+            if isinstance(tensor, torch.Tensor):
+                self.record(f"site-{self.operations:03d}.input.{key}", tensor)
+
+    def after_op(self, name, result):
+        if self.active is None or self.pending != name:
+            raise ValueError("model trace operation completion changed")
+        names = {
+            OP_NAMES[0]: ("post_mix", "comb_mix", "layer_input"),
+            OP_NAMES[1]: ("residual", "post_mix", "comb_mix", "layer_input"),
+            OP_NAMES[2]: ("streams",),
+        }[name]
+        values = result if isinstance(result, tuple) else (result,)
+        if len(values) != len(names):
+            raise ValueError("model trace result arity changed")
+        for key, tensor in zip(names, values):
+            self.record(f"site-{self.operations:03d}.output.{key}", tensor)
+        self.pending = None
+        self.operations += 1
+
+    def finish(self):
+        if self.moe_enabled and (
+            self.moe_capture is None or self.matches not in self.moe_capture.completed
+        ):
+            raise ValueError("missing first-MoE capture")
+        if self.active is None or self.pending is not None or self.operations != 91:
+            raise ValueError("incomplete model trace")
+        self.write(
+            {
+                "kind": "complete",
+                "match": self.matches,
+                "operations": self.operations,
+                "tensor_records": self.records,
+            }
+        )
+        self.active = None
+
+    def close(self):
+        self.stream.close()
+
+
+def install_model_journal(runner):
+    """Wrap this runner instance once; no per-step hook at all when disabled."""
+    if not enabled():
+        return
+    from slimserve.score_journal import ScoreJournal
+
+    config = runner.model_config.hf_config
+    text_config = runner.model_config.hf_text_config
+    if (
+        text_config.hidden_size != 4096
+        or text_config.num_hidden_layers != 45
+        or runner.parallel_config.tensor_parallel_size != 4
+        or runner.parallel_config.pipeline_parallel_size != 1
+        or runner.speculative_config is not None
+    ):
+        raise ValueError("model journal requires GLM53 TP4 no-spec")
+    score = ScoreJournal.from_env(getattr(config, "model_type", None))
+    if score is None:
+        raise ValueError("model journal requires a bounded score journal")
+    runner._slimserve_score_journal = score
+    journal = ModelJournal(score)
+    original = runner._model_forward
+
+    @wraps(original)
+    def traced(**kwargs):
+        import torch
+
+        matches = [
+            rid
+            for rid in runner.num_prompt_logprobs
+            if runner.requests[rid].prompt_token_ids == journal.prompt_ids
+        ]
+        if not matches:
+            return original(**kwargs)
+        if len(matches) != 1 or runner.input_batch.num_reqs != 1:
+            raise ValueError("model journal requires one unmixed request")
+        rid = matches[0]
+        if (
+            runner.requests[rid].num_computed_tokens != 0
+            or runner.num_prompt_logprobs[rid] != 0
+        ):
+            raise ValueError("model journal requires an uncached whole prompt")
+        input_ids, embeds, positions = (
+            kwargs.get(k) for k in ("input_ids", "inputs_embeds", "positions")
+        )
+        tokens = input_ids if input_ids is not None else embeds
+        if tokens is None or tokens.shape[0] != 640:
+            raise ValueError("model journal requires the exact 640-token forward")
+        if tokens.device.type != "cuda" or torch.cuda.is_current_stream_capturing():
+            raise ValueError("model journal requires uncaptured CUDA prefill")
+        journal.begin(rid)
+        if input_ids is not None:
+            if input_ids.cpu().tolist() != journal.prompt_ids:
+                raise ValueError("model inputs differ from requested token IDs")
+            journal.record("forward.input_ids", input_ids)
+        if embeds is not None:
+            journal.record("forward.inputs_embeds", embeds)
+        journal.record("forward.positions", positions)
+        token = ACTIVE.set(journal)
+        try:
+            result = original(**kwargs)
+            if not isinstance(result, torch.Tensor) or result.shape != (640, 4096):
+                raise ValueError("model journal requires the complete GLM53 output")
+            journal.record("forward.output", result)
+            journal.record("forward.prompt_head_rows", result[:639])
+            journal.finish()
+            return result
+        finally:
+            ACTIVE.reset(token)
+
+    runner._model_forward = traced

--- a/slimserve/moe_journal.py
+++ b/slimserve/moe_journal.py
@@ -9,6 +9,7 @@ from functools import wraps
 
 from slimserve.model_journal import ACTIVE
 from slimserve.model_journal import enabled as model_journal_enabled
+from slimserve.score_journal import private_directory, private_open
 
 MAX_DUMP_BYTES = 2 * 1024**3
 
@@ -30,7 +31,7 @@ class MoECapture:
         self.completed = set()
         self.saved_bytes = 0
         self.directory = journal.path.parent / f"moe-{os.getpid()}"
-        self.directory.mkdir(exist_ok=False)
+        private_directory(self.directory, exist_ok=False)
 
     def snapshot(self, stage, tensor, parameter=False):
         import torch
@@ -53,14 +54,16 @@ class MoECapture:
             raise ValueError("first-MoE worker dump byte bound exceeded")
         suffix = "parameter" if parameter else f"match-{match}"
         path = self.directory / f"{stage}-{suffix}.pt"
-        with path.open("xb") as stream:
+        with private_open(path, binary=True) as stream:
             torch.save(host, stream)
         size = path.stat().st_size
         if size > nbytes + 65536:
             raise ValueError("unexpected tensor serialization overhead")
         self.saved_bytes += size
+        digest = hashlib.sha256()
         with path.open("rb") as stream:
-            digest = hashlib.file_digest(stream, "sha256").hexdigest()
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
         self.journal.write(
             {
                 "kind": "moe_snapshot",
@@ -68,7 +71,7 @@ class MoECapture:
                 "stage": "moe3." + stage,
                 "path": str(path),
                 "file_bytes": size,
-                "file_sha256": digest,
+                "file_sha256": digest.hexdigest(),
                 "parameter": parameter,
                 "worker_saved_bytes": self.saved_bytes,
             }

--- a/slimserve/moe_journal.py
+++ b/slimserve/moe_journal.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded first-MoE snapshots; disabled decorators are identity functions."""
+
+import hashlib
+import inspect
+import os
+import re
+from functools import wraps
+
+from slimserve.model_journal import ACTIVE
+from slimserve.model_journal import enabled as model_journal_enabled
+
+MAX_DUMP_BYTES = 2 * 1024**3
+
+
+def enabled():
+    flag = os.environ.get("SLIMSERVE_GLM53_MOE_JOURNAL", "0")
+    if flag not in ("0", "1"):
+        raise ValueError("SLIMSERVE_GLM53_MOE_JOURNAL must be 0 or 1")
+    if flag == "1" and not model_journal_enabled():
+        raise ValueError("MoE journal requires the bounded model journal")
+    return flag == "1"
+
+
+class MoECapture:
+    def __init__(self, journal):
+        self.journal = journal
+        self.seen = set()
+        self.gemm_calls = {}
+        self.completed = set()
+        self.saved_bytes = 0
+        self.directory = journal.path.parent / f"moe-{os.getpid()}"
+        self.directory.mkdir(exist_ok=False)
+
+    def snapshot(self, stage, tensor, parameter=False):
+        import torch
+
+        if re.fullmatch(r"(?:router|up|down|sum)\.[a-z_]+", stage) is None:
+            raise ValueError("invalid MoE snapshot stage")
+        match = self.journal.matches
+        key = match, stage
+        if key in self.seen:
+            raise ValueError("duplicate first-MoE stage")
+        self.seen.add(key)
+        host = self.journal.record("moe3." + stage, tensor)
+        if parameter and match != 1:
+            return
+        # Ensure Torch serialization cannot retain an oversized backing storage.
+        nbytes = host.numel() * host.element_size()
+        if host.storage_offset() or host.untyped_storage().nbytes() != nbytes:
+            host = host.clone()
+        if self.saved_bytes + nbytes + 65536 > MAX_DUMP_BYTES:
+            raise ValueError("first-MoE worker dump byte bound exceeded")
+        suffix = "parameter" if parameter else f"match-{match}"
+        path = self.directory / f"{stage}-{suffix}.pt"
+        with path.open("xb") as stream:
+            torch.save(host, stream)
+        size = path.stat().st_size
+        if size > nbytes + 65536:
+            raise ValueError("unexpected tensor serialization overhead")
+        self.saved_bytes += size
+        with path.open("rb") as stream:
+            digest = hashlib.file_digest(stream, "sha256").hexdigest()
+        self.journal.write(
+            {
+                "kind": "moe_snapshot",
+                "match": match,
+                "stage": "moe3." + stage,
+                "path": str(path),
+                "file_bytes": size,
+                "file_sha256": digest,
+                "parameter": parameter,
+                "worker_saved_bytes": self.saved_bytes,
+            }
+        )
+
+
+def _capture():
+    journal = ACTIVE.get()
+    if journal is None or journal.operations != 8 or journal.pending is not None:
+        return None
+    if journal.moe_capture is None:
+        journal.moe_capture = MoECapture(journal)
+    return journal.moe_capture
+
+
+def _decorate(function, operation):
+    if not enabled():
+        return function
+    signature = inspect.signature(function)
+
+    @wraps(function)
+    def traced(*args, **kwargs):
+        capture = _capture()
+        if capture is None:
+            return function(*args, **kwargs)
+        bound = signature.bind(*args, **kwargs)
+        bound.apply_defaults()
+        return operation(capture, bound.arguments, lambda: function(*args, **kwargs))
+
+    return traced
+
+
+def _router(capture, args, call):
+    if args["hidden_states"].shape != (640, 4096) or args["router_logits"].shape != (
+        640,
+        288,
+    ):
+        raise ValueError("first-MoE router shape changed")
+    capture.snapshot("router.input", args["hidden_states"])
+    capture.snapshot("router.logits", args["router_logits"])
+    weights, ids = result = call()
+    if weights.shape != (640, 8) or ids.shape != (640, 8):
+        raise ValueError("first-MoE routes changed")
+    capture.snapshot("router.weights", weights)
+    capture.snapshot("router.ids", ids)
+    return result
+
+
+def instrument_router(function):
+    return _decorate(function, _router)
+
+
+def _marlin(capture, args, call):
+    import torch
+
+    match = capture.journal.matches
+    index = capture.gemm_calls.get(match, 0)
+    if index not in (0, 1):
+        raise ValueError("extra first-MoE GEMM")
+    stage = "up" if index == 0 else "down"
+    expected = ((640, 1024, 4096, 8), (5120, 4096, 512, 1))[index]
+    if (
+        tuple(args[k] for k in ("size_m", "size_n", "size_k", "top_k")) != expected
+        or args["moe_block_size"] != 32
+        or args["input"].dtype != torch.bfloat16
+        or args["use_atomic_add"]
+        or not args["use_fp32_reduce"]
+        or args["topk_weights"].shape != (640, 8)
+    ):
+        raise ValueError("first-MoE Marlin recipe changed")
+    optional = ("b_bias", "a_scales", "b_qzeros", "g_idx", "perm")
+    if any(args[k] is not None and args[k].numel() != 0 for k in optional):
+        raise ValueError("unexpected optional tensor in first-MoE Marlin")
+    capture.gemm_calls[match] = index + 1
+    capture.journal.write(
+        {
+            "kind": "moe_gemm",
+            "match": match,
+            "stage": stage,
+            "parameters": {
+                k: args[k]
+                for k in (
+                    "size_m",
+                    "size_n",
+                    "size_k",
+                    "top_k",
+                    "moe_block_size",
+                    "mul_topk_weights",
+                    "is_k_full",
+                    "use_atomic_add",
+                    "use_fp32_reduce",
+                    "is_zp_float",
+                    "thread_k",
+                    "thread_n",
+                    "blocks_per_sm",
+                )
+            },
+            "b_q_type_id": args["b_q_type"].id,
+            "optional": {
+                k: None
+                if args[k] is None
+                else {"shape": list(args[k].shape), "dtype": str(args[k].dtype)}
+                for k in optional
+            },
+            "global_scale_present": args["global_scale"] is not None,
+        }
+    )
+    for key in ("input", "b_qweight", "b_scales", "global_scale"):
+        if args[key] is not None:
+            capture.snapshot(stage + "." + key, args[key], parameter=key != "input")
+    capture.snapshot(stage + ".workspace_before", args["workspace"])
+    # Only defined alignment prefixes count as evidence, not uninitialized
+    # capacity beyond the actual padded token/block counts.
+    used = int(args["num_tokens_past_padded"].item())
+    block = args["moe_block_size"]
+    if not (
+        0 < used <= args["sorted_token_ids"].numel()
+        and used % block == 0
+        and used // block <= args["expert_ids"].numel()
+    ):
+        raise ValueError("invalid first-MoE alignment extent")
+    capture.snapshot(stage + ".sorted_ids", args["sorted_token_ids"][:used])
+    capture.snapshot(stage + ".expert_ids", args["expert_ids"][: used // block])
+    capture.snapshot(stage + ".padded_count", args["num_tokens_past_padded"])
+    capture.snapshot(stage + ".topk_weights", args["topk_weights"])
+    result = call()
+    capture.snapshot(stage + ".output", result)
+    capture.snapshot(stage + ".workspace_after", args["workspace"])
+    return result
+
+
+def instrument_marlin_gemm(function):
+    return _decorate(function, _marlin)
+
+
+def _sum(capture, args, call):
+    match = capture.journal.matches
+    if (
+        capture.gemm_calls.get(match) != 2
+        or match in capture.completed
+        or args["x"].shape != (640, 8, 4096)
+        or args["shared"].shape != (640, 4096)
+    ):
+        raise ValueError("first-MoE shared sum changed")
+    capture.snapshot("sum.input", args["x"])
+    capture.snapshot("sum.shared", args["shared"])
+    result = call()
+    capture.snapshot("sum.output", args["out"])
+    capture.completed.add(match)
+    capture.journal.write(
+        {
+            "kind": "moe_complete",
+            "match": match,
+            "gemm_calls": 2,
+            "worker_saved_bytes": capture.saved_bytes,
+        }
+    )
+    return result
+
+
+def instrument_moe_sum(function):
+    return _decorate(function, _sum)

--- a/slimserve/score_journal.py
+++ b/slimserve/score_journal.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in, bounded prompt-score fingerprints; diagnostic synchronization only.
+
+Never changes tensor values. Copies one stage at a time to CPU and retains
+only metadata/digests, not model tensors. Must not be used for performance claims.
+"""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+STAGES = (
+    "prompt_head_input",
+    "logits",
+    "scores",
+    "target_token_ids",
+    "selected_logprobs",
+)
+
+
+class ScoreJournal:
+    @classmethod
+    def from_env(cls, model_type):
+        path = os.environ.get("SLIMSERVE_GLM53_SCORE_JOURNAL")
+        if not path:
+            return None
+        if model_type not in ("glm5_next", "glm5_next_text"):
+            raise ValueError("score journal is scoped to the GLM53 diagnostic")
+        return cls(Path(path))
+
+    def __init__(self, path):
+        raw = path.read_bytes()
+        config = json.loads(raw)
+        if not isinstance(config, dict) or set(config) != {
+            "schema",
+            "prompt_ids",
+            "max_matches",
+            "output_directory",
+        }:
+            raise ValueError("invalid score journal configuration fields")
+        ids, limit = config["prompt_ids"], config["max_matches"]
+        if (
+            type(config["schema"]) is not int
+            or config["schema"] != 1
+            or not isinstance(ids, list)
+            or len(ids) != 640
+            or any(type(t) is not int or t < 0 for t in ids)
+            or type(limit) is not int
+            or not 1 <= limit <= 8
+            or not isinstance(config["output_directory"], str)
+            or not config["output_directory"]
+        ):
+            raise ValueError("score journal requires 640 token IDs and 1..8 matches")
+        self.prompt_ids, self.limit = ids, limit
+        self.matches, self.active = 0, None
+        directory = Path(config["output_directory"])
+        directory.mkdir(parents=True, exist_ok=True)
+        self.path = directory / f"score-{os.getpid()}.jsonl"
+        self.stream = self.path.open("x", buffering=1)
+        root = Path(__file__).resolve().parents[1]
+        source_paths = (
+            "slimserve/canonical_indexer.py",
+            "slimserve/canonical_indexer_kernel.py",
+            "slimserve/index_journal.py",
+            "vllm/model_executor/layers/glm5_next_indexer.py",
+            "slimserve/score_journal.py",
+            "vllm/v1/worker/gpu_model_runner.py",
+            "vllm/model_executor/models/glm5_next.py",
+            "vllm/v1/sample/sampler.py",
+            "vllm/v1/sample/prompt_logprobs.py",
+            "slimserve/model_journal.py",
+            "vllm/model_executor/layers/glm5_next_mhc_ops.py",
+            "slimserve/moe_journal.py",
+            "vllm/_custom_ops.py",
+            "vllm/quixicore/ops.py",
+            "vllm/model_executor/layers/fused_moe/router/fused_moe_router.py",
+            "vllm/model_executor/layers/fused_moe/experts/marlin_moe.py",
+            "slimserve/canonical_moe.py",
+            "slimserve/glm53_ordering.py",
+            "slimserve/canonical_moe_kernel.py",
+            "vllm/model_executor/layers/fused_moe/router/glm_route_align.py",
+            "csrc/quixicore/serving/glm_moe_routing.cuh",
+            "csrc/quixicore/serving/glm_moe_stable_align.cuh",
+            "vllm/model_executor/layers/fused_moe/router/glm_stable_align.py",
+            "csrc/quixicore/tm_cuda/tm_cuda_serving.cu",
+        )
+        self._write(
+            {
+                "kind": "header",
+                "schema": 1,
+                "pid": os.getpid(),
+                "diagnostic_only": True,
+                "config_sha256": hashlib.sha256(raw).hexdigest(),
+                "implementation_sha256": {
+                    name: hashlib.sha256((root / name).read_bytes()).hexdigest()
+                    for name in source_paths
+                },
+                "prompt_ids": ids,
+                "max_matches": limit,
+                "stages": STAGES,
+                "max_tensor_bytes": 1024**3,
+            }
+        )
+
+    def _write(self, row):
+        self.stream.write(json.dumps(row, separators=(",", ":")) + "\n")
+
+    def begin(self, prompt_ids, start_idx, num_logits, num_logprobs, request_id):
+        if prompt_ids != self.prompt_ids:
+            return None
+        if self.active is not None or self.matches >= self.limit:
+            raise ValueError("unexpected extra or overlapping score trace match")
+        if start_idx != 0 or num_logits != 639 or num_logprobs != 0:
+            raise ValueError(
+                "score trace requires one complete uncached 640-token prompt"
+            )
+        self.matches += 1
+        self.active = []
+        self._write({"kind": "begin", "match": self.matches, "request_id": request_id})
+        return self.matches
+
+    def record(self, match, stage, tensor):
+        import torch
+
+        if (
+            match != self.matches
+            or self.active is None
+            or len(self.active) >= len(STAGES)
+            or stage != STAGES[len(self.active)]
+        ):
+            raise ValueError("score trace stage order changed")
+        nbytes = tensor.numel() * tensor.element_size()
+        if tensor.ndim == 0 or tensor.shape[0] != 639 or nbytes > 1024**3:
+            raise ValueError("score trace shape or byte bound exceeded")
+        if stage in ("target_token_ids", "selected_logprobs") and tensor.numel() != 639:
+            raise ValueError("score trace requires one target and score per row")
+        # Blocking D2H is deliberate instrumentation. This trace is never a
+        # timing baseline and cannot, by itself, exonerate a hidden race.
+        host = tensor.detach().cpu().contiguous()
+        digest = hashlib.sha256(memoryview(host.view(torch.uint8).numpy())).hexdigest()
+        self._write(
+            {
+                "kind": "tensor",
+                "match": match,
+                "stage": stage,
+                "device": str(tensor.device),
+                "shape": list(tensor.shape),
+                "dtype": str(tensor.dtype),
+                "nbytes": nbytes,
+                "sha256": digest,
+                # Small final vectors allow exact comparison with HTTP results.
+                "values": host.tolist()
+                if stage in ("target_token_ids", "selected_logprobs")
+                else None,
+            }
+        )
+        self.active.append(stage)
+
+    def finish(self, match):
+        if match != self.matches or self.active != list(STAGES):
+            raise ValueError("incomplete score trace")
+        self._write({"kind": "complete", "match": match})
+        self.active = None
+
+    def close(self):
+        self.stream.close()

--- a/slimserve/score_journal.py
+++ b/slimserve/score_journal.py
@@ -8,6 +8,7 @@ only metadata/digests, not model tensors. Must not be used for performance claim
 import hashlib
 import json
 import os
+import stat
 from pathlib import Path
 
 STAGES = (
@@ -17,6 +18,34 @@ STAGES = (
     "target_token_ids",
     "selected_logprobs",
 )
+
+
+def private_directory(path, *, exist_ok=True):
+    """Keep diagnostic data private without changing existing artifacts."""
+    path = Path(path)
+    path.mkdir(mode=0o700, parents=True, exist_ok=exist_ok)
+    info = path.lstat()
+    if (
+        not stat.S_ISDIR(info.st_mode)
+        or info.st_uid != os.geteuid()
+        or stat.S_IMODE(info.st_mode) & 0o077
+    ):
+        raise ValueError(
+            f"journal directory must be private and owned by this user: {path}"
+        )
+    return path
+
+
+def private_open(path, *, binary=False, buffering=-1):
+    """Exclusive creation with owner-only permissions, independent of umask."""
+    path = Path(path)
+    private_directory(path.parent)
+    return open(
+        path,
+        "xb" if binary else "x",
+        buffering=buffering,
+        opener=lambda name, flags: os.open(name, flags, 0o600),
+    )
 
 
 class ScoreJournal:
@@ -54,10 +83,9 @@ class ScoreJournal:
             raise ValueError("score journal requires 640 token IDs and 1..8 matches")
         self.prompt_ids, self.limit = ids, limit
         self.matches, self.active = 0, None
-        directory = Path(config["output_directory"])
-        directory.mkdir(parents=True, exist_ok=True)
+        directory = private_directory(config["output_directory"])
         self.path = directory / f"score-{os.getpid()}.jsonl"
-        self.stream = self.path.open("x", buffering=1)
+        self.stream = private_open(self.path, buffering=1)
         root = Path(__file__).resolve().parents[1]
         source_paths = (
             "slimserve/canonical_indexer.py",

--- a/tests/kernels/test_glm53_mhc_prefill_tc.py
+++ b/tests/kernels/test_glm53_mhc_prefill_tc.py
@@ -10,6 +10,8 @@ from benchmarks.kernels.benchmark_mhc_output_parallel import inputs
 from benchmarks.kernels.mhc_fp64_oracle import accuracy_pair
 from vllm.quixicore.ops import quixicore_ops as qc
 
+pytest.importorskip("vllm._quixicore_C")
+
 pytestmark = pytest.mark.skipif(
     not (
         torch.cuda.is_available()

--- a/tests/kernels/test_glm53_mhc_prefill_tc.py
+++ b/tests/kernels/test_glm53_mhc_prefill_tc.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native SM120 opt-in dispatch, independent accuracy, graphs and fallback."""
+
+import pytest
+import torch
+
+from benchmarks.kernels.benchmark_glm53_mhc_prefill_tc import installed
+from benchmarks.kernels.benchmark_glm53_mhc_storage import exact
+from benchmarks.kernels.benchmark_mhc_output_parallel import inputs
+from benchmarks.kernels.mhc_fp64_oracle import accuracy_pair
+from vllm.quixicore.ops import quixicore_ops as qc
+
+pytestmark = pytest.mark.skipif(
+    not (
+        torch.cuda.is_available()
+        and torch.cuda.get_device_capability() == (12, 0)
+        and qc.has_glm53_mhc_prefill_tc()
+    ),
+    reason="requires the SM120 native mHC tensor-core build",
+)
+
+
+@pytest.fixture(autouse=True)
+def restore_switches():
+    old = (
+        qc.get_glm53_mhc_prefill_tc(),
+        qc.get_dsv4_mhc_mode(),
+        qc.get_dsv4_mhc_prefill_min_t(),
+    )
+    qc.set_dsv4_mhc_mode(2)
+    qc.set_dsv4_mhc_prefill_min_t(64)
+    yield
+    qc.set_glm53_mhc_prefill_tc(old[0])
+    qc.set_dsv4_mhc_mode(old[1])
+    qc.set_dsv4_mhc_prefill_min_t(old[2])
+
+
+def data_for(batch=65, seed=941):
+    data = inputs(batch, seed)[:7]
+    data[4] = data[4].bfloat16()
+    return data
+
+
+@pytest.mark.parametrize("batch", [64, 65, 129, 1000, 7616])
+@pytest.mark.parametrize("fused", [False, True])
+def test_native_both_arms_pass_independent_accuracy(batch, fused):
+    data = data_for(batch)
+    qc.set_glm53_mhc_prefill_tc(0)
+    reference = installed(data, fused)
+    qc.set_glm53_mhc_prefill_tc(1)
+    candidate = installed(data, fused)
+    exact(reference[:1], candidate[:1])
+    result = accuracy_pair(reference[0], *data[4:], reference[1:], candidate[1:])
+    assert result["passed"], result
+
+
+@pytest.mark.parametrize("fused", [False, True])
+@pytest.mark.parametrize(
+    "fallback",
+    [
+        "small",
+        "below_min",
+        "large",
+        "fp16",
+        "fp32",
+        "offset1",
+        "offset2",
+        "offset4",
+        "rms_eps",
+        "pre_eps",
+        "sinkhorn_eps",
+        "post_mult",
+        "iterations",
+        "norm",
+    ],
+)
+def test_unqualified_cases_remain_bit_exact_to_control(fused, fallback):
+    batch = {"small": 16, "below_min": 63, "large": 7617}.get(fallback, 65)
+    data = data_for(batch)
+    constants = [1e-5, 1e-6, 1e-6, 2.0, 20, None, 0.0]
+    if fallback in ("fp16", "fp32"):
+        data[4] = data[4].to(torch.float16 if fallback == "fp16" else torch.float32)
+    if fallback.startswith("offset"):
+        offset = int(fallback[-1])
+        storage = torch.empty(
+            data[4].numel() + offset, device="cuda", dtype=torch.bfloat16
+        )
+        unaligned = storage[offset:].view_as(data[4])
+        unaligned.copy_(data[4])
+        data[4] = unaligned
+    changed = {
+        "rms_eps": (0, 1e-6),
+        "pre_eps": (1, 1e-2),
+        "sinkhorn_eps": (2, 1e-5),
+        "post_mult": (3, 0.5),
+        "iterations": (4, 3),
+    }
+    if fallback in changed:
+        index, value = changed[fallback]
+        constants[index] = value
+    if fallback == "norm":
+        constants[5] = torch.ones(4096, device="cuda", dtype=torch.bfloat16)
+        constants[6] = 1e-5
+
+    def call():
+        if fused:
+            return qc.dsv4_mhc_fused_post_pre(*data, *constants)
+        return [data[1], *qc.dsv4_mhc_pre(data[1], *data[4:], *constants)]
+
+    qc.set_glm53_mhc_prefill_tc(0)
+    a = call()
+    qc.set_glm53_mhc_prefill_tc(1)
+    b = call()
+    torch.cuda.synchronize()
+    exact(a, b)
+
+
+@pytest.mark.parametrize("fused", [False, True])
+def test_graphs_keep_their_captured_selection_with_changed_inputs(fused):
+    data = data_for()
+    graphs, output = [], []
+    for enabled in (0, 1):
+        qc.set_glm53_mhc_prefill_tc(enabled)
+        installed(data, fused)
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            out = installed(data, fused)
+        graphs.append(graph)
+        output.append(out)
+    for seed in (943, 944, 945):
+        fresh = data_for(seed=seed)
+        for target, value in zip(data[:4], fresh[:4]):
+            target.copy_(value)
+        for enabled in (0, 1):
+            # Flip the host selector before replay: it must NOT retroactively
+            # change kernels already captured in either graph.
+            qc.set_glm53_mhc_prefill_tc(1 - enabled)
+            graphs[enabled].replay()
+            qc.set_glm53_mhc_prefill_tc(enabled)
+            exact(output[enabled], installed(data, fused))
+        exact(output[0][:1], output[1][:1])
+        assert any(
+            not torch.equal(a, b) for a, b in zip(output[0][1:], output[1][1:])
+        ), "candidate dispatch was not exercised"
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires two devices")
+@pytest.mark.parametrize("fused", [False, True])
+def test_candidate_setup_follows_device_switches(fused):
+    qc.set_glm53_mhc_prefill_tc(1)
+    reference = None
+    for device in (0, 1, 0):
+        with torch.cuda.device(device):
+            out = installed(data_for(), fused)
+            torch.cuda.synchronize()
+            host = [v.cpu() for v in out]
+        if reference is None:
+            reference = host
+        exact(reference, host)
+
+
+@pytest.mark.parametrize("value", [-1, 2])
+def test_switch_rejects_invalid_states(value):
+    with pytest.raises(RuntimeError, match="0 or 1"):
+        qc.set_glm53_mhc_prefill_tc(value)

--- a/tests/kernels/test_quixicore_decode_gemm.py
+++ b/tests/kernels/test_quixicore_decode_gemm.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""bf16 decode GEMM (quixicore decode_gemm): x[M, K] @ w[N, K]^T for M <= 16 on
+tensor cores with fp32 accumulation, against an fp32 reference on the
+GLM-5.3-Flash backbone shapes, including the N tail (6288 = 196.5 tiles),
+bias, fp32 output and the shape gate."""
+
+import pytest
+import torch
+
+pytest.importorskip("vllm._quixicore_C")
+from vllm.quixicore.ops import quixicore_ops as qc  # noqa: E402
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+if not qc.has_decode_gemm():
+    pytest.skip("QuixiCore build without decode_gemm", allow_module_level=True)
+
+DEV = "cuda"
+SHAPES = [
+    (6288, 4096),  # KDA in_proj
+    (4096, 2048),  # KDA o_proj
+    (2048, 4096),  # DSA fused_qkv_a
+    (4096, 1536),  # DSA q_b / wq_b
+    (4096, 4096),  # DSA o_proj
+    (4096, 512),  # shared-expert down
+    (2064, 640),  # N tail + odd K multiple
+]
+
+
+def _check(out, ref):
+    # bf16 output: 2^-8 relative to the row scale, plus fp32 accumulation order.
+    scale = ref.abs().amax(dim=-1, keepdim=True).clamp(min=1.0)
+    assert ((out.float() - ref).abs() / scale).max().item() < 2**-7
+
+
+@pytest.mark.parametrize("N,K", SHAPES)
+@pytest.mark.parametrize("M", [1, 2, 3, 8, 13, 16])
+def test_decode_gemm_matches_fp32_reference(N, K, M):
+    torch.manual_seed(N * 7 + K * 3 + M)
+    x = torch.randn(M, K, device=DEV, dtype=torch.bfloat16)
+    w = torch.randn(N, K, device=DEV, dtype=torch.bfloat16) * 0.05
+    ref = x.float() @ w.float().t()
+    out = qc.decode_gemm(x, w)
+    assert out.shape == (M, N) and out.dtype == torch.bfloat16
+    _check(out, ref)
+
+
+def test_decode_gemm_bias_and_fp32_output():
+    torch.manual_seed(0)
+    x = torch.randn(5, 2048, device=DEV, dtype=torch.bfloat16)
+    w = torch.randn(4096, 2048, device=DEV, dtype=torch.bfloat16) * 0.05
+    b = torch.randn(4096, device=DEV, dtype=torch.float32)
+    ref = x.float() @ w.float().t() + b
+    out32 = qc.decode_gemm(x, w, b, True)
+    assert out32.dtype == torch.float32
+    torch.testing.assert_close(out32, ref, rtol=1e-3, atol=1e-2)
+    _check(qc.decode_gemm(x, w, b), ref)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires two CUDA devices")
+def test_shared_memory_setup_follows_device_switches():
+    for device in (0, 1, 0):
+        with torch.cuda.device(device):
+            # N2048 uses the six-stage, >48-KiB shared-memory kernel.
+            w = torch.randn(2048, 512, device="cuda", dtype=torch.bfloat16) * 0.05
+            x = torch.randn(16, 512, device="cuda", dtype=torch.bfloat16)
+            _check(qc.decode_gemm(x, w), x.float() @ w.float().t())
+
+
+def test_decode_gemm_rejects_unsupported_shapes():
+    x = torch.randn(17, 4096, device=DEV, dtype=torch.bfloat16)
+    w = torch.randn(4096, 4096, device=DEV, dtype=torch.bfloat16)
+    with pytest.raises(RuntimeError):
+        qc.decode_gemm(x, w)  # M > 16
+    with pytest.raises(RuntimeError):
+        qc.decode_gemm(x[:1, :4032].contiguous(), w[:, :4032].contiguous())  # K % 128
+    with pytest.raises(RuntimeError):
+        qc.decode_gemm(x[:1], w[:1024])  # N < 2048
+    with pytest.raises(RuntimeError):
+        qc.decode_gemm(x[:1].float(), w)  # dtype

--- a/tests/kernels/test_quixicore_decode_gemm_fp8.py
+++ b/tests/kernels/test_quixicore_decode_gemm_fp8.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+"""QuixiCore FP8-weight decode GEMM (csrc/quixicore/serving/fp8_decode_gemm.cuh):
+x (bf16, M <= 16) @ dequant(W)^T with e4m3 weights and 128x128 fp32 block scales,
+where dequant(W) = bf16(scale * W); and the swap-set custom op around it."""
+
+import pytest
+import torch
+
+from vllm.quixicore.ops import quixicore_ops
+
+pytestmark = pytest.mark.skipif(
+    not (torch.cuda.is_available() and quixicore_ops.has_decode_gemm_fp8()),
+    reason="needs CUDA and the QuixiCore decode_gemm_fp8 binding",
+)
+DEV = "cuda"
+SHAPES = [
+    (6144, 4096),  # dense gate_up
+    (4096, 3072),  # dense down
+    (1024, 4096),  # shared-expert gate_up
+    (4096, 512),  # shared-expert down
+    (4096, 1536),  # DSA q_b
+    (4096, 4096),  # DSA o_proj
+    (2336, 4096),  # fused_qkv_a (N tail inside a scale group)
+]
+
+
+def block_quant(w: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    n, k = w.shape
+    rows = (n + 127) // 128
+    wp = torch.zeros(rows * 128, k, device=w.device, dtype=torch.float32)
+    wp[:n] = w.float()
+    wb = wp.view(rows, 128, k // 128, 128).permute(0, 2, 1, 3)
+    amax = wb.abs().amax(dim=(2, 3), keepdim=True).clamp(min=1e-12)
+    s = amax / 448.0
+    q = (wb / s).clamp(-448, 448).permute(0, 2, 1, 3).reshape(rows * 128, k)[:n]
+    return q.contiguous().to(torch.float8_e4m3fn), s.squeeze(3).squeeze(2).contiguous()
+
+
+def dequant_bf16(q: torch.Tensor, s: torch.Tensor) -> torch.Tensor:
+    n, k = q.shape
+    rows = s.shape[0]
+    qp = torch.zeros(rows * 128, k, device=q.device, dtype=torch.float32)
+    qp[:n] = q.float()
+    d = qp.view(rows, 128, k // 128, 128) * s[:, None, :, None]
+    return d.view(rows * 128, k)[:n].to(torch.bfloat16)
+
+
+@pytest.mark.parametrize("n,k", SHAPES)
+@pytest.mark.parametrize("m", [1, 2, 3, 8, 13, 16])
+def test_matches_dequantized_reference(n: int, k: int, m: int) -> None:
+    torch.manual_seed(n * 31 + k + m)
+    w = (torch.randn(n, k, device=DEV) * 0.02).to(torch.bfloat16)
+    q, s = block_quant(w)
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    ref = x.float() @ dequant_bf16(q, s).float().t()
+    out = quixicore_ops.decode_gemm_fp8(x, q, s)
+    assert out.shape == (m, n) and out.dtype == torch.bfloat16
+    scale = ref.abs().amax(dim=1, keepdim=True).clamp(min=1e-6)
+    assert ((out.float() - ref).abs() / scale).max().item() < 2**-7
+
+
+def test_bias_and_fp32_output() -> None:
+    torch.manual_seed(0)
+    n, k, m = 4096, 1536, 5
+    w = (torch.randn(n, k, device=DEV) * 0.02).to(torch.bfloat16)
+    q, s = block_quant(w)
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    bias = torch.randn(n, device=DEV, dtype=torch.float32)
+    ref = x.float() @ dequant_bf16(q, s).float().t() + bias
+    out = quixicore_ops.decode_gemm_fp8(x, q, s, bias, fp32_out=True)
+    assert out.dtype == torch.float32
+    scale = ref.abs().amax(dim=1, keepdim=True).clamp(min=1e-6)
+    assert ((out - ref).abs() / scale).max().item() < 2**-8
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires two CUDA devices")
+def test_shared_memory_setup_follows_device_switches() -> None:
+    # M16/N1024 selects the >48-KiB opt-in kernel. A process-wide bool
+    # incorrectly treats setup on device0 as setup on device1 too.
+    for device in (0, 1, 0):
+        with torch.cuda.device(device):
+            w = torch.randn(1024, 512, device="cuda", dtype=torch.bfloat16) * 0.02
+            q, s = block_quant(w)
+            x = torch.randn(16, 512, device="cuda", dtype=torch.bfloat16)
+            ref = x.float() @ dequant_bf16(q, s).float().t()
+            out = quixicore_ops.decode_gemm_fp8(x, q, s)
+            scale = ref.abs().amax(1, keepdim=True).clamp_min(1e-6)
+            assert ((out.float() - ref).abs() / scale).max().item() < 2**-7
+
+
+def test_rejects_unsupported_shapes_and_dtypes() -> None:
+    w = (torch.randn(4096, 1536, device=DEV) * 0.02).to(torch.bfloat16)
+    q, s = block_quant(w)
+    x = torch.randn(4, 1536, device=DEV, dtype=torch.bfloat16)
+    with pytest.raises(RuntimeError):  # M > 16
+        quixicore_ops.decode_gemm_fp8(
+            torch.randn(17, 1536, device=DEV, dtype=torch.bfloat16), q, s
+        )
+    with pytest.raises(RuntimeError):  # wrong scale shape
+        quixicore_ops.decode_gemm_fp8(x, q, s[:, :1].contiguous())
+    with pytest.raises(RuntimeError):  # bf16 weight
+        quixicore_ops.decode_gemm_fp8(x, w, s)
+    with pytest.raises(RuntimeError):  # N below the gate
+        q2, s2 = block_quant(
+            (torch.randn(512, 1536, device=DEV) * 0.02).to(torch.bfloat16)
+        )
+        quixicore_ops.decode_gemm_fp8(x, q2, s2)
+
+
+def test_swapset_op_kernel_and_cutlass_branches() -> None:
+    """The custom op takes the kernel at M <= 16 and reproduces the stock
+    CUTLASS w8a8 path above, for 2-D and 3-D inputs."""
+    from vllm.model_executor.layers.utils import (
+        _cutlass_block_fp8_linear,
+        maybe_quixicore_fp8_block_linear,
+    )
+
+    torch.manual_seed(1)
+    n, k = 4096, 1536
+    w = (torch.randn(n, k, device=DEV) * 0.02).to(torch.bfloat16)
+    q, s = block_quant(w)
+    wd = dequant_bf16(q, s).float()
+    for m in (1, 16, 17, 200):
+        x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+        out = maybe_quixicore_fp8_block_linear(x, q, s, None)
+        assert out is not None and out.shape == (m, n)
+        if m <= 16:
+            ref = x.float() @ wd.t()
+            scale = ref.abs().amax(dim=1, keepdim=True).clamp(min=1e-6)
+            assert ((out.float() - ref).abs() / scale).max().item() < 2**-7
+        else:
+            assert torch.equal(out, _cutlass_block_fp8_linear(x, q, s))
+    x3 = torch.randn(2, 3, k, device=DEV, dtype=torch.bfloat16)
+    assert maybe_quixicore_fp8_block_linear(x3, q, s, None).shape == (2, 3, n)
+    assert (
+        maybe_quixicore_fp8_block_linear(x3, w, s, None) is None
+    )  # bf16 weight: not ours

--- a/tests/kernels/test_quixicore_decode_gemm_fp8.py
+++ b/tests/kernels/test_quixicore_decode_gemm_fp8.py
@@ -8,6 +8,8 @@ import torch
 
 from vllm.quixicore.ops import quixicore_ops
 
+pytest.importorskip("vllm._quixicore_C")
+
 pytestmark = pytest.mark.skipif(
     not (torch.cuda.is_available() and quixicore_ops.has_decode_gemm_fp8()),
     reason="needs CUDA and the QuixiCore decode_gemm_fp8 binding",

--- a/tests/kernels/test_quixicore_dsv4_mhc_modes.py
+++ b/tests/kernels/test_quixicore_dsv4_mhc_modes.py
@@ -1,0 +1,153 @@
+"""The three T == 1 launch modes of the DSV4/GLM-5.3 mHC pre-transition agree.
+
+Mode 0 is the cooperative fused kernel (grid sync), mode 1 the last-block
+fused kernel (regular launch; same partials, same reduction order, so it must
+be bit-exact against mode 0), mode 2 the three-kernel split path (a
+different partial layout, so it is compared with a tolerance). Mode 1 is
+also hammered in a loop to exercise the self-resetting completion counter.
+"""
+
+import pytest
+import torch
+
+from vllm.quixicore.ops import quixicore_ops
+
+pytestmark = pytest.mark.skipif(
+    not (torch.cuda.is_available() and quixicore_ops.has_dsv4_mhc_modes()),
+    reason="needs CUDA and the QuixiCore dsv4 mHC mode switch",
+)
+DEV = "cuda"
+HC, H, MIXES = 4, 4096, 24
+EPS = dict(
+    rms_eps=1e-6,
+    pre_eps=1e-2,
+    sinkhorn_eps=1e-6,
+    post_multiplier=0.5,
+    sinkhorn_repeat=3,
+)
+
+
+def _inputs(seed, fn_dtype):
+    g = torch.Generator(device=DEV).manual_seed(seed)
+    residual = torch.randn(1, HC, H, device=DEV, generator=g).to(torch.bfloat16)
+    fn = (torch.randn(MIXES, HC * H, device=DEV, generator=g) * 0.02).to(fn_dtype)
+    hc_scale = torch.tensor([0.3, 0.2, 0.1], device=DEV)
+    hc_base = torch.randn(MIXES, device=DEV, generator=g) * 0.1
+    x = torch.randn(1, H, device=DEV, generator=g).to(torch.bfloat16)
+    norm_weight = (1 + 0.1 * torch.randn(H, device=DEV, generator=g)).to(torch.bfloat16)
+    return residual, fn, hc_scale, hc_base, x, norm_weight
+
+
+def _run_pre(mode, residual, fn, hc_scale, hc_base, norm_weight):
+    quixicore_ops.set_dsv4_mhc_mode(mode)
+    assert quixicore_ops.get_dsv4_mhc_mode() == mode
+    out = quixicore_ops.dsv4_mhc_pre(
+        residual,
+        fn,
+        hc_scale,
+        hc_base,
+        EPS["rms_eps"],
+        EPS["pre_eps"],
+        EPS["sinkhorn_eps"],
+        EPS["post_multiplier"],
+        EPS["sinkhorn_repeat"],
+        norm_weight,
+        1e-6 if norm_weight is not None else 0.0,
+    )
+    torch.cuda.synchronize()
+    return [t.clone() for t in out]
+
+
+def _run_fused(mode, x, residual, post, comb, fn, hc_scale, hc_base, norm_weight):
+    quixicore_ops.set_dsv4_mhc_mode(mode)
+    out = quixicore_ops.dsv4_mhc_fused_post_pre(
+        x,
+        residual,
+        post,
+        comb,
+        fn,
+        hc_scale,
+        hc_base,
+        EPS["rms_eps"],
+        EPS["pre_eps"],
+        EPS["sinkhorn_eps"],
+        EPS["post_multiplier"],
+        EPS["sinkhorn_repeat"],
+        norm_weight,
+        1e-6 if norm_weight is not None else 0.0,
+    )
+    torch.cuda.synchronize()
+    return [t.clone() for t in out]
+
+
+def _assert_close(a, b, exact):
+    assert len(a) == len(b)
+    for ta, tb in zip(a, b):
+        assert ta.shape == tb.shape and ta.dtype == tb.dtype
+        if exact:
+            assert torch.equal(ta, tb), (
+                f"max diff {(ta.float() - tb.float()).abs().max()}"
+            )
+        else:
+            torch.testing.assert_close(ta.float(), tb.float(), atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("fn_dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("with_norm", [False, True])
+def test_pre_modes_agree(fn_dtype, with_norm):
+    residual, fn, hc_scale, hc_base, _, norm_weight = _inputs(1, fn_dtype)
+    nw = norm_weight if with_norm else None
+    try:
+        ref = _run_pre(0, residual, fn, hc_scale, hc_base, nw)
+        last = _run_pre(1, residual, fn, hc_scale, hc_base, nw)
+        split = _run_pre(2, residual, fn, hc_scale, hc_base, nw)
+    finally:
+        quixicore_ops.set_dsv4_mhc_mode(0)
+    _assert_close(last, ref, exact=True)
+    _assert_close(split, ref, exact=False)
+
+
+@pytest.mark.parametrize("fn_dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("with_norm", [False, True])
+def test_fused_post_pre_modes_agree(fn_dtype, with_norm):
+    residual, fn, hc_scale, hc_base, x, norm_weight = _inputs(2, fn_dtype)
+    nw = norm_weight if with_norm else None
+    try:
+        post, comb, _ = _run_pre(0, residual, fn, hc_scale, hc_base, nw)
+        ref = _run_fused(0, x, residual, post, comb, fn, hc_scale, hc_base, nw)
+        last = _run_fused(1, x, residual, post, comb, fn, hc_scale, hc_base, nw)
+        split = _run_fused(2, x, residual, post, comb, fn, hc_scale, hc_base, nw)
+    finally:
+        quixicore_ops.set_dsv4_mhc_mode(0)
+    _assert_close(last, ref, exact=True)
+    _assert_close(split, ref, exact=False)
+
+
+def test_last_block_counter_survives_a_burst():
+    """Back-to-back launches on one stream: the counter must reset every time."""
+    residual, fn, hc_scale, hc_base, x, _ = _inputs(3, torch.float32)
+    try:
+        ref = _run_pre(0, residual, fn, hc_scale, hc_base, None)
+        quixicore_ops.set_dsv4_mhc_mode(1)
+        outs = []
+        for _ in range(256):
+            outs.append(
+                quixicore_ops.dsv4_mhc_pre(
+                    residual,
+                    fn,
+                    hc_scale,
+                    hc_base,
+                    EPS["rms_eps"],
+                    EPS["pre_eps"],
+                    EPS["sinkhorn_eps"],
+                    EPS["post_multiplier"],
+                    EPS["sinkhorn_repeat"],
+                    None,
+                    0.0,
+                )
+            )
+        torch.cuda.synchronize()
+    finally:
+        quixicore_ops.set_dsv4_mhc_mode(0)
+    for out in outs:
+        _assert_close(list(out), ref, exact=True)

--- a/tests/kernels/test_quixicore_dsv4_mhc_modes.py
+++ b/tests/kernels/test_quixicore_dsv4_mhc_modes.py
@@ -4,13 +4,15 @@ Mode 0 is the cooperative fused kernel (grid sync), mode 1 the last-block
 fused kernel (regular launch; same partials, same reduction order, so it must
 be bit-exact against mode 0), mode 2 the three-kernel split path (a
 different partial layout, so it is compared with a tolerance). Mode 1 is
-also hammered in a loop to exercise the self-resetting completion counter.
+also exercised on concurrent streams and independently captured graphs.
 """
 
 import pytest
 import torch
 
 from vllm.quixicore.ops import quixicore_ops
+
+pytest.importorskip("vllm._quixicore_C")
 
 pytestmark = pytest.mark.skipif(
     not (torch.cuda.is_available() and quixicore_ops.has_dsv4_mhc_modes()),
@@ -151,3 +153,68 @@ def test_last_block_counter_survives_a_burst():
         quixicore_ops.set_dsv4_mhc_mode(0)
     for out in outs:
         _assert_close(list(out), ref, exact=True)
+
+
+@pytest.mark.parametrize("captured", [False, True])
+@pytest.mark.parametrize("fused", [False, True])
+def test_last_block_counter_isolated_across_streams(captured, fused):
+    """Capture on one stream, replay on two: a per-stream counter is insufficient."""
+    previous = quixicore_ops.get_dsv4_mhc_mode()
+    streams = [torch.cuda.Stream(), torch.cuda.Stream()]
+    capture_stream = torch.cuda.Stream()
+    references, calls = [], []
+    try:
+        for seed in (41, 42):
+            residual, fn, scale, base, x, norm = _inputs(seed, torch.bfloat16)
+            pre = _run_pre(0, residual, fn, scale, base, norm)
+            constants = [*EPS.values(), norm, 1e-6]
+            if fused:
+                args = (x, residual, pre[0], pre[1], fn, scale, base, *constants)
+                call = lambda args=args: quixicore_ops.dsv4_mhc_fused_post_pre(*args)
+            else:
+                args = (residual, fn, scale, base, *constants)
+                call = lambda args=args: quixicore_ops.dsv4_mhc_pre(*args)
+            references.append([value.clone() for value in call()])
+            calls.append(call)
+        torch.cuda.synchronize()
+        quixicore_ops.set_dsv4_mhc_mode(1)
+        graphs, outputs = [], []
+        if captured:
+            for call in calls:
+                with torch.cuda.stream(capture_stream):
+                    call()
+                capture_stream.synchronize()
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph, stream=capture_stream):
+                    outputs.append(call())
+                graphs.append(graph)
+        observed = []
+        for _ in range(32):
+            for index, stream in enumerate(streams):
+                with torch.cuda.stream(stream):
+                    if captured:
+                        graphs[index].replay()
+                        result = outputs[index]
+                    else:
+                        result = calls[index]()
+                    observed.append((index, [value.clone() for value in result]))
+        torch.cuda.synchronize()
+        for index, result in observed:
+            _assert_close(result, references[index], exact=True)
+    finally:
+        torch.cuda.synchronize()
+        quixicore_ops.set_dsv4_mhc_mode(previous)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires two GPUs")
+def test_mhc_device_scoped_launch_state():
+    previous = quixicore_ops.get_dsv4_mhc_mode()
+    try:
+        for device in (0, 1, 0):
+            with torch.cuda.device(device):
+                residual, fn, scale, base, _, norm = _inputs(51, torch.bfloat16)
+                reference = _run_pre(0, residual, fn, scale, base, norm)
+                result = _run_pre(1, residual, fn, scale, base, norm)
+                _assert_close(result, reference, exact=True)
+    finally:
+        quixicore_ops.set_dsv4_mhc_mode(previous)

--- a/tests/kernels/test_quixicore_dsv4_mhc_prefill.py
+++ b/tests/kernels/test_quixicore_dsv4_mhc_prefill.py
@@ -1,0 +1,213 @@
+"""The prefill-shaped mHC partials kernel agrees with the decode-shaped one.
+
+Both serve the split path (mode 2 here, so every T takes it). The prefill
+kernel stages a 512-flat split of a 32-token tile in shared memory and runs
+whole dot products per lane; it writes the same [T][32][25] partial layout
+over a different flat-to-split assignment, so the mix sums differ only in
+fp32 summation order (tolerance), while the fused post-mix residual is the
+same expression in the same order (bit-exact). T = 33 and 1000 exercise the
+tile tail; the threshold setter selects the kernel per call.
+"""
+
+import pytest
+import torch
+
+from vllm.quixicore.ops import quixicore_ops
+
+pytestmark = pytest.mark.skipif(
+    not (torch.cuda.is_available() and quixicore_ops.has_dsv4_mhc_prefill()),
+    reason="needs CUDA and the QuixiCore dsv4 mHC prefill kernel",
+)
+DEV = "cuda"
+HC, H, MIXES = 4, 4096, 24
+DEFAULT_MIN_T = 64  # the launcher's default; each test restores it
+EPS = dict(
+    rms_eps=1e-6,
+    pre_eps=1e-2,
+    sinkhorn_eps=1e-6,
+    post_multiplier=0.5,
+    sinkhorn_repeat=3,
+)
+
+
+def _inputs(seed, T, fn_dtype):
+    g = torch.Generator(device=DEV).manual_seed(seed)
+    residual = torch.randn(T, HC, H, device=DEV, generator=g).to(torch.bfloat16)
+    fn = (torch.randn(MIXES, HC * H, device=DEV, generator=g) * 0.02).to(fn_dtype)
+    hc_scale = torch.tensor([0.3, 0.2, 0.1], device=DEV)
+    hc_base = torch.randn(MIXES, device=DEV, generator=g) * 0.1
+    x = torch.randn(T, H, device=DEV, generator=g).to(torch.bfloat16)
+    post = torch.rand(T, HC, device=DEV, generator=g)
+    comb = torch.rand(T, HC, HC, device=DEV, generator=g)
+    norm_weight = (1 + 0.1 * torch.randn(H, device=DEV, generator=g)).to(torch.bfloat16)
+    return residual, fn, hc_scale, hc_base, x, post, comb, norm_weight
+
+
+def _pre(min_t, residual, fn, hc_scale, hc_base, nw):
+    quixicore_ops.set_dsv4_mhc_prefill_min_t(min_t)
+    assert quixicore_ops.get_dsv4_mhc_prefill_min_t() == min_t
+    out = quixicore_ops.dsv4_mhc_pre(
+        residual,
+        fn,
+        hc_scale,
+        hc_base,
+        EPS["rms_eps"],
+        EPS["pre_eps"],
+        EPS["sinkhorn_eps"],
+        EPS["post_multiplier"],
+        EPS["sinkhorn_repeat"],
+        nw,
+        1e-6 if nw is not None else 0.0,
+    )
+    torch.cuda.synchronize()
+    return [t.clone() for t in out]
+
+
+def _fused(min_t, x, residual, post, comb, fn, hc_scale, hc_base, nw):
+    quixicore_ops.set_dsv4_mhc_prefill_min_t(min_t)
+    out = quixicore_ops.dsv4_mhc_fused_post_pre(
+        x,
+        residual,
+        post,
+        comb,
+        fn,
+        hc_scale,
+        hc_base,
+        EPS["rms_eps"],
+        EPS["pre_eps"],
+        EPS["sinkhorn_eps"],
+        EPS["post_multiplier"],
+        EPS["sinkhorn_repeat"],
+        nw,
+        1e-6 if nw is not None else 0.0,
+    )
+    torch.cuda.synchronize()
+    return [t.clone() for t in out]
+
+
+def _close(a, b):
+    assert a.shape == b.shape and a.dtype == b.dtype
+    torch.testing.assert_close(a.float(), b.float(), atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires two CUDA devices")
+@pytest.mark.parametrize("fn_dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("fused", [False, True])
+def test_prefill_shared_memory_setup_follows_device_switches(fn_dtype, fused):
+    mode = quixicore_ops.get_dsv4_mhc_mode()
+    minimum = quixicore_ops.get_dsv4_mhc_prefill_min_t()
+    constants = (1e-5, 1e-6, 1e-6, 2.0, 20, None, 0.0)
+    reference = None
+    try:
+        quixicore_ops.set_dsv4_mhc_mode(2)
+        quixicore_ops.set_dsv4_mhc_prefill_min_t(64)
+        for device in (0, 1, 0):
+            with torch.cuda.device(device):
+                residual, fn, scale, base, x, post, comb, _ = _inputs(51, 65, fn_dtype)
+                if fused:
+                    output = quixicore_ops.dsv4_mhc_fused_post_pre(
+                        x, residual, post, comb, fn, scale, base, *constants
+                    )
+                else:
+                    output = quixicore_ops.dsv4_mhc_pre(
+                        residual, fn, scale, base, *constants
+                    )
+                torch.cuda.synchronize()
+                host = [tensor.cpu() for tensor in output]
+                assert all(torch.isfinite(tensor).all() for tensor in host)
+                if reference is None:
+                    reference = host
+                for actual, expected in zip(host, reference):
+                    torch.testing.assert_close(actual, expected, rtol=2e-5, atol=2e-6)
+    finally:
+        quixicore_ops.set_dsv4_mhc_mode(mode)
+        quixicore_ops.set_dsv4_mhc_prefill_min_t(minimum)
+
+
+@pytest.mark.parametrize("T", [65, 129])
+@pytest.mark.parametrize("fused", [False, True])
+def test_bf16_prefill_preserves_unaligned_contiguous_fn(T, fused):
+    residual, fn, scale, base, x, post, comb, _ = _inputs(41, T, torch.bfloat16)
+    storage = torch.empty(fn.numel() + 1, device=fn.device, dtype=fn.dtype)
+    odd = storage[1:].view_as(fn)
+    odd.copy_(fn)
+    assert odd.is_contiguous() and odd.data_ptr() % 4 == 2
+    assert fn.data_ptr() % 4 == 0
+    mode = quixicore_ops.get_dsv4_mhc_mode()
+    minimum = quixicore_ops.get_dsv4_mhc_prefill_min_t()
+    try:
+        quixicore_ops.set_dsv4_mhc_mode(2)
+        if fused:
+            aligned = _fused(1, x, residual, post, comb, fn, scale, base, None)
+            unaligned = _fused(1, x, residual, post, comb, odd, scale, base, None)
+        else:
+            aligned = _pre(1, residual, fn, scale, base, None)
+            unaligned = _pre(1, residual, odd, scale, base, None)
+        for a, b in zip(aligned, unaligned):
+            assert torch.equal(a.view(torch.uint8), b.view(torch.uint8))
+    finally:
+        quixicore_ops.set_dsv4_mhc_mode(mode)
+        quixicore_ops.set_dsv4_mhc_prefill_min_t(minimum)
+
+
+@pytest.mark.parametrize("T", [33, 256, 1000])
+@pytest.mark.parametrize("fn_dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("with_norm", [False, True])
+def test_pre_prefill_kernel_agrees(T, fn_dtype, with_norm):
+    residual, fn, hc_scale, hc_base, _, _, _, norm_weight = _inputs(1, T, fn_dtype)
+    nw = norm_weight if with_norm else None
+    saved_mode = quixicore_ops.get_dsv4_mhc_mode()
+    try:
+        quixicore_ops.set_dsv4_mhc_mode(2)
+        ref = _pre(0, residual, fn, hc_scale, hc_base, nw)
+        new = _pre(1, residual, fn, hc_scale, hc_base, nw)
+    finally:
+        quixicore_ops.set_dsv4_mhc_mode(saved_mode)
+        quixicore_ops.set_dsv4_mhc_prefill_min_t(DEFAULT_MIN_T)
+    for a, b in zip(new, ref):
+        _close(a, b)
+    # mix sums of 16384 products of order 1e-2: fp32 order noise is far below 1e-4
+    torch.testing.assert_close(new[0], ref[0], atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(new[1], ref[1], atol=1e-4, rtol=1e-4)
+
+
+@pytest.mark.parametrize("T", [33, 256, 1000])
+@pytest.mark.parametrize("fn_dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("with_norm", [False, True])
+def test_fused_prefill_kernel_agrees_and_residual_is_bit_exact(T, fn_dtype, with_norm):
+    residual, fn, hc_scale, hc_base, x, post, comb, norm_weight = _inputs(
+        2, T, fn_dtype
+    )
+    nw = norm_weight if with_norm else None
+    saved_mode = quixicore_ops.get_dsv4_mhc_mode()
+    try:
+        quixicore_ops.set_dsv4_mhc_mode(2)
+        ref = _fused(0, x, residual, post, comb, fn, hc_scale, hc_base, nw)
+        new = _fused(1, x, residual, post, comb, fn, hc_scale, hc_base, nw)
+    finally:
+        quixicore_ops.set_dsv4_mhc_mode(saved_mode)
+        quixicore_ops.set_dsv4_mhc_prefill_min_t(DEFAULT_MIN_T)
+    assert torch.equal(new[0], ref[0]), "fused post-mix residual must be bit-exact"
+    torch.testing.assert_close(new[1], ref[1], atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(new[2], ref[2], atol=1e-4, rtol=1e-4)
+    _close(new[3], ref[3])
+
+
+def test_threshold_gates_the_kernel():
+    residual, fn, hc_scale, hc_base, _, _, _, _ = _inputs(3, 64, torch.float32)
+    saved_mode = quixicore_ops.get_dsv4_mhc_mode()
+    try:
+        quixicore_ops.set_dsv4_mhc_mode(2)
+        below = _pre(
+            65, residual, fn, hc_scale, hc_base, None
+        )  # T < min_t: decode-shaped kernel
+        at = _pre(
+            64, residual, fn, hc_scale, hc_base, None
+        )  # T == min_t: prefill kernel
+        off = _pre(0, residual, fn, hc_scale, hc_base, None)
+    finally:
+        quixicore_ops.set_dsv4_mhc_mode(saved_mode)
+        quixicore_ops.set_dsv4_mhc_prefill_min_t(DEFAULT_MIN_T)
+    for a, b in zip(below, off):
+        assert torch.equal(a, b)
+    torch.testing.assert_close(at[0], off[0], atol=1e-4, rtol=1e-4)

--- a/tests/kernels/test_quixicore_moe_sum_add.py
+++ b/tests/kernels/test_quixicore_moe_sum_add.py
@@ -62,3 +62,32 @@ def test_moe_sum_add_rejects_bad_shapes():
         )
     with pytest.raises(RuntimeError):
         qc.moe_sum_add(x.float(), shared, torch.empty_like(shared))
+
+
+@pytest.mark.parametrize("argument", [0, 1, 2])
+def test_moe_sum_add_rejects_misaligned_contiguous_views(argument):
+    tensors = [
+        torch.zeros(2, 8, 16, device=DEV, dtype=torch.bfloat16),
+        torch.zeros(2, 16, device=DEV, dtype=torch.bfloat16),
+        torch.zeros(2, 16, device=DEV, dtype=torch.bfloat16),
+    ]
+    tensor = tensors[argument]
+    tensors[argument] = torch.zeros(tensor.numel() + 1, device=DEV, dtype=tensor.dtype)[
+        1:
+    ].view_as(tensor)
+    assert tensors[argument].is_contiguous()
+    assert tensors[argument].data_ptr() % 16 == 2
+    with pytest.raises(RuntimeError, match="16-byte aligned"):
+        qc.moe_sum_add(*tensors)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires two GPUs")
+def test_moe_sum_add_checks_and_guards_device():
+    x = torch.ones(2, 8, 16, device="cuda:1", dtype=torch.bfloat16)
+    shared = torch.ones(2, 16, device="cuda:1", dtype=torch.bfloat16)
+    out = torch.empty_like(shared)
+    with torch.cuda.device(0):
+        qc.moe_sum_add(x, shared, out)
+        with pytest.raises(RuntimeError, match="same device"):
+            qc.moe_sum_add(x, shared.to("cuda:0"), out)
+    torch.testing.assert_close(out, _reference(x, shared), rtol=0, atol=0)

--- a/tests/kernels/test_quixicore_moe_sum_add.py
+++ b/tests/kernels/test_quixicore_moe_sum_add.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fused MoE combine (quixicore moe_sum_add): out = shared + sum_k x[:, k] with
+fp32 accumulation and one bf16 rounding, against the same fold in torch."""
+
+import pytest
+import torch
+
+pytest.importorskip("vllm._quixicore_C")
+from vllm.quixicore.ops import quixicore_ops as qc  # noqa: E402
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+if not qc.has_moe_sum_add():
+    pytest.skip("QuixiCore build without moe_sum_add", allow_module_level=True)
+
+DEV = "cuda"
+
+
+def _reference(x: torch.Tensor, shared: torch.Tensor) -> torch.Tensor:
+    # Same association as the kernel: shared first, then k in order, fp32.
+    acc = shared.float()
+    for k in range(x.shape[1]):
+        acc = acc + x[:, k].float()
+    return acc.to(torch.bfloat16)
+
+
+@pytest.mark.parametrize("tokens", [1, 8, 16, 37, 300])
+@pytest.mark.parametrize("topk", [8, 6])
+@pytest.mark.parametrize("hidden", [4096, 2048, 8])
+def test_moe_sum_add_matches_fp32_fold(tokens, topk, hidden):
+    torch.manual_seed(tokens * 31 + topk * 7 + hidden)
+    x = torch.randn(tokens, topk, hidden, device=DEV, dtype=torch.bfloat16) * 3
+    shared = torch.randn(tokens, hidden, device=DEV, dtype=torch.bfloat16) * 5
+    out = torch.empty(tokens, hidden, device=DEV, dtype=torch.bfloat16)
+    qc.moe_sum_add(x, shared, out)
+    torch.testing.assert_close(out, _reference(x, shared), rtol=0, atol=0)
+    # And within two bf16 ulps (of the largest magnitude) of the unfused
+    # two-step path, which rounds twice.
+    two_step = (shared + x.sum(dim=1)).float()
+    ulp = 2.0 ** (torch.floor(torch.log2(two_step.abs().max())) - 7)
+    torch.testing.assert_close(out.float(), two_step, rtol=0, atol=2 * ulp.item())
+
+
+def test_moe_sum_add_is_total_on_non_finite_inputs():
+    x = torch.full((4, 8, 4096), float("nan"), device=DEV, dtype=torch.bfloat16)
+    shared = torch.randn(4, 4096, device=DEV, dtype=torch.bfloat16)
+    out = torch.zeros(4, 4096, device=DEV, dtype=torch.bfloat16)
+    qc.moe_sum_add(x, shared, out)
+    torch.cuda.synchronize()
+    assert out.isnan().all()
+
+
+def test_moe_sum_add_rejects_bad_shapes():
+    x = torch.randn(4, 8, 4096, device=DEV, dtype=torch.bfloat16)
+    shared = torch.randn(4, 4096, device=DEV, dtype=torch.bfloat16)
+    with pytest.raises(RuntimeError):
+        qc.moe_sum_add(x, shared[:2], torch.empty_like(shared))
+    with pytest.raises(RuntimeError):
+        qc.moe_sum_add(
+            x[:, :, :4092], shared[:, :4092], torch.empty_like(shared[:, :4092])
+        )
+    with pytest.raises(RuntimeError):
+        qc.moe_sum_add(x.float(), shared, torch.empty_like(shared))

--- a/tests/kernels/test_quixicore_router_projection_gemv.py
+++ b/tests/kernels/test_quixicore_router_projection_gemv.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Router-gate use of the QuixiCore decode projection GEMV (dsv4_projection_gemv:
+bf16 in, fp32 out, H=4096, M<=8) at GLM-5.3-Flash's expert count (E=288,
+not the DSV4 kernel's E=256) against a float32 torch reference, and against
+the bf16 F.linear + fp32 cast path it replaces in GateLinear tier 1b."""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+pytest.importorskip("vllm._quixicore_C")
+from vllm.quixicore import quixicore_ops as qc  # noqa: E402
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+
+DEV = "cuda"
+HIDDEN = 4096
+
+
+@pytest.mark.parametrize("experts", [288, 256, 32])
+@pytest.mark.parametrize("tokens", [1, 2, 3, 4, 8])
+def test_router_projection_gemv_matches_fp32_reference(experts, tokens):
+    torch.manual_seed(0)
+    w = (torch.randn(experts, HIDDEN, device=DEV) * 0.02).to(torch.bfloat16)
+    x = torch.randn(tokens, HIDDEN, device=DEV).to(torch.bfloat16)
+    ref = x.float() @ w.float().t()
+    out = qc.dsv4_projection_gemv(x, w, False)
+    assert out.dtype == torch.float32 and out.shape == (tokens, experts)
+    # fp32 accumulation of bf16 products: only summation order differs.
+    torch.testing.assert_close(out, ref, atol=2e-3, rtol=2e-3)
+    # The path it replaces rounds the logits through bf16 first; the new
+    # tier must be at least as close to the reference as that.
+    old = F.linear(x, w).to(torch.float32)
+    assert (out - ref).abs().max() <= (old - ref).abs().max() + 1e-6
+
+
+def test_router_projection_gemv_rejects_wrong_shapes():
+    w = torch.zeros(288, HIDDEN, device=DEV, dtype=torch.bfloat16)
+    with pytest.raises(RuntimeError):
+        qc.dsv4_projection_gemv(
+            torch.zeros(9, HIDDEN, device=DEV, dtype=torch.bfloat16), w, False
+        )
+    with pytest.raises(RuntimeError):
+        qc.dsv4_projection_gemv(
+            torch.zeros(1, 2048, device=DEV, dtype=torch.bfloat16), w[:, :2048], False
+        )

--- a/tests/kernels/test_quixicore_sparse_mla_prefill.py
+++ b/tests/kernels/test_quixicore_sparse_mla_prefill.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Head-batched sparse MLA prefill kernel (NoPE bf16 latents) against the
+decode walk it replaces and against a float32 torch reference: -1 holes,
+empty rows, out-of-table entries, strided pages, 16 and 32 heads."""
+
+import math
+
+import pytest
+import torch
+
+pytest.importorskip("vllm._quixicore_C")
+from vllm.quixicore import quixicore_ops as qc  # noqa: E402
+from vllm.v1.attention.backends.mla import (  # noqa: E402
+    quixicore_mla_sparse_prefill as pf,
+)
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+
+DEV = "cuda"
+BS, N_BLOCKS, MAX_TOPK = 64, 64, 2080
+LENS = [0, 1, 37, 1000, 2048, 5, 640]
+SCALE = 1.0 / math.sqrt(256)  # checkpoint qk_nope_head_dim, not latent width
+
+
+def _inputs(heads, strided=False, seed=0):
+    torch.manual_seed(seed)
+    B = len(LENS)
+    if strided:
+        # blocks strided, slots packed at 512: the packed cross-layer slab
+        big = (torch.randn(N_BLOCKS, BS * 512 + 1024, device=DEV) * 0.5).to(
+            torch.bfloat16
+        )
+        kv = big[:, : BS * 512].view(N_BLOCKS, BS, 512)
+    else:
+        kv = (torch.randn(N_BLOCKS, BS, 512, device=DEV) * 0.5).to(torch.bfloat16)
+    q = (torch.randn(B, heads, 512, device=DEV) * 0.2).to(torch.bfloat16)
+    bt = torch.arange(N_BLOCKS, device=DEV, dtype=torch.int32).repeat(B, 1)
+    idx = torch.full((B, MAX_TOPK), -1, device=DEV, dtype=torch.int32)
+    for b, L in enumerate(LENS):
+        idx[b, :L] = torch.randperm(N_BLOCKS * BS, device=DEV)[:L].to(torch.int32)
+    idx[3, 5::7] = -1  # interleaved holes: skip, do not stop
+    idx[6, 640:] = -1
+    idx[6, 100] = N_BLOCKS * BS + 5  # past the block table: skipped
+    tlen = qc.sparse_topk_tlen(idx)
+    return q, kv, bt, idx, tlen
+
+
+def _reference(q, kv, bt, idx):
+    outs = []
+    for b in range(q.shape[0]):
+        toks = idx[b][(idx[b] >= 0) & (idx[b] < N_BLOCKS * BS)].long()
+        if toks.numel() == 0:
+            outs.append(torch.zeros(q.shape[1], 512, device=DEV))
+            continue
+        rows = kv[bt[b][toks // BS].long(), toks % BS].float()
+        s = (q[b].float() @ rows.T) * SCALE
+        outs.append(torch.softmax(s, dim=-1) @ rows)
+    return torch.stack(outs)
+
+
+@pytest.mark.parametrize("heads", [16, 32])
+@pytest.mark.parametrize("strided", [False, True])
+def test_matches_decode_walk_and_reference(heads, strided):
+    q, kv, bt, idx, tlen = _inputs(heads, strided)
+    psb = kv.stride(0) * kv.element_size() if strided else 0
+    out = pf.sparse_mla_prefill_nope(q, kv, bt, idx, tlen, BS, SCALE, psb)
+    walk = qc.mla_decode_bf16_sparse_nope(q, kv, bt, idx, tlen, BS, SCALE, 0, psb)
+    torch.cuda.synchronize()
+    assert out.shape == (len(LENS), heads, 512) and out.dtype == torch.bfloat16
+    assert not torch.isnan(out).any()
+    # one bf16 rounding of the result apart from the walk (P in fp16 there
+    # is fp32; the score sums differ in order)
+    torch.testing.assert_close(out.float(), walk.float(), atol=1.6e-2, rtol=1e-2)
+    torch.testing.assert_close(
+        out.float(), _reference(q, kv, bt, idx), atol=2e-2, rtol=2e-2
+    )
+    assert torch.equal(out[0], torch.zeros_like(out[0]))  # tlen 0 -> 0
+
+
+@pytest.mark.parametrize("swapab", [False, True])
+def test_many_tokens_smoke(swapab, monkeypatch):
+    """A prefill-sized batch: every token its own program, lists of every
+    length; compared to the walk."""
+    if swapab and torch.cuda.get_device_capability() != (12, 0):
+        pytest.skip("swapAB requires SM120")
+    monkeypatch.setattr(pf, "SWAPAB_ENABLED", swapab)
+    native_calls = []
+    native = qc.mla_prefill_bf16_sparse_nope_sm120
+
+    def tracked_native(*args):
+        native_calls.append(args[0].shape)
+        return native(*args)
+
+    monkeypatch.setattr(qc, "mla_prefill_bf16_sparse_nope_sm120", tracked_native)
+    torch.manual_seed(1)
+    B, heads = 3000, 16  # checkpoint's 64 attention heads / TP4
+    kv = (torch.randn(N_BLOCKS, BS, 512, device=DEV) * 0.5).to(torch.bfloat16)
+    q = (torch.randn(B, heads, 512, device=DEV) * 0.2).to(torch.bfloat16)
+    bt = torch.arange(N_BLOCKS, device=DEV, dtype=torch.int32).repeat(B, 1)
+    lens = torch.randint(0, 2049, (B,), device=DEV)
+    pos = torch.arange(MAX_TOPK, device=DEV)[None, :]
+    idx = torch.randint(0, N_BLOCKS * BS, (B, MAX_TOPK), device=DEV, dtype=torch.int32)
+    idx[pos >= lens[:, None]] = -1
+    tlen = qc.sparse_topk_tlen(idx)
+    out = pf.sparse_mla_prefill_nope(q, kv, bt, idx, tlen, BS, SCALE)
+    assert native_calls == ([q.shape] if swapab else [])
+    walk = qc.mla_decode_bf16_sparse_nope(q, kv, bt, idx, tlen, BS, SCALE, 0, 0)
+    torch.testing.assert_close(out.float(), walk.float(), atol=1.6e-2, rtol=1e-2)
+
+
+def test_supports():
+    assert pf.supports(torch.empty(2, 32, 512, dtype=torch.bfloat16))
+    assert pf.supports(torch.empty(2, 16, 512, dtype=torch.bfloat16))
+    assert not pf.supports(torch.empty(2, 8, 512, dtype=torch.bfloat16))
+    assert not pf.supports(torch.empty(2, 32, 576, dtype=torch.bfloat16))
+
+
+@pytest.mark.parametrize("strided", [False, True])
+def test_sm120_swapab_paged_graph(strided):
+    """Native tail tiles, per-request page maps and changed graph inputs."""
+    if torch.cuda.get_device_capability() != (12, 0):
+        pytest.skip("swapAB requires SM120")
+    q, kv, bt, idx, tlen = _inputs(16, strided)
+    for row in bt:
+        row.copy_(torch.randperm(N_BLOCKS, device=DEV, dtype=torch.int32))
+
+    def call():
+        return qc.mla_prefill_bf16_sparse_nope_sm120(
+            q, kv, bt, idx, tlen, BS, SCALE, kv.stride(0) * 2
+        )
+
+    call()  # Native function-attribute setup before capture.
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        call()
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        out = call()
+    for phase in range(2):
+        if phase:
+            q.mul_(8)
+            bt.copy_(bt.flip(0))
+            idx[4].fill_(-1)  # nonzero tlen with no valid cache rows
+            tlen[0] = -1
+            tlen[-1] = MAX_TOPK + 19  # clamp before reading the index array
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(
+            out.float(), _reference(q, kv, bt, idx), atol=0.016, rtol=0.01
+        )
+        assert torch.count_nonzero(out[0]).item() == 0
+
+
+def test_sm120_swapab_rejects_invalid_metadata():
+    if torch.cuda.get_device_capability() != (12, 0):
+        pytest.skip("swapAB requires SM120")
+    q, kv, bt, idx, tlen = _inputs(16)
+    call = qc.mla_prefill_bf16_sparse_nope_sm120
+    with pytest.raises(RuntimeError, match="metadata"):
+        call(q, kv, bt.long(), idx, tlen, BS, SCALE)
+    with pytest.raises(RuntimeError, match="page stride"):
+        call(q, kv, bt, idx, tlen, BS, SCALE, kv.stride(0) * 2 + 16)
+    with pytest.raises(RuntimeError, match="block size"):
+        call(q, kv, bt, idx, tlen, 0, SCALE)
+    with pytest.raises(RuntimeError, match="share a device"):
+        call(q, kv, bt.cpu(), idx, tlen, BS, SCALE)
+    unaligned = torch.empty(q.numel() + 1, dtype=q.dtype, device=q.device)[1:]
+    unaligned = unaligned.view_as(q)
+    with pytest.raises(RuntimeError, match="4-byte-aligned"):
+        call(unaligned, kv, bt, idx, tlen, BS, SCALE)

--- a/tests/kernels/test_quixicore_stable_align_bounds.py
+++ b/tests/kernels/test_quixicore_stable_align_bounds.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The public binding rejects an oversized bitmap before launching any kernel."""
+
+import pytest
+import torch
+
+pytest.importorskip("vllm._quixicore_C")
+from vllm.quixicore.ops import quixicore_ops as qc  # noqa: E402
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+def test_stable_align_rejects_oversized_ids_before_output_checks():
+    ids = torch.zeros(8193, 8, device="cuda", dtype=torch.int32)
+    empty = torch.empty(0, device="cuda", dtype=torch.int32)
+    with pytest.raises(RuntimeError, match=r"expects int32 \[17\.\.8192,8\]"):
+        qc.glm_stable_align(ids, empty, empty, empty, empty, 32)

--- a/tests/slimserve/test_fp8_cache_probe.py
+++ b/tests/slimserve/test_fp8_cache_probe.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+
+
+@pytest.fixture
+def probe():
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "benchmarks/kernels/benchmark_glm53_fp8_cache.py"
+    )
+    spec = importlib.util.spec_from_file_location("fp8_cache_probe", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_rotation_is_byte_sized_not_a_fixed_copy_count(probe):
+    for weight_bytes, copies in ((1024 * 4096, 97), (4096 * 512, 193)):
+        assert 24 * weight_bytes < probe.L2_BYTES
+        assert probe.rotation_count(weight_bytes) == copies
+        assert copies * weight_bytes > 3 * probe.L2_BYTES
+    with pytest.raises(ValueError):
+        probe.rotation_count(0)
+
+
+def test_oracle_rounds_dequant_weight_before_fp64_matmul(probe):
+    q = torch.ones(128, 128).to(torch.float8_e4m3fn)
+    scale = torch.tensor([[1.007]])
+    expected = torch.full((128, 128), 1.007).bfloat16().double()
+    assert torch.equal(probe.oracle_weight(q, scale), expected)
+
+
+@pytest.mark.parametrize("rank", [0, 3])
+def test_tp4_shared_expert_slices_and_gate_up_order(probe, monkeypatch, rank):
+    gate = (
+        torch.arange(1, 5)
+        .repeat_interleave(512)[:, None]
+        .expand(2048, 4096)
+        .to(torch.float8_e4m3fn)
+    )
+    up = (
+        torch.arange(5, 9)
+        .repeat_interleave(512)[:, None]
+        .expand(2048, 4096)
+        .to(torch.float8_e4m3fn)
+    )
+    down = (
+        torch.arange(10, 14)
+        .repeat_interleave(512)[None, :]
+        .expand(4096, 2048)
+        .to(torch.float8_e4m3fn)
+    )
+    scales = torch.arange(16, dtype=torch.float32)[:, None].expand(16, 32).contiguous()
+    tensors = {
+        "gate_proj.weight": gate,
+        "up_proj.weight": up,
+        "down_proj.weight": down,
+        "gate_proj.weight_scale": scales,
+        "up_proj.weight_scale": scales + 100,
+        "down_proj.weight_scale": scales.t().contiguous(),
+    }
+
+    class Source:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def get_tensor(self, key):
+            prefix = "model.language_model.layers.3.mlp.shared_experts."
+            assert key.startswith(prefix)
+            return tensors[key[len(prefix) :]]
+
+    monkeypatch.setattr(probe, "safe_open", lambda *args, **kwargs: Source())
+    result = probe.load_weights(Path("unused"), 3, rank)
+    q, s = result["gate_up"]
+    assert q.shape == (1024, 4096) and s.shape == (8, 32)
+    assert (q[:512].float() == rank + 1).all()
+    assert (q[512:].float() == rank + 5).all()
+    assert torch.equal(s[:4], scales[rank * 4 : (rank + 1) * 4])
+    assert torch.equal(s[4:], scales[rank * 4 : (rank + 1) * 4] + 100)
+    q, s = result["down"]
+    assert q.shape == (4096, 512) and s.shape == (32, 4)
+    assert (q.float() == rank + 10).all()
+    assert torch.equal(s, scales.t()[:, rank * 4 : (rank + 1) * 4])

--- a/tests/slimserve/test_fp8_launch_probe.py
+++ b/tests/slimserve/test_fp8_launch_probe.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+import argparse
+
+import pytest
+import torch
+
+from benchmarks.kernels.benchmark_glm53_fp8_launch import (
+    CONFIGS,
+    oracle_errors,
+    parse_config,
+)
+
+
+def test_fixed_configs_include_every_current_shared_expert_dispatch():
+    assert len(CONFIGS) == len(set(CONFIGS)) == 12
+    assert {(8, 8, 8), (16, 8, 8), (32, 8, 4)} <= set(CONFIGS)
+    for config in CONFIGS:
+        assert parse_config(",".join(map(str, config))) == config
+        assert config[0] in (8, 16, 32)
+        assert config[1] in (4, 8)
+        assert config[2] in (4, 8)
+
+
+@pytest.mark.parametrize("value", ["auto", "16,8", "16,8,3", "16,2,4", "8,8,8,8"])
+def test_unprescribed_config_is_rejected(value):
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_config(value)
+
+
+def test_independent_oracle_records_and_rejects_large_or_nonfinite_errors():
+    expected = torch.tensor([[1.0, -2.0], [0.0, 0.0]], dtype=torch.float64)
+    good = oracle_errors(expected.bfloat16(), expected)
+    assert good == {
+        "finite": True,
+        "normalized_rms": 0.0,
+        "row_peak_error": 0.0,
+        "passed": True,
+    }
+    bad = expected.clone()
+    bad[0, 0] += 0.1
+    assert not oracle_errors(bad, expected)["passed"]
+    bad[0, 0] = float("nan")
+    assert not oracle_errors(bad, expected)["passed"]
+    bad = expected.clone()
+    bad[1, 0] = 1e-8
+    assert not oracle_errors(bad, expected)["passed"]
+
+
+def test_oracle_rejects_broadcastable_output_shape():
+    with pytest.raises(ValueError, match="shapes differ"):
+        oracle_errors(torch.ones(1, 2), torch.ones(3, 2))

--- a/tests/slimserve/test_kernel_dispatch.py
+++ b/tests/slimserve/test_kernel_dispatch.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only checks for optional native paths; no CUDA launch or model load."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+@pytest.mark.parametrize("fp8", [False, True])
+@pytest.mark.parametrize(
+    "cuda,capability,disabled,symbol,expected",
+    [
+        (False, 120, False, True, False),
+        (True, 75, False, True, False),
+        (True, 80, False, True, True),
+        (True, 120, False, True, True),
+        (True, 120, True, True, False),
+        (True, 120, False, False, False),
+    ],
+)
+def test_decode_gemm_dispatch(
+    monkeypatch, fp8, cuda, capability, disabled, symbol, expected
+):
+    from vllm.model_executor.layers import utils
+    from vllm.quixicore.ops import quixicore_ops as qc
+
+    suffix = "_fp8" if fp8 else ""
+    enabled = getattr(utils, f"decode_gemm{suffix}_enabled")
+    calls = []
+    monkeypatch.setattr(
+        utils,
+        "current_platform",
+        SimpleNamespace(
+            is_cuda=lambda: cuda,
+            has_device_capability=lambda minimum: capability >= minimum,
+        ),
+    )
+    monkeypatch.setenv(
+        f"SLIMSERVE_DECODE_GEMM{suffix.upper()}", "0" if disabled else "1"
+    )
+    monkeypatch.setattr(
+        qc, f"has_decode_gemm{suffix}", lambda: calls.append(True) or symbol
+    )
+    enabled.cache_clear()
+    try:
+        assert enabled() is expected
+        assert bool(calls) is (cuda and capability >= 80 and not disabled)
+    finally:
+        enabled.cache_clear()
+
+
+@pytest.mark.parametrize("symbol", [False, True])
+def test_swapab_missing_symbol_uses_triton(monkeypatch, symbol):
+    from vllm.quixicore.ops import quixicore_ops as qc
+    from vllm.v1.attention.backends.mla import quixicore_mla_sparse_prefill as pf
+
+    q = SimpleNamespace(
+        shape=(2048, 16, 512),
+        dtype=torch.bfloat16,
+        device="cuda:0",
+        is_cuda=True,
+        is_contiguous=lambda: True,
+        data_ptr=lambda: 256,
+    )
+    kv = torch.empty(1, 64, 512, dtype=torch.bfloat16)
+    table = torch.zeros(1, 1, dtype=torch.int32)
+    indices = torch.zeros(1, 1, dtype=torch.int32)
+    lengths = torch.ones(1, dtype=torch.int32)
+    native_out, fallback_out = object(), object()
+    calls = []
+
+    class TritonKernel:
+        def __getitem__(self, grid):
+            assert grid == (2048,)
+            return lambda *args, **kwargs: calls.append("triton")
+
+    def has(name):
+        assert name == "mla_prefill_bf16_sparse_nope_sm120"
+        return symbol
+
+    monkeypatch.setattr(pf, "SWAPAB_ENABLED", True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device: (12, 0))
+    monkeypatch.setattr(torch, "empty_like", lambda value: fallback_out)
+    monkeypatch.setattr(pf, "_sparse_mla_prefill_kernel", TritonKernel())
+    monkeypatch.setattr(qc, "has", has)
+    monkeypatch.setattr(
+        qc,
+        "mla_prefill_bf16_sparse_nope_sm120",
+        lambda *args: calls.append("native") or native_out,
+    )
+    out = pf.sparse_mla_prefill_nope(q, kv, table, indices, lengths, 64, 0.0625)
+    assert out is (native_out if symbol else fallback_out)
+    assert calls == (["native"] if symbol else ["triton"])

--- a/tests/slimserve/test_kernel_dispatch.py
+++ b/tests/slimserve/test_kernel_dispatch.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """CPU-only checks for optional native paths; no CUDA launch or model load."""
 
+import ctypes
 from types import SimpleNamespace
 
 import pytest
@@ -16,11 +17,13 @@ def test_cold_decode_gate_compiles_without_tracing_driver(monkeypatch, fp8, supp
     suffix = "_fp8" if fp8 else ""
     enabled = getattr(utils, f"decode_gemm{suffix}_enabled")
     calls = []
+    getpid = ctypes.CDLL(None).getpid
 
     def capability(minimum):
-        # Real capability queries call NVML ctypes functions, which cannot be
-        # traced. Fail if Dynamo tries to enter this function symbolically.
-        assert not torch.compiler.is_compiling(), "driver query entered graph"
+        # Like NVML, this actual ctypes call cannot enter a tensor graph.
+        # is_compiling() is still true during eager constant evaluation, so
+        # that flag alone does not distinguish tracing from constant folding.
+        assert getpid() > 0
         calls.append(minimum)
         return supported
 

--- a/tests/slimserve/test_kernel_dispatch.py
+++ b/tests/slimserve/test_kernel_dispatch.py
@@ -8,6 +8,49 @@ import torch
 
 
 @pytest.mark.parametrize("fp8", [False, True])
+@pytest.mark.parametrize("supported", [False, True])
+def test_cold_decode_gate_compiles_without_tracing_driver(monkeypatch, fp8, supported):
+    from vllm.model_executor.layers import utils
+    from vllm.quixicore.ops import quixicore_ops as qc
+
+    suffix = "_fp8" if fp8 else ""
+    enabled = getattr(utils, f"decode_gemm{suffix}_enabled")
+    calls = []
+
+    def capability(minimum):
+        # Real capability queries call NVML ctypes functions, which cannot be
+        # traced. Fail if Dynamo tries to enter this function symbolically.
+        assert not torch.compiler.is_compiling(), "driver query entered graph"
+        calls.append(minimum)
+        return supported
+
+    monkeypatch.setattr(
+        utils,
+        "current_platform",
+        SimpleNamespace(
+            is_cuda=lambda: True,
+            has_device_capability=capability,
+        ),
+    )
+    monkeypatch.setenv(f"SLIMSERVE_DECODE_GEMM{suffix.upper()}", "1")
+    monkeypatch.setattr(qc, f"has_decode_gemm{suffix}", lambda: True)
+    enabled.cache_clear()
+    torch._dynamo.reset()
+    try:
+
+        def forward(x):
+            return x + (1 if enabled() else 2)
+
+        compiled = torch.compile(forward, backend="eager", fullgraph=True)
+        x = torch.ones(2)
+        torch.testing.assert_close(compiled(x), x + (1 if supported else 2))
+        assert calls == [80]
+    finally:
+        enabled.cache_clear()
+        torch._dynamo.reset()
+
+
+@pytest.mark.parametrize("fp8", [False, True])
 @pytest.mark.parametrize(
     "cuda,capability,disabled,symbol,expected",
     [

--- a/tests/slimserve/test_marlin_counters.py
+++ b/tests/slimserve/test_marlin_counters.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+import csv
+
+import pytest
+
+from benchmarks.analyze_marlin_counters import METRICS, analyze
+
+
+def data(tmp_path, missing=False):
+    names = [
+        name for name in METRICS if not missing or name != "dram__bytes_op_read.sum"
+    ]
+    fields = ["ID", "Kernel Name", *names]
+    path = tmp_path / "raw.csv"
+    with path.open("w") as stream:
+        writer = csv.DictWriter(stream, fieldnames=fields)
+        writer.writeheader()
+        writer.writerow({name: METRICS[name] for name in names})
+        for i in range(2):
+            writer.writerow(
+                {
+                    "ID": i,
+                    "Kernel Name": "void Marlin<0>()",
+                    **{name: 100 for name in names},
+                }
+            )
+    cases = {
+        "status": "complete",
+        "cases": [{"label": "test", "batch": 1, "layer": 3, "unique_experts": 8}],
+    }
+    return path, cases
+
+
+def test_exact_pairing_and_byte_units(tmp_path):
+    path, cases = data(tmp_path)
+    result = analyze(path, cases)
+    assert [r["phase"] for r in result["rows"]] == ["gate_up", "down"]
+    row = result["rows"][0]
+    assert row["unique_weight_footprint_bytes"] == 8 * 1024 * 4096 * 9 / 16
+    assert row["profiled_dram_read_GB_per_s"] == 0.001
+
+
+def test_missing_counter_is_not_zero(tmp_path):
+    path, cases = data(tmp_path, missing=True)
+    with pytest.raises(ValueError, match="missing metrics"):
+        analyze(path, cases)
+
+
+def test_scaled_bytes_are_decimal_not_binary(tmp_path):
+    path, cases = data(tmp_path)
+    lines = path.read_text().splitlines()
+    lines[1] = lines[1].replace("byte", "Mbyte")
+    path.write_text("\n".join(lines) + "\n")
+    row = analyze(path, cases)["rows"][0]
+    assert row["dram_read_bytes"] == 100_000_000
+    assert row["dram_write_bytes"] == 100_000_000
+    assert row["profiled_dram_read_GB_per_s"] == 1000
+
+
+def test_incomplete_case_count_rejected(tmp_path):
+    path, cases = data(tmp_path)
+    cases["cases"] *= 2
+    with pytest.raises(ValueError, match="unexpected number"):
+        analyze(path, cases)

--- a/tests/slimserve/test_marlin_profile.py
+++ b/tests/slimserve/test_marlin_profile.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+import json
+
+import pytest
+
+from benchmarks.kernels.profile_glm53_marlin import route_cases
+
+
+def make_journal(tmp_path, *, invalid=False):
+    header = dict(
+        kind="header", num_layers=45, first_moe_layer=3, num_experts=288, top_k=8
+    )
+    rows = [header]
+    for step in range(9):
+        for batch in [1, 8, 16]:
+            rows.append(dict(kind="decode", step=step, request_ids=list(range(batch))))
+    if invalid:
+        rows.append(dict(kind="invalid"))
+    path = tmp_path / "journal.jsonl"
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows))
+    return path
+
+
+def test_selection_is_predetermined_and_keeps_actual_steps(tmp_path):
+    path = make_journal(tmp_path)
+    selected = route_cases(path, [1, 8, 16], 3)
+    assert [(batch, row["step"]) for batch, row in selected] == [
+        (batch, step) for batch in (1, 8, 16) for step in (0, 4, 8)
+    ]
+    assert route_cases(path, [8], 1)[0][1]["step"] == 4
+
+
+def test_reject_failed_or_insufficient_capture(tmp_path):
+    with pytest.raises(ValueError, match="invalid capture"):
+        route_cases(make_journal(tmp_path, invalid=True), [8], 1)
+    with pytest.raises(ValueError, match="insufficient"):
+        route_cases(make_journal(tmp_path), [8], 10)
+
+
+def test_reject_other_model_journal(tmp_path):
+    path = tmp_path / "journal.jsonl"
+    path.write_text(
+        json.dumps(
+            dict(
+                kind="header",
+                num_layers=46,
+                first_moe_layer=3,
+                num_experts=288,
+                top_k=8,
+            )
+        )
+        + "\n"
+    )
+    with pytest.raises(ValueError, match="GLM53"):
+        route_cases(path, [8], 1)

--- a/tests/slimserve/test_marlin_schedule.py
+++ b/tests/slimserve/test_marlin_schedule.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+import argparse
+
+import pytest
+import torch
+
+from benchmarks.kernels.benchmark_glm53_marlin_schedule import footprint, parse_config
+from benchmarks.kernels.check_glm53_marlin_schedule import decode_fragments
+
+
+def test_only_existing_generated_launch_shapes():
+    assert parse_config("auto") == (-1, -1, -1)
+    assert parse_config("64,128,3") == (64, 128, 3)
+    for invalid in ("64,64,1", "128,128,0", "64,128,5", "bad", "1,2"):
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_config(invalid)
+
+
+def test_unique_weight_footprint_groups_by_layer_not_route():
+    cases = [
+        {"layer": 3, "expert_ids": [[0, 1], [1, 2]]},
+        {"layer": 3, "expert_ids": [[2, 3]]},
+        {"layer": 4, "expert_ids": [[0, 1]]},
+    ]
+    assert footprint(cases, "gate_up") == 6 * 1024 * 4096 * 9 // 16
+    assert footprint(cases, "down") == 6 * 4096 * 512 * 9 // 16
+    assert footprint(cases, "moe") == 6 * 4096 * 1536 * 9 // 16
+    with pytest.raises(ValueError, match="unknown phase"):
+        footprint(cases, "not-a-phase")
+
+
+def test_independent_planar_nvfp4_decode():
+    # Low nibble is the earlier K element; sign is bit 3, groups are 16.
+    packed = torch.tensor(
+        [[0x10, 0x32, 0x54, 0x76, 0x98, 0xBA, 0xDC, 0xFE] * 2], dtype=torch.uint8
+    )
+    scales = torch.tensor([[2.0, 0.5]], dtype=torch.float8_e4m3fn)
+    values = torch.tensor(
+        [0, 0.5, 1, 1.5, 2, 3, 4, 6, 0, -0.5, -1, -1.5, -2, -3, -4, -6],
+        dtype=torch.float64,
+    )
+    torch.testing.assert_close(
+        decode_fragments(packed, scales), torch.cat([values * 2, values / 2])[None]
+    )
+    with pytest.raises(ValueError, match="group-16"):
+        decode_fragments(packed, scales[:, :1])

--- a/tests/slimserve/test_marlin_shared_boundary.py
+++ b/tests/slimserve/test_marlin_shared_boundary.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from benchmarks.kernels.repro_marlin_shared_boundary import isolated_source
+
+
+def test_only_requested_boundary_changes():
+    original = """  auto thread_block_reduce = [&]() {
+    compute();
+  };
+  auto write_result = [&](bool last) {
+    write();
+  };"""
+    assert isolated_source(original, "original") == original
+    assert isolated_source(original, "compute").count("__syncthreads();") == 1
+    assert isolated_source(original, "output").count("__syncthreads();") == 1
+    assert isolated_source(original, "both").count("__syncthreads();") == 2
+    with pytest.raises(ValueError, match="unknown boundary"):
+        isolated_source(original, "typo")
+    with pytest.raises(ValueError, match="no longer matches"):
+        isolated_source(original + original, "both")

--- a/tests/slimserve/test_mhc_fp64_oracle.py
+++ b/tests/slimserve/test_mhc_fp64_oracle.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU tests for the independent gate; original strict parity stays unchanged."""
+
+import math
+
+import pytest
+import torch
+
+from benchmarks.kernels.mhc_fp64_oracle import (
+    accuracy_pair,
+    direct_bf16_rne,
+    ideal_outputs,
+    layer_accuracy,
+)
+
+
+@pytest.mark.parametrize("negative", [False, True])
+def test_every_finite_bf16_midpoint_and_its_fp64_neighbors(negative):
+    bits = torch.arange(0x7F7F, dtype=torch.int32)
+    lo = bits.to(torch.int16).view(torch.bfloat16).double()
+    hi = (bits + 1).to(torch.int16).view(torch.bfloat16).double()
+    middle = (lo + hi) / 2
+    ties = torch.where((bits & 1) == 0, lo, hi)
+    if negative:
+        lo, hi, middle, ties = -hi, -lo, -middle, -ties
+    values = torch.stack(
+        [
+            torch.nextafter(middle, torch.full_like(middle, -math.inf)),
+            middle,
+            torch.nextafter(middle, torch.full_like(middle, math.inf)),
+        ]
+    )
+    wanted = torch.stack([lo, ties, hi]).bfloat16()
+    assert torch.equal(
+        direct_bf16_rne(values).view(torch.int16), wanted.view(torch.int16)
+    )
+
+
+def test_direct_rounding_preserves_signed_zero_and_extrema():
+    biggest = torch.finfo(torch.bfloat16).max
+    values = torch.tensor([0.0, -0.0, biggest, -biggest], dtype=torch.float64)
+    assert torch.equal(
+        direct_bf16_rne(values).view(torch.int16), values.bfloat16().view(torch.int16)
+    )
+
+
+@pytest.mark.parametrize("value", [math.inf, -math.inf, math.nan, 3.4e38])
+def test_direct_rounding_rejects_nonfinite_and_overflow(value):
+    with pytest.raises(ValueError, match="finite BF16-range"):
+        direct_bf16_rne(torch.tensor([value], dtype=torch.float64))
+
+
+def test_direct_rounding_rejects_wrong_dtype():
+    with pytest.raises(ValueError, match="CPU float64"):
+        direct_bf16_rne(torch.ones(2))
+
+
+def test_independent_boundary_favors_candidate_without_changing_old_parity():
+    from benchmarks.kernels.benchmark_glm53_mhc_prefill_tc import check_outputs
+
+    ideal = torch.tensor([[2.007812650812945]], dtype=torch.float64)
+    budget = torch.full_like(ideal, 5e-5)
+    old = torch.tensor([[2.0]], dtype=torch.bfloat16)
+    new = torch.tensor([[2.015625]], dtype=torch.bfloat16)
+    old_accuracy = layer_accuracy(old, ideal, budget)
+    new_accuracy = layer_accuracy(new, ideal, budget)
+    assert old_accuracy["violations"] == new_accuracy["violations"] == 0
+    assert new_accuracy["not_ideally_rounded"] == 0
+    assert old_accuracy["not_ideally_rounded"] == 1
+    assert new_accuracy["squared_error"] < old_accuracy["squared_error"]
+    prefix = [torch.zeros(1, dtype=torch.bfloat16), torch.ones(1), torch.ones(1)]
+    with pytest.raises(AssertionError, match="0.0078125"):
+        check_outputs([*prefix, old], [*prefix, new])
+    bad = torch.tensor([[2.03125]], dtype=torch.bfloat16)
+    assert layer_accuracy(bad, ideal, budget)["violations"] == 1
+
+
+def test_layer_gate_rejects_one_ulp_away_from_an_exact_result():
+    ideal = torch.tensor([[2.0]], dtype=torch.float64)
+    assert (
+        layer_accuracy(
+            torch.tensor([[2.015625]], dtype=torch.bfloat16),
+            ideal,
+            torch.full_like(ideal, 5e-5),
+        )["violations"]
+        == 1
+    )
+
+
+def fixture(rows=2):
+    r = torch.stack([torch.full((rows, 4096), float(i)) for i in range(1, 5)], 1)
+    w = torch.zeros(24, 16384)
+    scale = torch.zeros(3)
+    base = torch.zeros(24)
+    return r.bfloat16(), w.bfloat16(), scale, base
+
+
+def test_full_equations_uniform_closed_form_and_error_budget():
+    args = [t.double() for t in fixture()]
+    post, comb, layer, budget = ideal_outputs(*args)
+    torch.testing.assert_close(post, torch.ones_like(post), rtol=0, atol=0)
+    torch.testing.assert_close(
+        layer, torch.full_like(layer, 5.00001), rtol=0, atol=1e-14
+    )
+    scalar = 0.25 + 1e-6
+    for i in range(20):
+        if i:
+            scalar /= 4 * scalar + 1e-6
+        scalar /= 4 * scalar + 1e-6
+    torch.testing.assert_close(comb, torch.full_like(comb, scalar), rtol=0, atol=0)
+    assert (budget > 0).all()
+
+
+def test_full_projection_uses_stream_and_output_coordinates():
+    args = [t.double() for t in fixture()]
+    r, w, scale, base = args
+    # Nonuniform stream and output weights, with exact binary products.
+    for mix in range(24):
+        for stream in range(4):
+            w[mix, stream * 4096 : (stream + 1) * 4096] = (
+                (mix + 1) * (stream + 1) / 65536
+            )
+    scale[:] = 0.03
+    post, _, layer, _ = ideal_outputs(*args)
+    rms = math.sqrt(7.5 + 1e-5)
+    pre = [
+        1 / (1 + math.exp(-((mix + 1) * 30 / 16) / rms * 0.03)) + 1e-6
+        for mix in range(4)
+    ]
+    wanted_layer = sum((i + 1) * pre[i] for i in range(4))
+    torch.testing.assert_close(
+        layer, torch.full_like(layer, wanted_layer), rtol=1e-14, atol=0
+    )
+    for mix in range(4, 8):
+        wanted_post = 2 / (1 + math.exp(-((mix + 1) * 30 / 16) / rms * 0.03))
+        torch.testing.assert_close(
+            post[:, mix - 4],
+            torch.full_like(post[:, mix - 4], wanted_post),
+            rtol=1e-14,
+            atol=0,
+        )
+
+
+def test_pair_checks_every_row_and_chunk_size_does_not_change_metrics():
+    r, w, scale, base = fixture(3)
+    post, comb, layer, _ = ideal_outputs(*(t.double() for t in (r, w, scale, base)))
+    outputs = [post.float(), comb.float(), direct_bf16_rne(layer)]
+    a = accuracy_pair(r, w, scale, base, outputs, outputs, chunk_rows=1)
+    b = accuracy_pair(r, w, scale, base, outputs, outputs, chunk_rows=3)
+    assert a["passed"] and b["passed"] and a["rows"] == 3
+    assert a["candidate"]["elements"] == 3 * 4096
+    assert a["candidate"]["normalized_rms"] == pytest.approx(
+        b["candidate"]["normalized_rms"]
+    )
+    bad = [t.clone() for t in outputs]
+    bad[-1][-1, -1] *= 1.25
+    result = accuracy_pair(r, w, scale, base, outputs, bad, chunk_rows=1)
+    assert not result["passed"]
+    assert result["candidate"]["violations"] == 1
+
+
+@pytest.mark.parametrize("index", [0, 1])
+def test_pair_checks_both_fp32_outputs(index):
+    r, w, scale, base = fixture()
+    p, c, y, _ = ideal_outputs(*(t.double() for t in (r, w, scale, base)))
+    outputs = [p.float(), c.float(), direct_bf16_rne(y)]
+    bad = [t.clone() for t in outputs]
+    bad[index].flatten()[-1] *= 1.1
+    result = accuracy_pair(r, w, scale, base, outputs, bad)
+    assert not result["passed"]
+    assert (
+        result["candidate"]["post_violations" if index == 0 else "comb_violations"] == 1
+    )
+
+
+def test_oracle_rejects_shape_nonfinite_and_dtype_changes():
+    r, w, scale, base = fixture()
+    args = [t.double() for t in (r, w, scale, base)]
+    with pytest.raises(ValueError, match="shapes"):
+        ideal_outputs(args[0][:, :3], *args[1:])
+    args[1][0, 0] = math.nan
+    with pytest.raises(ValueError, match="nonfinite"):
+        ideal_outputs(*args)
+    with pytest.raises(ValueError, match="CPU float64"):
+        ideal_outputs(r, *args[1:])
+
+
+def test_accuracy_census_keeps_original_failure_and_held_out_seeds():
+    from benchmarks.kernels.check_glm53_mhc_tc_accuracy import case_plan
+
+    plan = case_plan([64, 65, 128, 129, 7616], list(range(90)))
+    assert len(plan) == 2700
+    bad = [
+        p
+        for p in plan
+        if p["site"] == 79
+        and p["batch"] == 7616
+        and p["magnitude"] == 1.0
+        and p["fused"]
+    ]
+    assert len(bad) == 1 and bad[0]["eager_seed"] == 2240
+    assert bad[0]["graph_seeds"] == [12238, 12239, 12240]
+    assert len(case_plan([7616], [79])) == 6
+    for batches, sites in [
+        ([63], [0]),
+        ([64, 64], [0]),
+        ([64], [90]),
+        ([64], [0, 0]),
+        ([], [0]),
+        ([64], []),
+    ]:
+        with pytest.raises(ValueError):
+            case_plan(batches, sites)
+
+
+def test_pair_requires_nonempty_rows_and_native_parameter_precision():
+    r, w, s, b = fixture()
+    with pytest.raises(ValueError, match="nonempty"):
+        accuracy_pair(r[:0], w, s, b, [], [])
+    with pytest.raises(ValueError, match="native FP32"):
+        accuracy_pair(r, w, s.bfloat16(), b, [], [])

--- a/tests/slimserve/test_mhc_norm_probe.py
+++ b/tests/slimserve/test_mhc_norm_probe.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+
+from benchmarks.kernels.benchmark_glm53_mhc_norm import (
+    norm_oracle,
+    normalize_inplace,
+    ulp_distance,
+)
+
+
+def test_bf16_ulp_order_handles_negative_values_and_signed_zero():
+    values = torch.tensor([-2, -1, -0.0, 0.0, 1, 2], dtype=torch.bfloat16)
+    adjacent = torch.nextafter(values, torch.full_like(values, float("inf")))
+    assert ulp_distance(values, adjacent) == 1
+    assert ulp_distance(values, values) == 0
+    assert ulp_distance(values[2:3], values[3:4]) == 0
+    with pytest.raises(ValueError, match="finite"):
+        ulp_distance(values, torch.full_like(values, float("inf")))
+    with pytest.raises(ValueError, match="matching BF16"):
+        ulp_distance(values, values.float())
+
+
+def test_norm_reference_is_inplace_with_fp32_weight_multiply():
+    values = torch.tensor([[1, 2], [-3, 4]], dtype=torch.bfloat16)
+    weight = torch.tensor([0.5, 2], dtype=torch.bfloat16)
+    expected = norm_oracle(values, weight)
+    output = normalize_inplace(values, weight)
+    assert output.data_ptr() == values.data_ptr()
+    assert ulp_distance(output, expected) <= 1

--- a/tests/slimserve/test_mhc_prefill_tc_probe.py
+++ b/tests/slimserve/test_mhc_prefill_tc_probe.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only tests for the isolated mHC tensor-core oracle, not GPU parity."""
+
+import pytest
+import torch
+
+from benchmarks.kernels.benchmark_glm53_mhc_prefill_tc import (
+    check_outputs,
+    oracle_rows,
+    partial_errors,
+)
+
+
+def fixture():
+    # Nonuniform stream/split coordinates, but exactly representable products
+    # and sums: catches mixing up stream, split, or output axes in the oracle.
+    residual = torch.empty(65, 4, 4096, dtype=torch.bfloat16)
+    fn = torch.empty(24, 16384, dtype=torch.bfloat16)
+    partial = torch.empty(65, 32, 25)
+    for split in range(32):
+        square = 0
+        for stream in range(4):
+            v = (stream + 1) * (1 + split % 3)
+            residual[:, stream, split * 128 : (split + 1) * 128] = v
+            square += 128 * v * v
+        partial[:, split, 24] = square
+        for output in range(24):
+            dot = 0
+            for stream in range(4):
+                w = (output + 1) * (stream + 1) * 0.125
+                start = stream * 4096 + split * 128
+                fn[output, start : start + 128] = w
+                dot += 128 * ((stream + 1) * (1 + split % 3)) * w
+            partial[:, split, output] = dot
+    return residual, fn, partial
+
+
+def test_oracle_checks_stream_split_and_mix_coordinates():
+    result = partial_errors(*fixture())
+    assert result["passed"]
+    assert result["dot_normalized_rms"] == 0
+    assert result["dot_row_peak_error"] == 0
+    assert result["square_relative_error"] == 0
+
+
+@pytest.mark.parametrize("column", [0, 23, 24])
+def test_oracle_rejects_bad_dot_or_norm_at_tail(column):
+    residual, fn, partial = fixture()
+    partial[-1, -1, column] *= 1.1
+    assert not partial_errors(residual, fn, partial)["passed"]
+
+
+@pytest.mark.parametrize("bad_input", [0, 1, 2])
+def test_oracle_rejects_nonfinite_inputs_without_nan_metrics(bad_input):
+    data = fixture()
+    data[bad_input].flatten()[0] = float("nan")
+    result = partial_errors(*data)
+    assert result["finite"] is False
+    assert result["passed"] is False
+    assert "dot_normalized_rms" not in result
+
+
+def test_oracle_checks_zero_case_and_shapes():
+    data = fixture()
+    for tensor in data:
+        tensor.zero_()
+    assert partial_errors(*data)["passed"]
+    with pytest.raises(ValueError, match="shapes"):
+        partial_errors(data[0], data[1], data[2][:, :, :24])
+
+
+def test_row_selection_covers_tile_boundaries_and_last_row():
+    assert oracle_rows(65) == [0, 1, 15, 16, 31, 32, 63, 64]
+    assert oracle_rows(7616)[-1] == 7615
+    assert oracle_rows(64)[-1] == 63
+    with pytest.raises(ValueError, match="at least 64"):
+        oracle_rows(63)
+
+
+def test_output_gate_preserves_residual_bits_and_output_arity():
+    reference = [
+        torch.zeros(1, dtype=torch.bfloat16),
+        torch.ones(1),
+        torch.ones(1),
+        torch.ones(1, dtype=torch.bfloat16),
+    ]
+    assert check_outputs(reference, reference)
+    candidate = [tensor.clone() for tensor in reference]
+    candidate[0].fill_(-0.0)
+    with pytest.raises(AssertionError, match="different bits"):
+        check_outputs(reference, candidate)
+    with pytest.raises(ValueError, match="output count"):
+        check_outputs(reference, candidate[:3])
+
+
+def test_output_gate_keeps_strict_boundary_and_reports_failed_value():
+    reference = [
+        torch.zeros(1, dtype=torch.bfloat16),
+        torch.ones(1),
+        torch.ones(1),
+        torch.tensor([[2.0]], dtype=torch.bfloat16),
+    ]
+    candidate = [tensor.clone() for tensor in reference]
+    candidate[-1].fill_(2.015625)
+    with pytest.raises(AssertionError, match='"row_peak_error": 0.0078125') as error:
+        check_outputs(reference, candidate)
+    assert '"reference": 2.0' in str(error.value)
+    assert '"candidate": 2.015625' in str(error.value)
+
+
+@pytest.mark.parametrize("change", ["shape", "dtype"])
+def test_output_gate_rejects_broadcasting_and_dtype_changes(change):
+    reference = [torch.ones(2, 1), torch.ones(2, 1), torch.ones(2, 1), torch.ones(2, 1)]
+    candidate = list(reference)
+    candidate[-1] = reference[-1][:1] if change == "shape" else reference[-1].bfloat16()
+    with pytest.raises(ValueError, match="shape or dtype"):
+        check_outputs(reference, candidate)

--- a/tests/slimserve/test_mhc_storage_probe.py
+++ b/tests/slimserve/test_mhc_storage_probe.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+
+from benchmarks.kernels import benchmark_glm53_mhc_storage as probe
+from benchmarks.kernels.benchmark_glm53_mhc_storage import exact, lossless_bf16
+
+
+@pytest.mark.parametrize("indices", [[], [-1], [90], [0, 0]])
+def test_sanitizer_site_selection_rejects_invalid_indices(indices):
+    with pytest.raises(ValueError, match="distinct indices"):
+        probe.selected_check_sites(indices)
+
+
+def test_sanitizer_site_selection_defaults_to_exhaustive_census():
+    assert probe.selected_check_sites(None) == list(range(90))
+    assert probe.selected_check_sites([0, 89]) == [0, 89]
+
+
+def test_storage_conversion_requires_exact_checkpoint_values():
+    value = torch.tensor([0.0, -1.0, 0.125, 1e-20], dtype=torch.bfloat16).float()
+    assert torch.equal(lossless_bf16(value).float(), value)
+    with pytest.raises(ValueError, match="alter checkpoint"):
+        lossless_bf16(torch.tensor([0.1], dtype=torch.float32))
+
+
+def test_storage_probe_rejects_nan_and_any_output_difference():
+    with pytest.raises(ValueError):
+        lossless_bf16(torch.tensor([float("nan")]))
+    value = torch.ones(2, dtype=torch.bfloat16)
+    exact([value], [value.clone()])
+    with pytest.raises(AssertionError, match="bit-exact"):
+        exact([value], [value + 0.01])
+    with pytest.raises(AssertionError, match="bit-exact"):
+        exact([value], [value.float()])
+
+
+def test_exact_probe_checks_signed_zero_and_rejects_nan():
+    for dtype in (torch.float32, torch.bfloat16):
+        positive = torch.tensor([0.0], dtype=dtype)
+        negative = torch.tensor([-0.0], dtype=dtype)
+        assert torch.equal(positive, negative)
+        with pytest.raises(AssertionError, match="signed zero"):
+            exact([positive], [negative])
+        nan = torch.tensor([float("nan")], dtype=dtype)
+        with pytest.raises(AssertionError, match="bit-exact"):
+            exact([nan], [nan.clone()])
+
+
+@pytest.mark.parametrize("shared", [False, True])
+@pytest.mark.parametrize("banks", [2, 6])
+def test_timing_banks_share_only_activations_when_requested(monkeypatch, shared, banks):
+    seeds = []
+
+    def fake_inputs(batch, seed):
+        seeds.append(seed)
+        return [torch.full((batch, 2), float(seed)) for _ in range(4)]
+
+    monkeypatch.setattr(probe, "inputs", fake_inputs)
+    sites = [[torch.ones(4, 2) * i, torch.ones(3), torch.ones(24)] for i in range(3)]
+    narrow = [site[0].bfloat16() for site in sites]
+    rows = probe.timing_rows(sites, narrow, 2, shared, banks)
+    assert len(rows) == 3 * banks
+    assert seeds == (
+        list(range(5001, 5001 + banks * 3, 3))
+        if shared
+        else list(range(5001, 5001 + banks * 3))
+    )
+    assert [row[2] for row in rows] == [False, True, True] * banks
+    for variant in (0, 1):
+        assert len({row[variant][4].data_ptr() for row in rows}) == 3 * banks
+        for index, row in enumerate(rows):
+            expected = narrow[index % 3] if variant else sites[index % 3][0]
+            assert torch.equal(row[variant][4], expected)
+            assert row[variant][4].data_ptr() != expected.data_ptr()
+        assert len({row[variant][0].data_ptr() for row in rows}) == (
+            banks if shared else 3 * banks
+        )
+    for row in rows:
+        assert all(a.data_ptr() == b.data_ptr() for a, b in zip(row[0][:4], row[1][:4]))
+
+
+def test_timing_banks_reject_mismatched_site_counts():
+    with pytest.raises(ValueError, match="site counts"):
+        probe.timing_rows([[]], [], 1)
+    with pytest.raises(ValueError, match="positive weight bank"):
+        probe.timing_rows([], [], 1, weight_banks=0)

--- a/tests/slimserve/test_mhc_storage_probe.py
+++ b/tests/slimserve/test_mhc_storage_probe.py
@@ -85,3 +85,38 @@ def test_timing_banks_reject_mismatched_site_counts():
         probe.timing_rows([[]], [], 1)
     with pytest.raises(ValueError, match="positive weight bank"):
         probe.timing_rows([], [], 1, weight_banks=0)
+
+
+def test_bf16_only_timing_does_not_clone_fp32_weights(monkeypatch):
+    monkeypatch.setattr(probe, "inputs", lambda *args: [torch.ones(1)] * 4)
+
+    class UnusedWeight:
+        def clone(self):
+            raise AssertionError("unused FP32 weight must not be allocated")
+
+    narrow = torch.ones(2, dtype=torch.bfloat16)
+    rows = probe.timing_rows(
+        [[UnusedWeight(), torch.ones(3), torch.ones(24)]],
+        [narrow],
+        1,
+        weight_banks=2,
+        fp32_arm=False,
+    )
+    assert all(row[0][4] is None for row in rows)
+    assert all(torch.equal(row[1][4], narrow) for row in rows)
+    assert len({row[1][4].data_ptr() for row in rows}) == 2
+
+
+@pytest.mark.parametrize("extra", [False, True])
+def test_installed_baseline_requires_matching_output_count(monkeypatch, extra):
+    from types import SimpleNamespace
+
+    from benchmarks.kernels import benchmark_mhc_output_parallel as comparison
+    from vllm.quixicore.ops import quixicore_ops as qc
+
+    values = [torch.ones(1) for _ in range(8)]
+    monkeypatch.setattr(comparison, "inputs", lambda *args: values)
+    monkeypatch.setattr(qc, "dsv4_mhc_pre", lambda *args: values[:3])
+    extension = SimpleNamespace(run=lambda *args: [values[0]] * (5 if extra else 3))
+    with pytest.raises(ValueError, match="output count differs"):
+        comparison.installed_baseline_checks(extension, 1)

--- a/tests/slimserve/test_mhc_tc_native_receipt.py
+++ b/tests/slimserve/test_mhc_tc_native_receipt.py
@@ -11,12 +11,50 @@ def test_native_kernel_body_is_unchanged_except_namespace(mutation):
     root = Path(__file__).resolve().parents[2]
     probe = (root / "benchmarks/kernels/mhc_prefill_tc_probe.cu").read_text()
     native = (root / "csrc/quixicore/serving/glm53_mhc_prefill_tc.cuh").read_text()
-    if mutation == "arithmetic":
-        native = native.replace("sum += v.x * v.x;", "sum += v.x;")
-    if mutation == "layout":
-        native = native.replace("ROW = 520", "ROW = 512")
+    anchors = {
+        "arithmetic": ("sum += v.x * v.x;", "sum += v.x;"),
+        "layout": ("ROW = 520", "ROW = 512"),
+    }
+    if mutation is not None:
+        original, replacement = anchors[mutation]
+        mutated = native.replace(original, replacement)
+        assert mutated != native, f"mutation anchor {original!r} no longer exists"
+        native = mutated
     if mutation is None:
         qualified_kernel_body(probe, native)
     else:
         with pytest.raises(ValueError, match="kernel body changed"):
             qualified_kernel_body(probe, native)
+
+
+def test_missing_census_source_fails_before_hash_or_gpu_probe(tmp_path, monkeypatch):
+    from benchmarks.kernels import check_glm53_mhc_tc_native as check
+
+    missing = tmp_path / "missing.cuh"
+    monkeypatch.setattr(
+        check.sys,
+        "argv",
+        [
+            "check",
+            "--census",
+            str(tmp_path / "census.json"),
+            "--output",
+            str(tmp_path / "output"),
+        ],
+    )
+    monkeypatch.setattr(
+        check,
+        "qualified_census",
+        lambda path: (
+            {"source_sha256": {str(missing): "not-a-digest"}},
+            {},
+        ),
+    )
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("missing sources must fail before hashing or GPU work")
+
+    monkeypatch.setattr(check, "sha", forbidden)
+    monkeypatch.setattr(check.subprocess, "check_output", forbidden)
+    with pytest.raises(ValueError, match="qualified source missing"):
+        check.main()

--- a/tests/slimserve/test_mhc_tc_native_receipt.py
+++ b/tests/slimserve/test_mhc_tc_native_receipt.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+
+import pytest
+
+from benchmarks.kernels.check_glm53_mhc_tc_native import qualified_kernel_body
+
+
+@pytest.mark.parametrize("mutation", [None, "arithmetic", "layout"])
+def test_native_kernel_body_is_unchanged_except_namespace(mutation):
+    root = Path(__file__).resolve().parents[2]
+    probe = (root / "benchmarks/kernels/mhc_prefill_tc_probe.cu").read_text()
+    native = (root / "csrc/quixicore/serving/glm53_mhc_prefill_tc.cuh").read_text()
+    if mutation == "arithmetic":
+        native = native.replace("sum += v.x * v.x;", "sum += v.x;")
+    if mutation == "layout":
+        native = native.replace("ROW = 520", "ROW = 512")
+    if mutation is None:
+        qualified_kernel_body(probe, native)
+    else:
+        with pytest.raises(ValueError, match="kernel body changed"):
+            qualified_kernel_body(probe, native)

--- a/tests/slimserve/test_mhc_tc_qualified_timing.py
+++ b/tests/slimserve/test_mhc_tc_qualified_timing.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only fail-closed checks for the independent-census timing prerequisite."""
+
+import copy
+import json
+import math
+
+import pytest
+
+from benchmarks.kernels.benchmark_glm53_mhc_prefill_tc import oracle_rows
+from benchmarks.kernels.benchmark_glm53_mhc_tc_qualified import (
+    BATCHES,
+    qualified_census,
+    validate_accuracy,
+    validate_partial,
+)
+from benchmarks.kernels.check_glm53_mhc_tc_accuracy import PROBE_SHA, case_plan, sha
+
+
+def accuracy(rows):
+    arm = {
+        "passed": True,
+        "elements": rows * 4096,
+        "violations": 0,
+        "post_violations": 0,
+        "comb_violations": 0,
+        "squared_error": 0,
+        "ideal_squared_sum": 1,
+        "normalized_rms": 0,
+    }
+    return {
+        "passed": True,
+        "rows": rows,
+        "candidate_rms_noninferior": True,
+        "reference": dict(arm),
+        "candidate": dict(arm),
+    }
+
+
+def partial(batch):
+    return {
+        "passed": True,
+        "finite": True,
+        "rows": oracle_rows(batch),
+        "dot_normalized_rms": 0,
+        "dot_row_peak_error": 0,
+        "square_relative_error": 0,
+    }
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("violations", 1),
+        ("post_violations", 1),
+        ("comb_violations", 1),
+        ("elements", 4096),
+        ("normalized_rms", math.nan),
+        ("squared_error", -1),
+        ("normalized_rms", 0.1),
+    ],
+)
+def test_accuracy_validator_recomputes_gates_despite_passed_flags(key, value):
+    data = accuracy(64)
+    data["candidate"][key] = value
+    with pytest.raises(ValueError):
+        validate_accuracy(data, 64)
+
+
+def test_accuracy_validator_recomputes_rms_noninferiority():
+    data = accuracy(64)
+    data["candidate"].update(squared_error=1e-6, normalized_rms=0.001)
+    with pytest.raises(ValueError, match="RMS regression"):
+        validate_accuracy(data, 64)
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("dot_normalized_rms", 2.01e-6),
+        ("dot_row_peak_error", 2.01e-5),
+        ("square_relative_error", 1.01e-5),
+        ("finite", False),
+        ("rows", [0]),
+        ("square_relative_error", math.nan),
+    ],
+)
+def test_partial_validator_preserves_original_bounds(key, value):
+    data = partial(65)
+    data[key] = value
+    with pytest.raises(ValueError):
+        validate_partial(data, 65)
+
+
+def write_census(directory, change=None):
+    plan = case_plan(BATCHES, list(range(90)))
+    summary = {
+        "status": "complete",
+        "contract": "glm53-mhc-tc-accuracy-v1",
+        "planned_cases": 2700,
+        "completed_cases": 2700,
+        "completed_graph_phases": 8100,
+        "plan": plan,
+        "extension_sha256": PROBE_SHA,
+        "strict_parity_failed_comparisons": 1,
+    }
+    rows = []
+    for item in plan:
+        t = item["batch"]
+        original_failure = (
+            t == 7616
+            and item["site"] == 79
+            and item["magnitude"] == 1
+            and item["fused"]
+        )
+        row = {
+            **item,
+            "status": "complete",
+            "eager_fp64_all_rows": accuracy(t),
+            "partial_oracle": partial(t),
+            "strict_parity_diagnostic": {"passed": not original_failure},
+            "graphs": [],
+        }
+        for seed in item["graph_seeds"]:
+            row["graphs"].append(
+                {
+                    "status": "complete",
+                    "seed": seed,
+                    "all_output_bits_match_eager": True,
+                    "oracle_rows": oracle_rows(t),
+                    "fp64_sampled_rows": accuracy(len(oracle_rows(t))),
+                    "partial_oracle": partial(t),
+                    "strict_parity_diagnostic": {"passed": True},
+                }
+            )
+        rows.append(row)
+    if change:
+        change(summary, rows)
+    journal = directory / "checks.jsonl"
+    journal.write_text("".join(json.dumps(r) + "\n" for r in rows))
+    summary["journal_sha256"] = sha(journal)
+    (directory / "summary.json").write_text(json.dumps(summary))
+
+
+def test_full_census_accepts_preserved_old_parity_failure(tmp_path):
+    write_census(tmp_path)
+    _, receipt = qualified_census(tmp_path)
+    assert receipt["completed_cases"] == 2700
+    assert receipt["strict_parity_failed_comparisons"] == 1
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        lambda s, r: s.update(status="running"),
+        lambda s, r: s.update(completed_cases=6),
+        lambda s, r: s.update(strict_parity_failed_comparisons=0),
+        lambda s, r: r.pop(),
+        lambda s, r: r.append(copy.deepcopy(r[-1])),
+        lambda s, r: r[-1].update(eager_seed=1),
+        lambda s, r: r[-1]["graphs"][-1].update(seed=1),
+        lambda s, r: r[-1]["graphs"][-1].update(all_output_bits_match_eager=False),
+        lambda s, r: r[-1]["eager_fp64_all_rows"]["candidate"].update(violations=1),
+    ],
+)
+def test_census_rejects_partial_or_inconsistent_receipts(tmp_path, change):
+    write_census(tmp_path, change)
+    with pytest.raises(ValueError):
+        qualified_census(tmp_path)
+
+
+def test_census_rejects_changed_journal(tmp_path):
+    write_census(tmp_path)
+    with (tmp_path / "checks.jsonl").open("a") as stream:
+        stream.write("{}\n")
+    with pytest.raises(ValueError, match="digest"):
+        qualified_census(tmp_path)

--- a/tests/slimserve/test_model_journal.py
+++ b/tests/slimserve/test_model_journal.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+import inspect
+import json
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from slimserve.model_journal import (
+    ACTIVE,
+    OP_NAMES,
+    ModelJournal,
+    enabled,
+    install_model_journal,
+    instrument_mhc,
+)
+from slimserve.score_journal import ScoreJournal
+
+
+@pytest.fixture
+def journal(tmp_path):
+    path = tmp_path / "config.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "prompt_ids": list(range(640)),
+                "max_matches": 3,
+                "output_directory": str(tmp_path / "journals"),
+            }
+        )
+    )
+    score = ScoreJournal(path)
+    model = ModelJournal(score)
+    yield model
+    model.close()
+    score.close()
+
+
+def test_disabled_is_original_callable_and_runner(monkeypatch):
+    monkeypatch.delenv("SLIMSERVE_GLM53_MODEL_JOURNAL", raising=False)
+    function = lambda: None
+    assert instrument_mhc(function) is function
+    runner = SimpleNamespace(_model_forward=function)
+    install_model_journal(runner)
+    assert runner._model_forward is function
+    assert vars(runner) == {"_model_forward": function}
+
+
+def test_invalid_flag_and_operation_rejected(monkeypatch):
+    monkeypatch.setenv("SLIMSERVE_GLM53_MODEL_JOURNAL", "yes")
+    with pytest.raises(ValueError, match="0 or 1"):
+        enabled()
+    monkeypatch.setenv("SLIMSERVE_GLM53_MODEL_JOURNAL", "1")
+    with pytest.raises(ValueError, match="unknown"):
+        instrument_mhc(lambda: None)
+
+
+def test_enabled_wrapper_preserves_signature_outputs_and_empty_context(monkeypatch):
+    monkeypatch.setenv("SLIMSERVE_GLM53_MODEL_JOURNAL", "1")
+
+    def glm5_mhc_pre(x: torch.Tensor, scale: float = 1.0) -> torch.Tensor:
+        return x
+
+    wrapped = instrument_mhc(glm5_mhc_pre)
+    assert inspect.signature(wrapped) == inspect.signature(glm5_mhc_pre)
+    tensor = torch.ones(2)
+    assert wrapped(tensor) is tensor
+    calls = []
+    observer = SimpleNamespace(
+        before_op=lambda name, args: calls.append((name, args)),
+        after_op=lambda name, value: calls.append((name, value)),
+    )
+    token = ACTIVE.set(observer)
+    try:
+        assert wrapped(tensor, scale=2.0) is tensor
+    finally:
+        ACTIVE.reset(token)
+    assert calls[0][1] == {"x": tensor, "scale": 2.0}
+    assert calls[1][1] is tensor
+    assert ACTIVE.get() is None
+
+
+def complete_ops(journal):
+    tensor = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+    for site in range(91):
+        name = OP_NAMES[0 if site == 0 else 1 if site < 90 else 2]
+        journal.before_op(name, {"x": tensor, "eps": 1e-5})
+        result = tensor if site == 90 else (tensor,) * (3 if site == 0 else 4)
+        journal.after_op(name, result)
+
+
+def test_all_operations_and_repeats_are_bounded(journal):
+    for match in range(3):
+        journal.begin(f"request-{match}")
+        complete_ops(journal)
+        journal.finish()
+    with pytest.raises(ValueError, match="extra"):
+        journal.begin("fourth")
+    rows = [json.loads(line) for line in journal.path.read_text().splitlines()]
+    assert rows[0]["expected_operations"] == 91
+    assert len([r for r in rows if r["kind"] == "complete"]) == 3
+    assert len([r for r in rows if r["kind"] == "operation"]) == 3 * 91
+    assert {r["parameters"]["eps"] for r in rows if r["kind"] == "operation"} == {1e-5}
+    assert len({r["sha256"] for r in rows if r["kind"] == "tensor"}) == 1
+
+
+def test_inactive_overlap_incomplete_and_wrong_operation_rejected(journal):
+    with pytest.raises(ValueError, match="inactive"):
+        journal.record("bad", torch.ones(1))
+    with pytest.raises(ValueError, match="incomplete"):
+        journal.finish()
+    journal.begin("one")
+    with pytest.raises(ValueError, match="overlapping"):
+        journal.begin("two")
+    with pytest.raises(ValueError, match="order"):
+        journal.before_op(OP_NAMES[1], {})
+    journal.before_op(OP_NAMES[0], {})
+    with pytest.raises(ValueError, match="order"):
+        journal.before_op(OP_NAMES[0], {})
+    with pytest.raises(ValueError, match="completion"):
+        journal.after_op(OP_NAMES[1], ())
+    with pytest.raises(ValueError, match="arity"):
+        journal.after_op(OP_NAMES[0], (torch.ones(1),))
+    with pytest.raises(ValueError, match="incomplete"):
+        journal.finish()
+
+
+def test_extra_operation_refused(journal):
+    journal.begin("one")
+    complete_ops(journal)
+    with pytest.raises(ValueError, match="order"):
+        journal.before_op(OP_NAMES[2], {})
+
+
+@pytest.mark.parametrize("shape", [(0,), (2**29,)])
+def test_byte_bound_checked_before_copy(journal, shape):
+    journal.begin("one")
+    with pytest.raises(ValueError, match="byte bound"):
+        journal.record("bad", torch.empty(shape, device="meta"))
+
+
+def test_record_bound_checked_before_copy(journal):
+    journal.begin("one")
+    journal.records = 1024
+    with pytest.raises(ValueError, match="record bound"):
+        journal.record("bad", torch.empty(1, device="meta"))
+
+
+def test_scalar_snapshot_retains_shape_and_bits(journal):
+    journal.begin("one")
+    tensor = torch.tensor(-0.0)
+    host = journal.record("scalar", tensor)
+    assert host.shape == ()
+    assert torch.signbit(host)
+
+
+@pytest.mark.parametrize("change", ["model", "tp", "pp", "spec", "score_config"])
+def test_install_scope_is_validated(monkeypatch, change):
+    monkeypatch.setenv("SLIMSERVE_GLM53_MODEL_JOURNAL", "1")
+    monkeypatch.delenv("SLIMSERVE_GLM53_SCORE_JOURNAL", raising=False)
+    runner = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(model_type="glm5_next"),
+            hf_text_config=SimpleNamespace(hidden_size=4096, num_hidden_layers=45),
+        ),
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=4, pipeline_parallel_size=1
+        ),
+        speculative_config=None,
+    )
+    if change == "model":
+        runner.model_config.hf_text_config.hidden_size = 2048
+    elif change == "tp":
+        runner.parallel_config.tensor_parallel_size = 2
+    elif change == "pp":
+        runner.parallel_config.pipeline_parallel_size = 2
+    elif change == "spec":
+        runner.speculative_config = object()
+    with pytest.raises(ValueError):
+        install_model_journal(runner)

--- a/tests/slimserve/test_model_journal.py
+++ b/tests/slimserve/test_model_journal.py
@@ -177,5 +177,8 @@ def test_install_scope_is_validated(monkeypatch, change):
         runner.parallel_config.pipeline_parallel_size = 2
     elif change == "spec":
         runner.speculative_config = object()
-    with pytest.raises(ValueError):
+    message = (
+        "bounded score journal" if change == "score_config" else "GLM53 TP4 no-spec"
+    )
+    with pytest.raises(ValueError, match=message):
         install_model_journal(runner)

--- a/tests/slimserve/test_moe_journal.py
+++ b/tests/slimserve/test_moe_journal.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+import hashlib
+import inspect
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from slimserve import moe_journal as mj
+from slimserve.model_journal import ACTIVE
+
+
+class FakeJournal:
+    def __init__(self, path):
+        self.path = path
+        self.matches = 1
+        self.operations = 8
+        self.pending = None
+        self.moe_capture = None
+        self.rows = []
+
+    def write(self, row):
+        self.rows.append(row)
+
+    def record(self, stage, tensor):
+        host = tensor.detach().cpu().contiguous()
+        self.write(
+            {
+                "kind": "tensor",
+                "stage": stage,
+                "shape": list(tensor.shape),
+                "sha256": hashlib.sha256(
+                    host.reshape(-1).view(torch.uint8).numpy()
+                ).hexdigest(),
+            }
+        )
+        return host
+
+
+@pytest.fixture
+def journal(tmp_path, monkeypatch):
+    monkeypatch.setenv("SLIMSERVE_GLM53_MODEL_JOURNAL", "1")
+    monkeypatch.setenv("SLIMSERVE_GLM53_MOE_JOURNAL", "1")
+    return FakeJournal(tmp_path / "model.jsonl")
+
+
+@pytest.mark.parametrize(
+    "decorator",
+    [mj.instrument_router, mj.instrument_marlin_gemm, mj.instrument_moe_sum],
+)
+def test_disabled_decorators_are_identity(monkeypatch, decorator):
+    monkeypatch.delenv("SLIMSERVE_GLM53_MOE_JOURNAL", raising=False)
+    function = lambda: None
+    assert decorator(function) is function
+
+
+@pytest.mark.parametrize("moe,model", [("yes", "1"), ("1", "0")])
+def test_bad_flags_fail(monkeypatch, moe, model):
+    monkeypatch.setenv("SLIMSERVE_GLM53_MOE_JOURNAL", moe)
+    monkeypatch.setenv("SLIMSERVE_GLM53_MODEL_JOURNAL", model)
+    with pytest.raises(ValueError):
+        mj.enabled()
+
+
+def test_snapshot_values_metadata_and_parameter_dedup(journal):
+    capture = mj.MoECapture(journal)
+    original = torch.arange(80, dtype=torch.float32)
+    tensor = original[4:12]
+    for match in (1, 2, 3):
+        journal.matches = match
+        capture.snapshot("up.b_scales", tensor, parameter=True)
+    files = list(capture.directory.glob("*.pt"))
+    assert len(files) == 1
+    saved = torch.load(files[0], weights_only=True)
+    assert torch.equal(saved, tensor)
+    assert saved.untyped_storage().nbytes() == tensor.numel() * tensor.element_size()
+    assert torch.equal(original, torch.arange(80, dtype=torch.float32))
+    row = next(r for r in journal.rows if r["kind"] == "moe_snapshot")
+    assert row["file_bytes"] == capture.saved_bytes == files[0].stat().st_size
+    assert row["file_sha256"] == hashlib.sha256(files[0].read_bytes()).hexdigest()
+    assert len([r for r in journal.rows if r["kind"] == "tensor"]) == 3
+
+
+def test_duplicate_stage_and_unsafe_path_fail(journal):
+    capture = mj.MoECapture(journal)
+    capture.snapshot("up.input", torch.ones(1))
+    with pytest.raises(ValueError, match="duplicate"):
+        capture.snapshot("up.input", torch.ones(1))
+    with pytest.raises(ValueError, match="stage"):
+        capture.snapshot("../../bad", torch.ones(1))
+
+
+def test_dump_bound_fails_before_file_creation(journal, monkeypatch):
+    capture = mj.MoECapture(journal)
+    monkeypatch.setattr(mj, "MAX_DUMP_BYTES", 16)
+    with pytest.raises(ValueError, match="byte bound"):
+        capture.snapshot("up.input", torch.ones(1))
+    assert not list(capture.directory.iterdir())
+
+
+def test_router_wrapper_forwards_same_objects_and_only_at_site8(journal):
+    weights = torch.ones(640, 8)
+    ids = torch.arange(8).repeat(640, 1)
+    returned = (weights, ids)
+
+    def select_experts(hidden_states, router_logits, marker=None):
+        assert marker is returned
+        return returned
+
+    wrapped = mj.instrument_router(select_experts)
+    assert inspect.signature(wrapped) == inspect.signature(select_experts)
+    hidden = torch.zeros(640, 4096, dtype=torch.bfloat16)
+    logits = torch.zeros(640, 288)
+    assert wrapped(hidden, logits, returned) is returned
+    assert journal.moe_capture is None
+    token = ACTIVE.set(journal)
+    try:
+        journal.operations = 7
+        assert wrapped(hidden, logits, returned) is returned
+        assert journal.moe_capture is None
+        journal.operations = 8
+        assert wrapped(hidden, logits, returned) is returned
+    finally:
+        ACTIVE.reset(token)
+    assert len([r for r in journal.rows if r["kind"] == "tensor"]) == 4
+
+
+def marlin_args():
+    return dict(
+        size_m=640,
+        size_n=1024,
+        size_k=4096,
+        top_k=8,
+        moe_block_size=32,
+        input=torch.zeros(640, 4096, dtype=torch.bfloat16),
+        topk_weights=torch.ones(640, 8),
+        b_qweight=torch.ones(8, dtype=torch.int32),
+        b_scales=torch.ones(8, dtype=torch.bfloat16),
+        global_scale=torch.tensor(1.0),
+        workspace=torch.zeros(8, dtype=torch.int32),
+        sorted_token_ids=torch.arange(64, dtype=torch.int32),
+        expert_ids=torch.arange(2, dtype=torch.int32),
+        num_tokens_past_padded=torch.tensor([32], dtype=torch.int32),
+        b_q_type=SimpleNamespace(id=1),
+        mul_topk_weights=False,
+        is_k_full=True,
+        use_atomic_add=False,
+        use_fp32_reduce=True,
+        is_zp_float=False,
+        thread_k=-1,
+        thread_n=-1,
+        blocks_per_sm=-1,
+        b_bias=None,
+        a_scales=None,
+        b_qzeros=None,
+        g_idx=torch.empty(0),
+        perm=None,
+    )
+
+
+def test_marlin_captures_only_defined_alignment_and_forwards_result(journal):
+    capture = mj.MoECapture(journal)
+    args = marlin_args()
+    result = torch.zeros(2, dtype=torch.bfloat16)
+    assert mj._marlin(capture, args, lambda: result) is result
+    rows = {r["stage"]: r for r in journal.rows if r["kind"] == "tensor"}
+    assert rows["moe3.up.sorted_ids"]["shape"] == [32]
+    assert rows["moe3.up.expert_ids"]["shape"] == [1]
+    assert rows["moe3.up.global_scale"]["shape"] == []
+    assert capture.gemm_calls == {1: 1}
+
+
+@pytest.mark.parametrize("failure", ["recipe", "optional", "alignment", "extra"])
+def test_bad_marlin_scope_fails(journal, failure):
+    capture = mj.MoECapture(journal)
+    args = marlin_args()
+    if failure == "recipe":
+        args["use_atomic_add"] = True
+    elif failure == "optional":
+        args["b_bias"] = torch.ones(1)
+    elif failure == "alignment":
+        args["num_tokens_past_padded"].fill_(65)
+    else:
+        capture.gemm_calls[1] = 2
+    with pytest.raises(ValueError):
+        mj._marlin(capture, args, lambda: pytest.fail("must fail before GEMM"))
+
+
+def test_sum_wrapper_preserves_inplace_result_and_completion(journal):
+    capture = mj.MoECapture(journal)
+    journal.moe_capture = capture
+    capture.gemm_calls[1] = 2
+    x = torch.zeros(640, 8, 4096, dtype=torch.bfloat16)
+    shared = torch.ones(640, 4096, dtype=torch.bfloat16)
+    out = torch.empty_like(shared)
+
+    def sum_add(x, shared, out):
+        out.copy_(shared)
+
+    wrapped = mj.instrument_moe_sum(sum_add)
+    token = ACTIVE.set(journal)
+    try:
+        assert wrapped(x, shared, out) is None
+    finally:
+        ACTIVE.reset(token)
+    assert torch.equal(out, shared)
+    assert capture.completed == {1}
+    assert journal.rows[-1]["kind"] == "moe_complete"

--- a/tests/slimserve/test_moe_journal.py
+++ b/tests/slimserve/test_moe_journal.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 import hashlib
 import inspect
+import os
+import stat
 from types import SimpleNamespace
 
 import pytest
@@ -79,6 +81,19 @@ def test_snapshot_values_metadata_and_parameter_dedup(journal):
     assert row["file_bytes"] == capture.saved_bytes == files[0].stat().st_size
     assert row["file_sha256"] == hashlib.sha256(files[0].read_bytes()).hexdigest()
     assert len([r for r in journal.rows if r["kind"] == "tensor"]) == 3
+
+
+def test_snapshot_permissions_ignore_permissive_umask(journal):
+    previous = os.umask(0)
+    try:
+        capture = mj.MoECapture(journal)
+        capture.snapshot("up.input", torch.ones(1))
+    finally:
+        os.umask(previous)
+    assert stat.S_IMODE(capture.directory.stat().st_mode) == 0o700
+    assert [stat.S_IMODE(p.stat().st_mode) for p in capture.directory.iterdir()] == [
+        0o600
+    ]
 
 
 def test_duplicate_stage_and_unsafe_path_fail(journal):

--- a/tests/slimserve/test_score_journal.py
+++ b/tests/slimserve/test_score_journal.py
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 import hashlib
 import json
+import os
+import stat
+from pathlib import Path
 
 import pytest
 import torch
 
-from slimserve.score_journal import STAGES, ScoreJournal
+from slimserve.score_journal import STAGES, ScoreJournal, private_open
 
 
 @pytest.fixture
@@ -24,6 +27,53 @@ def config(tmp_path):
 def test_disabled_does_not_read_configuration(monkeypatch):
     monkeypatch.delenv("SLIMSERVE_GLM53_SCORE_JOURNAL", raising=False)
     assert ScoreJournal.from_env("unrelated") is None
+
+
+def test_journal_permissions_ignore_permissive_umask(config):
+    from slimserve.model_journal import ModelJournal
+
+    previous = os.umask(0)
+    try:
+        score = ScoreJournal(config[0])
+        model = ModelJournal(score)
+    finally:
+        os.umask(previous)
+    try:
+        assert stat.S_IMODE(score.path.parent.stat().st_mode) == 0o700
+        for path in (score.path, model.path):
+            assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    finally:
+        model.close()
+        score.close()
+
+
+@pytest.mark.parametrize("kind", ["public", "symlink"])
+def test_nonprivate_journal_directory_rejected_without_chmod(config, kind):
+    path, value = config
+    directory = Path(value["output_directory"])
+    if kind == "public":
+        directory.mkdir(mode=0o755)
+        directory.chmod(0o755)
+    else:
+        target = path.parent / "target"
+        target.mkdir(mode=0o700)
+        directory.symlink_to(target, target_is_directory=True)
+    before = directory.lstat().st_mode
+    with pytest.raises(ValueError, match="must be private"):
+        ScoreJournal(path)
+    assert directory.lstat().st_mode == before
+    assert list(directory.iterdir()) == []
+
+
+def test_private_open_preserves_existing_file_and_symlink_target(tmp_path):
+    target = tmp_path / "existing"
+    target.write_text("preserve")
+    link = tmp_path / "link"
+    link.symlink_to(target)
+    for path in (target, link):
+        with pytest.raises(FileExistsError):
+            private_open(path)
+    assert target.read_text() == "preserve"
 
 
 def test_enabled_is_model_scoped(config, monkeypatch):

--- a/tests/slimserve/test_score_journal.py
+++ b/tests/slimserve/test_score_journal.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+import hashlib
+import json
+
+import pytest
+import torch
+
+from slimserve.score_journal import STAGES, ScoreJournal
+
+
+@pytest.fixture
+def config(tmp_path):
+    path = tmp_path / "config.json"
+    value = {
+        "schema": 1,
+        "prompt_ids": list(range(640)),
+        "max_matches": 3,
+        "output_directory": str(tmp_path / "journal"),
+    }
+    path.write_text(json.dumps(value))
+    return path, value
+
+
+def test_disabled_does_not_read_configuration(monkeypatch):
+    monkeypatch.delenv("SLIMSERVE_GLM53_SCORE_JOURNAL", raising=False)
+    assert ScoreJournal.from_env("unrelated") is None
+
+
+def test_enabled_is_model_scoped(config, monkeypatch):
+    path, _ = config
+    monkeypatch.setenv("SLIMSERVE_GLM53_SCORE_JOURNAL", str(path))
+    with pytest.raises(ValueError, match="scoped"):
+        ScoreJournal.from_env("unrelated")
+    journal = ScoreJournal.from_env("glm5_next")
+    journal.close()
+    with pytest.raises(FileExistsError):
+        ScoreJournal.from_env("glm5_next_text")
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "missing",
+        "extra",
+        "list",
+        "schema",
+        "schema_bool",
+        "short_ids",
+        "negative_id",
+        "bool_id",
+        "limit_zero",
+        "limit_large",
+        "limit_bool",
+        "directory",
+    ],
+)
+def test_invalid_config_creates_no_journal(config, mutation):
+    path, value = config
+    if mutation == "missing":
+        del value["schema"]
+    elif mutation == "extra":
+        value["other"] = 1
+    elif mutation == "list":
+        value = []
+    elif mutation == "schema":
+        value["schema"] = 2
+    elif mutation == "schema_bool":
+        value["schema"] = True
+    elif mutation == "short_ids":
+        value["prompt_ids"].pop()
+    elif mutation == "negative_id":
+        value["prompt_ids"][0] = -1
+    elif mutation == "bool_id":
+        value["prompt_ids"][0] = True
+    elif mutation == "limit_zero":
+        value["max_matches"] = 0
+    elif mutation == "limit_large":
+        value["max_matches"] = 9
+    elif mutation == "limit_bool":
+        value["max_matches"] = True
+    else:
+        value["output_directory"] = ""
+    path.write_text(json.dumps(value))
+    with pytest.raises(ValueError):
+        ScoreJournal(path)
+    assert not (path.parent / "journal").exists()
+
+
+def begin(journal, **changes):
+    kwargs = dict(
+        prompt_ids=list(range(640)),
+        start_idx=0,
+        num_logits=639,
+        num_logprobs=0,
+        request_id="test",
+    )
+    return journal.begin(**(kwargs | changes))
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"start_idx": 1},
+        {"num_logits": 128},
+        {"num_logprobs": 1},
+    ],
+)
+def test_chunked_cached_or_topk_match_refused(config, changes):
+    journal = ScoreJournal(config[0])
+    with pytest.raises(ValueError, match="uncached"):
+        begin(journal, **changes)
+    assert journal.matches == 0
+    journal.close()
+
+
+def tensors():
+    hidden = torch.tensor([0.0, -0.0, 1.5], dtype=torch.bfloat16).repeat(639, 1)
+    return [
+        hidden,
+        hidden.float(),
+        hidden.float(),
+        torch.arange(1, 640),
+        torch.zeros(639, 1),
+    ]
+
+
+def test_complete_repeats_hash_raw_bits_without_mutation(config):
+    journal = ScoreJournal(config[0])
+    assert begin(journal, prompt_ids=[9] * 640) is None
+    assert journal.matches == 0
+    values = tensors()
+    expected = [
+        hashlib.sha256(t.view(torch.uint8).numpy().tobytes()).hexdigest()
+        for t in values
+    ]
+    for match in range(1, 4):
+        assert begin(journal) == match
+        for stage, tensor in zip(STAGES, values):
+            journal.record(match, stage, tensor)
+        journal.finish(match)
+    assert begin(journal, prompt_ids=[9] * 640) is None
+    with pytest.raises(ValueError, match="extra"):
+        begin(journal)
+    journal.close()
+    rows = [json.loads(line) for line in journal.path.read_text().splitlines()]
+    assert rows[0]["diagnostic_only"]
+    assert (
+        rows[0]["config_sha256"] == hashlib.sha256(config[0].read_bytes()).hexdigest()
+    )
+    assert len(rows) == 22
+    for match in range(1, 4):
+        records = [r for r in rows if r["kind"] == "tensor" and r["match"] == match]
+        assert [r["sha256"] for r in records] == expected
+        assert [r["dtype"] for r in records] == [str(t.dtype) for t in values]
+        assert records[-2]["values"] == list(range(1, 640))
+        assert records[-1]["values"] == [[0.0]] * 639
+        assert records[0]["values"] is None
+    assert expected == [
+        hashlib.sha256(t.view(torch.uint8).numpy().tobytes()).hexdigest()
+        for t in values
+    ]
+
+
+def test_order_overlap_and_wrong_ticket_refused(config):
+    journal = ScoreJournal(config[0])
+    with pytest.raises(ValueError, match="stage order"):
+        journal.record(0, STAGES[0], tensors()[0])
+    begin(journal)
+    with pytest.raises(ValueError, match="overlapping"):
+        begin(journal)
+    with pytest.raises(ValueError, match="incomplete"):
+        journal.finish(1)
+    for match, stage in [(2, STAGES[0]), (1, STAGES[1])]:
+        with pytest.raises(ValueError, match="stage order"):
+            journal.record(match, stage, tensors()[0])
+    for stage, tensor in zip(STAGES, tensors()):
+        journal.record(1, stage, tensor)
+    with pytest.raises(ValueError, match="stage order"):
+        journal.record(1, STAGES[-1], tensors()[-1])
+    journal.finish(1)
+    journal.close()
+
+
+@pytest.mark.parametrize("shape", [(), (638, 1), (639, 500000)])
+def test_tensor_bounds_before_copy(config, shape):
+    journal = ScoreJournal(config[0])
+    begin(journal)
+    # Meta tensors allocate no data; attempting CPU copy would fail differently.
+    tensor = torch.empty(shape, device="meta")
+    with pytest.raises(ValueError, match="byte bound"):
+        journal.record(1, STAGES[0], tensor)
+    journal.close()
+
+
+def test_noncontiguous_logical_bytes_and_final_vector_bound(config):
+    journal = ScoreJournal(config[0])
+    begin(journal)
+    tensor = torch.arange(639 * 4).reshape(639, 4)[:, ::2]
+    assert not tensor.is_contiguous()
+    for stage in STAGES[:3]:
+        journal.record(1, stage, tensor)
+    with pytest.raises(ValueError, match="one target"):
+        journal.record(1, STAGES[3], tensor)
+    journal.close()
+    row = json.loads(journal.path.read_text().splitlines()[2])
+    assert row["sha256"] == hashlib.sha256(tensor.numpy().tobytes()).hexdigest()

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Literal
 import torch
 
 import vllm.envs as envs
+from slimserve.moe_journal import instrument_marlin_gemm
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.scalar_type import ScalarType
@@ -2653,6 +2654,7 @@ def grouped_topk(
     )
 
 
+@instrument_marlin_gemm
 def moe_wna16_marlin_gemm(
     input: torch.Tensor,
     output: torch.Tensor | None,
@@ -3112,6 +3114,52 @@ def top_k_per_row_prefill(
     topk_tokens: int,
 ) -> None:
     torch.ops._C.top_k_per_row_prefill(
+        logits,
+        cu_seqlen_ks,
+        cu_seqlen_ke,
+        raw_topk_indices,
+        num_rows,
+        stride0,
+        stride1,
+        topk_tokens,
+    )
+
+
+def glm53_top_k_per_row_prefill(
+    logits: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+    raw_topk_indices: torch.Tensor,
+    num_rows: int,
+    stride0: int,
+    stride1: int,
+    topk_tokens: int,
+) -> None:
+    """Opt-in GLM pool-ID tie policy; native output order remains unspecified."""
+    torch.ops._C.glm53_top_k_per_row_prefill(
+        logits,
+        cu_seqlen_ks,
+        cu_seqlen_ke,
+        raw_topk_indices,
+        num_rows,
+        stride0,
+        stride1,
+        topk_tokens,
+    )
+
+
+def glm53_top_k_per_row_ordered(
+    logits: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+    raw_topk_indices: torch.Tensor,
+    num_rows: int,
+    stride0: int,
+    stride1: int,
+    topk_tokens: int,
+) -> None:
+    """Opt-in diagnostic fused pool order; production defaults stay unchanged."""
+    torch.ops._C.glm53_top_k_per_row_ordered(
         logits,
         cu_seqlen_ks,
         cu_seqlen_ke,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -147,6 +147,7 @@ if TYPE_CHECKING:
     VLLM_QWEN4_EXP_FP8_MAIN_KV: bool = False
     VLLM_QWEN4_EXP_TQ_MAIN_KV: bool = False
     VLLM_CUSTOM_AR_ALLOW_PCIE: bool = False
+    VLLM_CUSTOM_AR_MAX_SIZE_MB: int = 8
     VLLM_CUSTOM_AR_PCIE_MAX_BYTES: int = 0
     VLLM_QWEN4_EXP_SKINNY_GEMM: bool = False
     VLLM_QWEN4_EXP_SKINNY_W8: bool = False
@@ -1287,6 +1288,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # without that the P2P probe fails and the gate below still disables it.
     "VLLM_CUSTOM_AR_ALLOW_PCIE": lambda: (
         os.getenv("VLLM_CUSTOM_AR_ALLOW_PCIE", "False").lower() in ("true", "1")
+    ),
+    # Custom all-reduce buffer cap in MiB; messages above it fall back to
+    # NCCL. 8 covers decode; a prefill chunk's [tokens, hidden] reduce is
+    # larger (57 MB at 7001 tokens x 4096 bf16) and NCCL's PCIe ring ran it
+    # at 15 GB/s on rtx6000 (notebook 2026-09-07 "Prefill attribution").
+    "VLLM_CUSTOM_AR_MAX_SIZE_MB": lambda: int(
+        os.getenv("VLLM_CUSTOM_AR_MAX_SIZE_MB", "8")
     ),
     # PCIe-only custom allreduce: payloads above this many bytes fall back to
     # NCCL (0 = no extra cap). The one-shot kernel reads every peer's slice,

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -105,7 +105,11 @@ DECODE_GEMM_MAX_TOKENS = 16
 
 @cache
 def decode_gemm_enabled() -> bool:
-    if os.getenv("SLIMSERVE_DECODE_GEMM", "1") == "0" or not current_platform.is_cuda():
+    if (
+        os.getenv("SLIMSERVE_DECODE_GEMM", "1") == "0"
+        or not current_platform.is_cuda()
+        or not current_platform.has_device_capability(80)
+    ):
         return False
     from vllm.quixicore.ops import quixicore_ops
 
@@ -172,6 +176,7 @@ def decode_gemm_fp8_enabled() -> bool:
     if (
         os.getenv("SLIMSERVE_DECODE_GEMM_FP8", "1") == "0"
         or not current_platform.is_cuda()
+        or not current_platform.has_device_capability(80)
     ):
         return False
     from vllm.quixicore.ops import quixicore_ops

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -2,7 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Utility methods for model layers."""
 
+import os
 from collections.abc import Callable
+from functools import cache
 
 import torch
 
@@ -23,8 +25,6 @@ MOE_LAYER_ROUTER_GATE_SUFFIXES = {
     "shared_expert_gate",
     "expert_gate",
 }
-
-
 
 
 def get_token_bin_counts_and_mask(
@@ -92,6 +92,173 @@ def default_unquantized_gemm(
     bias: torch.Tensor | None = None,
 ):
     return torch.nn.functional.linear(x, weight, bias)
+
+
+# QuixiCore bf16 decode GEMM (csrc/quixicore/serving/bf16_decode_gemm.cuh): the
+# M <= 16 tensor-core kernel that replaces cuBLAS on the backbone projections
+# at decode. The M branch lives inside an opaque custom op so torch.compile
+# traces one graph for every batch size; the shape gate below mirrors the
+# kernel's `supports` (the shapes where it beat cuBLAS at every M).
+# SLIMSERVE_DECODE_GEMM=0 keeps cuBLAS for A/B and diagnosis.
+DECODE_GEMM_MAX_TOKENS = 16
+
+
+@cache
+def decode_gemm_enabled() -> bool:
+    if os.getenv("SLIMSERVE_DECODE_GEMM", "1") == "0" or not current_platform.is_cuda():
+        return False
+    from vllm.quixicore.ops import quixicore_ops
+
+    return quixicore_ops.has_decode_gemm()
+
+
+def decode_gemm_supports(n: int, k: int) -> bool:
+    return 2048 <= n <= 16384 and k >= 512 and k % 128 == 0
+
+
+def _quixicore_decode_linear_impl(
+    x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None
+) -> torch.Tensor:
+    x2 = x.reshape(-1, x.shape[-1])
+    if x2.shape[0] <= DECODE_GEMM_MAX_TOKENS and bias is None:
+        from vllm.quixicore.ops import quixicore_ops
+
+        out = quixicore_ops.decode_gemm(x2.contiguous(), weight)
+        return out.view(*x.shape[:-1], weight.shape[0])
+    return torch.nn.functional.linear(x, weight, bias)
+
+
+def _quixicore_decode_linear_fake(
+    x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None
+) -> torch.Tensor:
+    return x.new_empty((*x.shape[:-1], weight.shape[0]))
+
+
+direct_register_custom_op(
+    op_name="quixicore_decode_linear",
+    op_func=_quixicore_decode_linear_impl,
+    fake_impl=_quixicore_decode_linear_fake,
+)
+
+
+def cuda_unquantized_gemm(
+    layer: torch.nn.Module,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+):
+    if (
+        bias is None
+        and decode_gemm_enabled()
+        and x.dtype == torch.bfloat16
+        and weight.dtype == torch.bfloat16
+        and weight.dim() == 2
+        and weight.is_contiguous()
+        and decode_gemm_supports(weight.shape[0], weight.shape[1])
+    ):
+        return torch.ops.vllm.quixicore_decode_linear(x, weight, None)
+    return torch.nn.functional.linear(x, weight, bias)
+
+
+# QuixiCore FP8 block-scaled decode GEMM (csrc/quixicore/serving/fp8_decode_gemm.cuh):
+# the M <= 16 kernel for the FP8 swap-set linears (compressed-tensors block-FP8 scheme,
+# e4m3 weights with 128x128 fp32 scales). bf16 activations, the block scale applied
+# in the weight conversion, so the mma multiplies exactly the BF16 a checkpoint
+# dequant stores; one launch instead of activation quant + CUTLASS. Above 16 tokens
+# the op runs the stock CUTLASS w8a8 blockwise path (prefill numerics unchanged).
+# SLIMSERVE_DECODE_GEMM_FP8=0 keeps the stock path for every M.
+@cache
+def decode_gemm_fp8_enabled() -> bool:
+    if (
+        os.getenv("SLIMSERVE_DECODE_GEMM_FP8", "1") == "0"
+        or not current_platform.is_cuda()
+    ):
+        return False
+    from vllm.quixicore.ops import quixicore_ops
+
+    return quixicore_ops.has_decode_gemm_fp8()
+
+
+def decode_gemm_fp8_supports(n: int, k: int) -> bool:
+    return 1024 <= n <= 16384 and n % 8 == 0 and k >= 512 and k % 128 == 0
+
+
+def _cutlass_block_fp8_linear(
+    x2: torch.Tensor, weight: torch.Tensor, weight_scale: torch.Tensor
+) -> torch.Tensor:
+    from vllm import _custom_ops as ops
+    from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+        per_token_group_quant_fp8,
+    )
+
+    q_input, input_scale = per_token_group_quant_fp8(x2, 128, column_major_scales=True)
+    return ops.cutlass_scaled_mm(
+        q_input,
+        weight.t(),
+        out_dtype=x2.dtype,
+        scale_a=input_scale,
+        scale_b=weight_scale.t(),
+    )
+
+
+def _quixicore_fp8_block_linear_impl(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None,
+) -> torch.Tensor:
+    x2 = x.reshape(-1, x.shape[-1])
+    n = weight.shape[0]
+    if x2.shape[0] <= DECODE_GEMM_MAX_TOKENS and bias is None:
+        from vllm.quixicore.ops import quixicore_ops
+
+        out = quixicore_ops.decode_gemm_fp8(x2.contiguous(), weight, weight_scale)
+        return out.view(*x.shape[:-1], n)
+    out = _cutlass_block_fp8_linear(x2, weight, weight_scale)
+    if bias is not None:
+        out = out + bias
+    return out.view(*x.shape[:-1], n)
+
+
+def _quixicore_fp8_block_linear_fake(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None,
+) -> torch.Tensor:
+    return x.new_empty((*x.shape[:-1], weight.shape[0]))
+
+
+direct_register_custom_op(
+    op_name="quixicore_fp8_block_linear",
+    op_func=_quixicore_fp8_block_linear_impl,
+    fake_impl=_quixicore_fp8_block_linear_fake,
+)
+
+
+def maybe_quixicore_fp8_block_linear(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None,
+) -> torch.Tensor | None:
+    """The swap-set linear through the QuixiCore op when the layer qualifies
+    (bf16 input, e4m3 [N, K] weight with fp32 [N/128, K/128] scales, shape
+    inside the kernel's gate), else None so the caller keeps its own path."""
+    if (
+        decode_gemm_fp8_enabled()
+        and x.dtype == torch.bfloat16
+        and weight.dtype == torch.float8_e4m3fn
+        and weight.dim() == 2
+        and weight.is_contiguous()
+        and weight_scale.dtype == torch.float32
+        and weight_scale.is_contiguous()
+        and tuple(weight_scale.shape)
+        == ((weight.shape[0] + 127) // 128, weight.shape[1] // 128)
+        and decode_gemm_fp8_supports(weight.shape[0], weight.shape[1])
+    ):
+        return torch.ops.vllm.quixicore_fp8_block_linear(x, weight, weight_scale, bias)
+    return None
 
 
 def use_aiter_triton_gemm(n, m, k, dtype):
@@ -340,5 +507,7 @@ def dispatch_unquantized_gemm() -> Callable[..., torch.Tensor]:
         return rocm_unquantized_gemm
     elif current_platform.is_cpu():
         return cpu_unquantized_gemm
+    elif current_platform.is_cuda():
+        return cuda_unquantized_gemm
     else:
         return default_unquantized_gemm

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -104,7 +104,10 @@ DECODE_GEMM_MAX_TOKENS = 16
 
 
 @cache
+@torch.compiler.assume_constant_result
 def decode_gemm_enabled() -> bool:
+    # Process-fixed configuration/device: do not trace NVML/driver calls when
+    # this cache is cold during full-graph model compilation.
     if (
         os.getenv("SLIMSERVE_DECODE_GEMM", "1") == "0"
         or not current_platform.is_cuda()
@@ -172,6 +175,7 @@ def cuda_unquantized_gemm(
 # the op runs the stock CUTLASS w8a8 blockwise path (prefill numerics unchanged).
 # SLIMSERVE_DECODE_GEMM_FP8=0 keeps the stock path for every M.
 @cache
+@torch.compiler.assume_constant_result
 def decode_gemm_fp8_enabled() -> bool:
     if (
         os.getenv("SLIMSERVE_DECODE_GEMM_FP8", "1") == "0"

--- a/vllm/quixicore/ops.py
+++ b/vllm/quixicore/ops.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 
 import torch
 
+from slimserve.moe_journal import instrument_moe_sum
 from vllm.logger import init_logger
 
 if TYPE_CHECKING:
@@ -60,6 +61,121 @@ class quixicore_ops:
         except ImportError as e:
             logger.debug("QuixiCore-CUDA extension unavailable: %s", e)
             return False
+
+    @staticmethod
+    @cache
+    def has_glm_route_align() -> bool:
+        return quixicore_ops.is_available() and hasattr(_qc(), "glm_route_align")
+
+    @staticmethod
+    def glm_route_align(
+        logits: torch.Tensor,
+        bias: torch.Tensor,
+        topk: int,
+        scoring: int,
+        renormalize: bool,
+        scaling: float,
+        block_size: int,
+        max_padded: int,
+        max_blocks: int,
+        *,
+        stable: bool = False,
+    ) -> list[torch.Tensor]:
+        """Fused small-M routing: scored top-k with bias-only selection plus
+        the Marlin block alignment, one launch. Returns [topk_weights,
+        topk_ids, sorted_token_ids, expert_ids, num_tokens_post_padded]."""
+        native = _qc()
+        if stable and not hasattr(native, "glm_route_align_stable"):
+            raise RuntimeError("stable GLM routing requires rebuilt native kernels")
+        call = native.glm_route_align_stable if stable else native.glm_route_align
+        return call(
+            logits, bias, topk, scoring, renormalize, scaling, block_size,
+            max_padded, max_blocks,
+        )
+
+    @staticmethod
+    @cache
+    def has_moe_sum_add() -> bool:
+        return quixicore_ops.is_available() and hasattr(_qc(), "moe_sum_add")
+
+    @staticmethod
+    def glm_stable_align(
+        ids: torch.Tensor,
+        sorted_ids: torch.Tensor,
+        experts: torch.Tensor,
+        padded: torch.Tensor,
+        offsets: torch.Tensor,
+        block: int,
+    ) -> None:
+        """Checked, scoped SM120 stable alignment; outputs must be disjoint."""
+        native = _qc()
+        if not hasattr(native, "glm_stable_align"):
+            raise RuntimeError("stable GLM alignment requires rebuilt native kernels")
+        native.glm_stable_align(ids, sorted_ids, experts, padded, offsets, block)
+
+    @staticmethod
+    @cache
+    def has_decode_gemm() -> bool:
+        return quixicore_ops.is_available() and hasattr(_qc(), "decode_gemm")
+
+    @staticmethod
+    def decode_gemm(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor | None = None,
+        fp32_out: bool = False,
+    ) -> torch.Tensor:
+        """x[M, K] @ weight[N, K]^T (+ fp32 bias) for M <= 16 on tensor cores,
+        fp32 accumulation; the decode-shaped replacement for cuBLAS on the
+        backbone projections (N in 2048..16384, K a multiple of 128 >= 512)."""
+        return _qc().decode_gemm(x, weight, bias, fp32_out)
+
+    @staticmethod
+    @cache
+    def has_decode_gemm_fp8() -> bool:
+        return quixicore_ops.is_available() and hasattr(_qc(), "decode_gemm_fp8")
+
+    @staticmethod
+    def decode_gemm_fp8(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        scale: torch.Tensor,
+        bias: torch.Tensor | None = None,
+        fp32_out: bool = False,
+    ) -> torch.Tensor:
+        """x[M, K] (bf16) @ dequant(weight)[N, K]^T for M <= 16 on tensor cores,
+        where weight is float8_e4m3fn with fp32 128x128 block scales
+        [ceil(N/128), K/128] and dequant(w) = bf16(scale * w); fp32
+        accumulation. The FP8 swap-set's decode kernel (N in 1024..16384, N a
+        multiple of 8, K a multiple of 128 >= 512)."""
+        return _qc().decode_gemm_fp8(x, weight, scale, bias, fp32_out)
+
+    @staticmethod
+    def graph_factors() -> list[str]:
+        """Capabilities that change the traced computation graph (the MoE
+        runner and the unquantized linear pick their custom ops by them),
+        for VllmConfig.compute_hash: a compiled artifact from a build without
+        a kernel must not be reused by one with it."""
+        from slimserve.glm53_ordering import cache_factor
+        from vllm.model_executor.layers.utils import (
+            decode_gemm_enabled,
+            decode_gemm_fp8_enabled,
+        )
+
+        return [
+            f"moe_sum_add={quixicore_ops.has_moe_sum_add()}",
+            f"decode_gemm={decode_gemm_enabled()}",
+            f"decode_gemm_fp8={decode_gemm_fp8_enabled()}",
+            cache_factor(),
+        ]
+
+    @staticmethod
+    @instrument_moe_sum
+    def moe_sum_add(x: torch.Tensor, shared: torch.Tensor, out: torch.Tensor) -> None:
+        """out[t] = shared[t] + sum_k x[t, k] (bf16 in/out, fp32 accumulation):
+        the Marlin per-assignment sum, the finalize copy and the shared-expert
+        add in one launch."""
+        _qc().moe_sum_add(x, shared, out)
 
     # ------------------------------------------------------------------
     # DeepSeek-V4 multi-stream residual mixing (Ampere decode path)
@@ -159,6 +275,78 @@ class quixicore_ops:
             norm_weight,
             norm_eps,
         )
+
+    @staticmethod
+    def has_dsv4_mhc_modes() -> bool:
+        """True when the extension exposes the T == 1 mHC launch-mode switch."""
+        try:
+            return hasattr(_qc(), "set_dsv4_mhc_mode")
+        except Exception:
+            return False
+
+    @staticmethod
+    def set_dsv4_mhc_mode(mode: int) -> None:
+        """0 cooperative fused kernel, 1 last-block fused kernel, 2 split kernels."""
+        _qc().set_dsv4_mhc_mode(int(mode))
+
+    @staticmethod
+    def get_dsv4_mhc_mode() -> int:
+        return int(_qc().get_dsv4_mhc_mode())
+
+    @staticmethod
+    def has_dsv4_mhc_prefill() -> bool:
+        """True when the extension has the prefill-shaped mHC partials kernel."""
+        try:
+            return hasattr(_qc(), "set_dsv4_mhc_prefill_min_t")
+        except Exception:
+            return False
+
+    @staticmethod
+    def set_dsv4_mhc_prefill_min_t(min_t: int) -> None:
+        """Smallest T the split path hands to the prefill-shaped partials
+        kernel (0 = never; the env default is VLLM_DSV4_MHC_PREFILL_MIN_T)."""
+        _qc().set_dsv4_mhc_prefill_min_t(int(min_t))
+
+    @staticmethod
+    def get_dsv4_mhc_prefill_min_t() -> int:
+        return int(_qc().get_dsv4_mhc_prefill_min_t())
+
+    @staticmethod
+    def has_glm53_mhc_prefill_tc() -> bool:
+        try:
+            return hasattr(_qc(), "get_glm53_mhc_prefill_tc")
+        except Exception:
+            return False
+
+    @staticmethod
+    def set_glm53_mhc_prefill_tc(enabled: int) -> None:
+        """Diagnostic 0/1 switch; existing captured graphs do not change."""
+        _qc().set_glm53_mhc_prefill_tc(int(enabled))
+
+    @staticmethod
+    def get_glm53_mhc_prefill_tc() -> int:
+        return int(_qc().get_glm53_mhc_prefill_tc())
+
+    @staticmethod
+    def has_topk_sample() -> bool:
+        try:
+            return hasattr(_qc(), "topk_sample")
+        except Exception:
+            return False
+
+    @staticmethod
+    def topk_sample(
+        logits: torch.Tensor,
+        top_k: torch.Tensor,
+        top_p: torch.Tensor | None,
+        noise: torch.Tensor,
+    ) -> torch.Tensor:
+        """Top-k (<=32, all ties kept), stable-order top-p, and sampling.
+
+        Caller noise is fp32/fp64 [B, V], indexed by vocabulary ID. Top-p
+        sorts ascending by (logit, ID). Returns int64 token IDs [B].
+        """
+        return _qc().topk_sample(logits, top_k, top_p, noise)
 
     @staticmethod
     def dsv4_mhc_post(
@@ -1595,6 +1783,23 @@ class quixicore_ops:
             block_size,
             scale,
             partition_size,
+            page_stride_bytes,
+        )
+
+    @staticmethod
+    def mla_prefill_bf16_sparse_nope_sm120(
+        q: torch.Tensor,
+        kv: torch.Tensor,
+        block_table: torch.Tensor,
+        indices: torch.Tensor,
+        topk_length: torch.Tensor,
+        block_size: int,
+        scale: float,
+        page_stride_bytes: int = 0,
+    ) -> torch.Tensor:
+        """SM120 H16 prefill; BF16 Q/KV and FP16 P/V, no cache conversion."""
+        return _qc().mla_prefill_bf16_sparse_nope_sm120(
+            q, kv, block_table, indices, topk_length, block_size, scale,
             page_stride_bytes,
         )
 

--- a/vllm/v1/attention/backends/mla/quixicore_mla_sparse_prefill.py
+++ b/vllm/v1/attention/backends/mla/quixicore_mla_sparse_prefill.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Head-batched sparse MLA attention for prefill chunks (NoPE bf16 latents).
+
+`mla_decode_fp8_v<true, false, 512, 512, 0, 0>` walks a query token's
+top-k list with one warp per (head, token): every head re-reads the same
+gathered 1 KB rows and does its dot products on CUDA cores, which is the
+right shape for a decode step of a few tokens and the wrong one for a
+7000-token prefill chunk (11 x 5.75 ms of the c8 step). Here one program
+owns one query token and all of its heads: the local heads are the M
+dimension of two tensor-core products per 32-key tile (S = Q K^T, then
+O += P V with V the same gathered rows), with an online softmax per head.
+Indices are request-local token positions resolved through the token's
+block-table row exactly as the decode kernel resolves them; -1 entries
+and out-of-table entries are skipped; a row with no valid entry is 0.
+
+Numerics against the decode walk: the score products are the same bf16
+pairs summed in a different order, and the probabilities go through the
+P V product in fp16 (2^-11) instead of fp32; the outputs agree to one
+bf16 rounding of the result (max 1.6e-2 at values near 4, mean 1e-5).
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.triton_utils import tl, triton
+
+logger = init_logger(__name__)
+
+# Kill switch for A/B runs only (read here, so not a torch-compile cache
+# factor): VLLM_MLA_SPARSE_PREFILL_TC=0 keeps prefill chunks on the decode
+# walk.
+ENABLED = os.getenv("VLLM_MLA_SPARSE_PREFILL_TC", "1") != "0"
+# Enabled by the qualified RTX6000 profile; other profiles default to Triton.
+SWAPAB_ENABLED = os.getenv("VLLM_GLM53_SPARSE_PREFILL_SWAPAB", "0") == "1"
+
+LATENT = 512
+_BLOCK_N = 32  # keys per tile: 64 does not fit the 100 KB shared budget
+_NUM_WARPS = 4
+_NUM_STAGES = 2
+
+
+@triton.jit(do_not_specialize=["bt_stride", "max_topk"])
+def _sparse_mla_prefill_kernel(
+    q_ptr,  # [B, H, D] bf16
+    cache_ptr,  # bf16 pages: block * page_stride + slot * D
+    bt_ptr,  # [B, bt_stride] int32: the token's request's block table
+    idx_ptr,  # [B, max_topk] int32 request-local positions, -1 = skip
+    tlen_ptr,  # [B] int32 entries to walk (last valid + 1)
+    out_ptr,  # [B, H, D] bf16
+    max_topk,
+    bt_stride,
+    page_stride,
+    block_size,
+    scale,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    b = tl.program_id(0)
+    h = tl.arange(0, H)
+    d = tl.arange(0, D)
+    q = tl.load(q_ptr + (b.to(tl.int64) * H + h)[:, None] * D + d[None, :])
+    tlen = tl.load(tlen_ptr + b)
+    tlen = tl.minimum(tl.maximum(tlen, 0), max_topk)
+    # a finite floor instead of -inf so an all-skipped tile keeps the
+    # running max finite (exp(m_i - m_new) stays 1, not nan)
+    m_i = tl.full((H,), -1.0e30, tl.float32)
+    l_i = tl.zeros((H,), tl.float32)
+    acc = tl.zeros((H, D), tl.float32)
+    for j0 in range(0, tlen, BLOCK_N):
+        j = j0 + tl.arange(0, BLOCK_N)
+        t = tl.load(idx_ptr + b.to(tl.int64) * max_topk + j, mask=j < tlen, other=-1)
+        col = t // block_size
+        ok = (t >= 0) & (col < bt_stride)
+        blk = tl.load(bt_ptr + b.to(tl.int64) * bt_stride + col, mask=ok, other=-1)
+        ok = ok & (blk >= 0)
+        slot = t - col * block_size
+        rows = blk.to(tl.int64) * page_stride + slot.to(tl.int64) * D
+        k = tl.load(cache_ptr + rows[:, None] + d[None, :], mask=ok[:, None], other=0.0)
+        s = tl.dot(q, tl.trans(k)) * scale  # [H, BLOCK_N] fp32
+        s = tl.where(ok[None, :], s, float("-inf"))
+        m_new = tl.maximum(m_i, tl.max(s, axis=1))
+        alpha = tl.exp(m_i - m_new)
+        p = tl.exp(s - m_new[:, None])
+        l_i = l_i * alpha + tl.sum(p, axis=1)
+        acc = acc * alpha[:, None] + tl.dot(p.to(tl.float16), k.to(tl.float16))
+        m_i = m_new
+    out = tl.where(l_i[:, None] > 0.0, acc / l_i[:, None], 0.0)
+    tl.store(
+        out_ptr + (b.to(tl.int64) * H + h)[:, None] * D + d[None, :],
+        out.to(tl.bfloat16),
+    )
+
+
+def supports(q: torch.Tensor) -> bool:
+    """The kernel takes the heads as a tensor-core M dimension: a power of
+    two from 16 up (TP <= 4 for GLM-5.3-Flash's 64 heads)."""
+    H = q.shape[1]
+    return q.shape[-1] == LATENT and H >= 16 and (H & (H - 1)) == 0
+
+
+def sparse_mla_prefill_nope(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    indices: torch.Tensor,
+    topk_length: torch.Tensor,
+    block_size: int,
+    scale: float,
+    page_stride_bytes: int = 0,
+) -> torch.Tensor:
+    """Same contract as quixicore_ops.mla_decode_bf16_sparse_nope
+    (unpartitioned): returns [tokens, heads, 512] bf16."""
+    B, H, D = q.shape
+    assert supports(q), q.shape
+    assert q.is_contiguous() and indices.is_contiguous()
+    assert block_table.is_contiguous() and kv_cache.stride(-1) == 1
+    page_stride = (
+        page_stride_bytes // kv_cache.element_size()
+        if page_stride_bytes
+        else block_size * D
+    )
+    if B == 0:
+        return torch.empty_like(q)
+    if (
+        SWAPAB_ENABLED
+        and 2048 <= B <= 8192
+        and H == 16
+        and q.dtype == torch.bfloat16
+        and q.is_cuda
+        and q.data_ptr() % 4 == 0
+        and torch.cuda.get_device_capability(q.device) == (12, 0)
+    ):
+        from vllm.quixicore import quixicore_ops
+
+        logger.info_once("GLM53 SM120 H16 BF16 sparse swapAB prefill active.")
+        return quixicore_ops.mla_prefill_bf16_sparse_nope_sm120(
+            q,
+            kv_cache,
+            block_table,
+            indices,
+            topk_length,
+            block_size,
+            scale,
+            page_stride * kv_cache.element_size(),
+        )
+    out = torch.empty_like(q)
+    _sparse_mla_prefill_kernel[(B,)](
+        q,
+        kv_cache,
+        block_table,
+        indices,
+        topk_length,
+        out,
+        indices.shape[1],
+        block_table.shape[1],
+        page_stride,
+        block_size,
+        scale,
+        H=H,
+        D=D,
+        BLOCK_N=_BLOCK_N,
+        num_warps=_NUM_WARPS,
+        num_stages=_NUM_STAGES,
+    )
+    return out

--- a/vllm/v1/attention/backends/mla/quixicore_mla_sparse_prefill.py
+++ b/vllm/v1/attention/backends/mla/quixicore_mla_sparse_prefill.py
@@ -138,17 +138,18 @@ def sparse_mla_prefill_nope(
     ):
         from vllm.quixicore import quixicore_ops
 
-        logger.info_once("GLM53 SM120 H16 BF16 sparse swapAB prefill active.")
-        return quixicore_ops.mla_prefill_bf16_sparse_nope_sm120(
-            q,
-            kv_cache,
-            block_table,
-            indices,
-            topk_length,
-            block_size,
-            scale,
-            page_stride * kv_cache.element_size(),
-        )
+        if quixicore_ops.has("mla_prefill_bf16_sparse_nope_sm120"):
+            logger.info_once("GLM53 SM120 H16 BF16 sparse swapAB prefill active.")
+            return quixicore_ops.mla_prefill_bf16_sparse_nope_sm120(
+                q,
+                kv_cache,
+                block_table,
+                indices,
+                topk_length,
+                block_size,
+                scale,
+                page_stride * kv_cache.element_size(),
+            )
     out = torch.empty_like(q)
     _sparse_mla_prefill_kernel[(B,)](
         q,


### PR DESCRIPTION
## Scope — part 1/5 (94 files)

Native BF16/FP8 projections, route/alignment barriers, expert combine, mHC, small-k sampling, wide Marlin and H16 sparse prefill, with bindings, native tests and isolated probes. Core journal hooks are inert by default; rejected prototypes remain under benchmarks.

## Review stack — ready

Dependency order: #26 → #27 → #28 → #25 → #24. Each PR targets the preceding layer; #26 targets main. Retarget the next layer after its base lands. Do not land later layers independently or merge automatically.

| Part | PR | Scope | Files |
|---|---|---|---:|
| 1 | #26 | Native kernels, bindings, focused probes/tests | 94 |
| 2 | #27 | Serving recipe, platform integration, regressions | 83 |
| 3 | #28 | Numerical diagnostics and prefill qualification | 83 |
| 4 | #25 | Indexer/routing diagnostics and qualification | 57 |
| 5 | #24 | Campaign harnesses, evidence and roadmap | 55 |

## Review outcome — 2026-09-11

- #26: 13 inline findings resolved; 14 nits dispositioned. 99 CPU / 172 GPU passes, plus18 cold-compilation/dispatch regressions.
- #27: 17 inline findings resolved; six nits dispositioned. Layer/microbatch-owned Marlin scratch, BF16 combine fallback, sidecar/MTP/journal/sampler contract fixes. 137 CPU / 11 GPU passes plus17 final CPU cleanup checks. [Disposition](https://github.com/QuixiAI/SlimServe/pull/27#issuecomment-5640839113).
- #28: CodeRabbit completed a full83-file static review with no actionable defects. This is a [review comment](https://github.com/QuixiAI/SlimServe/pull/28#issuecomment-5640985715), not a formal GitHub approval.
- #25: nine inline findings resolved; four nits dispositioned. Fix172c68bf7 tightens diagnostic per-rank/set-tail/SASS/archive evidence and path/environment/device/probe handling. 107 CPU +1 inherited-environment +1 compiled-indexer GPU pass;23 expected unavailable-device/probe skips. [Disposition](https://github.com/QuixiAI/SlimServe/pull/25#issuecomment-5641266239).
- #24: ten actionable findings resolved; two test nits addressed,128 CPU passes.

All49 inline threads are resolved. CI guards pass and main conflicts are resolved. Fixes are committed as Auroter on their owning branches and merged forward, without force-push. No merge into main has occurred.

## Combined serving qualification

Target: four RTX PRO6000 Blackwell SM120 GPUs, stock600W, TP4/no EP/no speculation, explicit V1 runner. Canonical profile `glm53f-nvfp4-4` (alias `glm53-nvfp4-4`), recipe `glm53-redhatai-nvfp4-fp8-kda-tp4-v1`: RedHatAI NVFP4 experts, pinned FP8 sidecars/FP32 repairs, BF16 KV/head.

Final clean-tree `f9963f878` includes main0313f5228, the rebuilt native binding, independent Marlin scratch and all serving-review fixes. One boot, three exact1000-input/300-output cold-prefix repeats, no source changes/restarts/exclusions:

| Measurement | Median [min,max] |
|---|---:|
| c1 E2E tok/s | 156.838 [156.689,157.100] |
| c8 E2E tok/s | 577.605 [577.499,578.503] |
| c16 E2E tok/s | 782.960 [781.820,784.241] |
| cold32K engine TTFT ms | 2511.369 [2508.355,2513.162] |
| cold128K engine TTFT ms | 9921.773 [9896.923,9948.182] |

Exact tokens, text/image canaries and six retrieval contrasts pass;4096 scored text tokens, mean logprob -2.731236241. Exit0 and GPU release verified. Later part4 fixes change only diagnostics/tests/docs: no changes under csrc/, slimserve/ or vllm/ since this serving qualification. No additional model boot.

This preserves performance, not a paired speedup or a resolution of historical score-repeatability limits. Known recovered prompt-score allocation warnings remain; chunked scoring stays opt-in. Earlier failed startup receipts remain preserved. No A100, DBO, MTP or disabled-tier qualification is implied.

Raw local receipts: `perf/results/2026-09-11/pr-review/`, including `serving-final-review/` and `part4-{cpu,env,gpu}.xml`. [Baseline and limitations](https://github.com/QuixiAI/SlimServe/blob/glm53-flash-sm120/perf/baseline_status.md#rtx6000-final-combined-review-qualification---2026-09-11), [review map](https://github.com/QuixiAI/SlimServe/blob/glm53-flash-sm120/docs/glm53-flash-sm120-review.md), [roadmap](https://github.com/QuixiAI/SlimServe/blob/glm53-flash-sm120/docs/glm53-flash-sm120-plan.md).

## Why the split and remaining scope

The user authorized splitting only if needed. CodeRabbit confirmed the original365-file diff exceeded the configured100-file and absolute300-file limits, with no supported within-PR file batching. Every file remains in this stack; no test/diagnostic exclusions or path filters were added. The history join `e5d0ec096` preserved all original campaign commits and was byte-identical to `c41148025`. Intermediate layers are review units, not independently serving-qualified releases.

The17 original main conflicts and two later binding/indexer conflicts are resolved. SM120 retains its qualified BF16/raw-cache/V1 path; A100's compact-cache/FP8-decode/V2/DFlash2 work remains intact. The unrelated main defect in `glm53f-q2-1/metal` (missing `glm53f-gguf` source/FP8-KV note; eight known registry failures) remains documented rather than hidden by invented metadata.

Foundry, disabled host/NVMe tiers and external QuixiCore port-back are out of scope. Broader next-layer prefetch and persistent decode remain explicitly deferred, not claimed implemented or exhausted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optimized GLM-5.3 support for SM120 GPUs, including prefill, decode, sparse attention, MoE routing, and quantized GEMM paths.
  * Added faster BF16 and FP8 decode operations with automatic fallback for unsupported shapes.
  * Added deterministic GLM-5.3 top-k selection and sampling with consistent tie handling.
  * Added configurable mHC execution modes and prefill acceleration options.
  * Added a configurable limit for custom all-reduce buffers, with larger operations using NCCL.
* **Bug Fixes**
  * Improved synchronization around shared-memory reductions for more reliable kernel execution.
* **Tests**
  * Expanded correctness and compatibility coverage across new GPU kernels and execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->