### PR TITLE
[2/5] GLM53 SM120 serving recipe and platform integration

### DIFF
--- a/slimserve/campaign_sources.py
+++ b/slimserve/campaign_sources.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+"""One source catalog for GLM53 campaign clients and prepared source freezes."""
+
+import hashlib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PATHS = (
+    *(
+        f"benchmarks/{name}.py"
+        for name in (
+            "benchmark_glm53_campaign",
+            "benchmark_glm53_server",
+            "benchmark_glm53_b12x",
+            "benchmark_dsv4_exact",
+            "benchmark_glm53_quality",
+            "benchmark_glm53_prefill",
+        )
+    ),
+    "slimserve/campaign_sources.py",
+    "slimserve/smoke.py",
+    "slimserve/stream.py",
+    "slimserve/cli.py",
+    "slimserve/server.py",
+    "vllm/utils/jit_monitor.py",
+    "slimserve/glm53_ordering.py",
+    "slimserve/deterministic_reductions.py",
+    "slimserve/reduction_receipts.py",
+    "slimserve/rmsnorm_diagnostic.py",
+    "slimserve/rmsnorm_geometry.py",
+    "slimserve/kv_diagnostic.py",
+    "slimserve/indexer_correction_diagnostic.py",
+    "slimserve/prompt_score_diagnostic.py",
+    "slimserve/prompt_score_shadow.py",
+    "benchmarks/kernels/glm53_indexer_correction_serving.py",
+    "slimserve/glm53_serving_diagnostic.py",
+    "benchmarks/kernels/glm53_kv_serving.py",
+    "benchmarks/kernels/glm53_kv_loader.py",
+    "benchmarks/kernels/glm53_indexer_correction_loader.py",
+    "benchmarks/kernels/glm53_indexer_correction.py",
+    "benchmarks/kernels/audit_glm53_indexer_correction_graphs.py",
+    "benchmarks/kernels/glm53_loader_hooks.py",
+    "benchmarks/kernels/glm53_attention_overwrite.py",
+    "benchmarks/kernels/audit_glm53_kv_graphs.py",
+    "benchmarks/kernels/glm53_geometry_serving.py",
+    "benchmarks/kernels/glm53_geometry_loader.py",
+    "benchmarks/kernels/glm53_artifact_roots.py",
+    "benchmarks/kernels/glm53_binary_observer.py",
+    "benchmarks/kernels/glm53_rmsnorm_geometry.py",
+    "benchmarks/kernels/audit_glm53_geometry_graphs.py",
+    "benchmarks/kernels/check_glm53_cached_rmsnorm.py",
+    "vllm/v1/worker/gpu_model_runner.py",
+    "vllm/envs.py",
+    "vllm/v1/sample/prompt_logprobs.py",
+    "vllm/v1/sample/sampler.py",
+    "vllm/v1/sample/ops/logprobs.py",
+    "slimserve/canonical_moe.py",
+    "slimserve/canonical_indexer.py",
+    "vllm/model_executor/layers/fused_moe/router/glm_route_align.py",
+    "vllm/model_executor/layers/fused_moe/router/glm_stable_align.py",
+    "vllm/model_executor/layers/fused_moe/experts/marlin_moe.py",
+    "vllm/model_executor/layers/glm5_next_indexer.py",
+    "vllm/v1/attention/backends/mla/quixicore_mla_sparse_prefill.py",
+    "vllm/quixicore/ops.py",
+)
+
+
+def snapshot():
+    return {
+        name: hashlib.sha256((ROOT / name).read_bytes()).hexdigest() for name in PATHS
+    }

--- a/slimserve/canonical_indexer.py
+++ b/slimserve/canonical_indexer.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GLM pool-order policy and preserved diagnostic selection controls.
+
+The disabled factory returns the original callable. Enabled only in the GLM
+pooled indexer, with model/selector observers and canonical MoE also required.
+The two-kernel control retains its extra sorting launch. CANONICAL_INDEX_FUSED
+instead emits ordered IDs inside the qualified native selector; it remains an
+opt-in diagnostic until full-model qualification, not a production default.
+CANONICAL_INDEX_TIES additionally chooses smaller pool IDs at exact equal-score
+cutoffs in the native selector. It never changes scores or higher-score choices.
+NATIVE_ORDER selects the qualified fused selector without requiring observers;
+the legacy diagnostic switches retain their original prerequisites.
+"""
+
+import os
+from functools import wraps
+
+import torch
+
+from slimserve.glm53_ordering import enabled as native_order_enabled
+
+
+def enabled():
+    if native_order_enabled():
+        return True
+    value = os.getenv("SLIMSERVE_GLM53_CANONICAL_INDEX_ORDER", "0")
+    if value not in ("0", "1"):
+        raise ValueError("canonical index order flag must be 0 or 1")
+    if value == "1" and (
+        os.getenv("SLIMSERVE_GLM53_MODEL_JOURNAL") != "1"
+        or os.getenv("SLIMSERVE_GLM53_CANONICAL_MOE") != "1"
+        or not os.getenv("SLIMSERVE_GLM53_INDEX_JOURNAL")
+    ):
+        raise ValueError(
+            "canonical index order requires model/index traces and canonical MoE"
+        )
+    return value == "1"
+
+
+def canonicalize(indices):
+    if (
+        indices.dtype != torch.int32
+        or not indices.is_cuda
+        or not indices.is_contiguous()
+        or indices.dim() != 2
+        or not 1 <= indices.shape[0] <= 8192
+        or indices.shape[1] != 512
+    ):
+        raise ValueError(
+            "canonical index order requires contiguous CUDA int32 [1..8192,512]"
+        )
+    from slimserve.canonical_indexer_kernel import sort_selected_pools
+
+    sort_selected_pools(indices)
+
+
+def ties_enabled():
+    if native_order_enabled():
+        return True
+    value = os.getenv("SLIMSERVE_GLM53_CANONICAL_INDEX_TIES", "0")
+    if value not in ("0", "1"):
+        raise ValueError("canonical index ties flag must be 0 or 1")
+    if value == "1" and not enabled():
+        raise ValueError("canonical index ties requires canonical index order")
+    return value == "1"
+
+
+def _native_tie_selector():
+    from vllm import _custom_ops as ops
+
+    if not hasattr(torch.ops._C, "glm53_top_k_per_row_prefill"):
+        raise RuntimeError("canonical index ties requires a rebuilt native selector")
+    return ops.glm53_top_k_per_row_prefill
+
+
+def fused_enabled():
+    if native_order_enabled():
+        return True
+    value = os.getenv("SLIMSERVE_GLM53_CANONICAL_INDEX_FUSED", "0")
+    if value not in ("0", "1"):
+        raise ValueError("canonical index fusion flag must be 0 or 1")
+    if value == "1" and not ties_enabled():
+        raise ValueError("canonical index fusion requires canonical index ties")
+    return value == "1"
+
+
+def _native_fused_selector():
+    from vllm import _custom_ops as ops
+
+    if not hasattr(torch.ops._C, "glm53_top_k_per_row_ordered"):
+        raise RuntimeError("canonical index fusion requires a rebuilt native selector")
+    return ops.glm53_top_k_per_row_ordered
+
+
+def maybe_ordered_topk(function):
+    canonical_ties = ties_enabled()
+    fused = fused_enabled()
+    if not enabled():
+        return function
+    selector = (
+        _native_fused_selector()
+        if fused
+        else _native_tie_selector()
+        if canonical_ties
+        else function
+    )
+
+    @wraps(function)
+    def ordered(
+        logits,
+        cu_seqlen_ks,
+        cu_seqlen_ke,
+        raw_topk_indices,
+        num_rows,
+        stride0,
+        stride1,
+        topk_tokens,
+    ):
+        if num_rows != raw_topk_indices.shape[0] or topk_tokens != 512:
+            raise ValueError("canonical index order selector geometry changed")
+        result = selector(
+            logits,
+            cu_seqlen_ks,
+            cu_seqlen_ke,
+            raw_topk_indices,
+            num_rows,
+            stride0,
+            stride1,
+            topk_tokens,
+        )
+        if not fused:
+            canonicalize(raw_topk_indices)
+        return result
+
+    return ordered

--- a/slimserve/canonical_indexer.py
+++ b/slimserve/canonical_indexer.py
@@ -5,11 +5,14 @@ The disabled factory returns the original callable. Enabled only in the GLM
 pooled indexer, with model/selector observers and canonical MoE also required.
 The two-kernel control retains its extra sorting launch. CANONICAL_INDEX_FUSED
 instead emits ordered IDs inside the qualified native selector; it remains an
-opt-in diagnostic until full-model qualification, not a production default.
+qualified opt-in diagnostic, not a production default.
 CANONICAL_INDEX_TIES additionally chooses smaller pool IDs at exact equal-score
 cutoffs in the native selector. It never changes scores or higher-score choices.
 NATIVE_ORDER selects the qualified fused selector without requiring observers;
 the legacy diagnostic switches retain their original prerequisites.
+
+Selector timing and full-model parity records (not production speed claims):
+docs/glm53-flash-sm120-review.md, "Qualification record map".
 """
 
 import os

--- a/slimserve/canonical_indexer_kernel.py
+++ b/slimserve/canonical_indexer_kernel.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Quarantined ordering-only diagnostic; no score access or selection changes."""
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _sort_selected_pools(Indices):
+    row = tl.program_id(0)
+    col = tl.arange(0, 512)
+    selected = tl.load(Indices + row * 512 + col)
+    # Pool IDs are nonnegative and bounded by context, far below INT_MAX.
+    # Only the native -1 padding sentinel is moved behind the valid IDs.
+    keys = tl.where(selected == -1, 2147483647, selected)
+    ordered = tl.sort(keys, descending=False)
+    result = tl.where(ordered == 2147483647, -1, ordered)
+    tl.store(Indices + row * 512 + col, result)
+
+
+def sort_selected_pools(indices):
+    _sort_selected_pools[(indices.shape[0],)](indices, num_warps=4)

--- a/slimserve/canonical_moe.py
+++ b/slimserve/canonical_moe.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GLM53 ordering policy and the preserved diagnostic sorting control.
+
+Sort existing expert-contiguous alignment in place. This preserves routing,
+expert block counts, padding, and GEMM arithmetic, but adds one sorting launch.
+Legacy flags require the bounded model journal. NATIVE_ORDER instead selects
+the qualified native source-alignment kernels without enabling any observer;
+its serving caller fails closed rather than taking this sorting fallback.
+"""
+
+import os
+
+from slimserve.glm53_ordering import enabled as native_order_enabled
+
+
+def enabled():
+    if native_order_enabled():
+        return True
+    flag = os.environ.get("SLIMSERVE_GLM53_CANONICAL_MOE", "0")
+    if flag not in ("0", "1"):
+        raise ValueError("SLIMSERVE_GLM53_CANONICAL_MOE must be 0 or 1")
+    if flag == "1" and os.environ.get("SLIMSERVE_GLM53_MODEL_JOURNAL") != "1":
+        raise ValueError("canonical MoE diagnostic requires the bounded model journal")
+    return flag == "1"
+
+
+def stable_route_enabled():
+    if native_order_enabled():
+        return True
+    flag = os.environ.get("SLIMSERVE_GLM53_STABLE_ROUTE", "0")
+    if flag not in ("0", "1"):
+        raise ValueError("stable route flag must be 0 or 1")
+    if flag == "1" and not enabled():
+        raise ValueError("stable route diagnostic requires canonical MoE")
+    return flag == "1"
+
+
+def stable_align_enabled():
+    if native_order_enabled():
+        return True
+    flag = os.environ.get("SLIMSERVE_GLM53_STABLE_ALIGN", "0")
+    if flag not in ("0", "1"):
+        raise ValueError("stable align flag must be 0 or 1")
+    if flag == "1" and not enabled():
+        raise ValueError("stable align diagnostic requires canonical MoE")
+    return flag == "1"
+
+
+def geometry(tokens, topk, experts, block_size):
+    # The scoped router selects DISTINCT top8 experts for every token, so one
+    # expert owns at most `tokens` assignments, even for maximally skewed input.
+    if not (
+        type(tokens) is int
+        and 1 <= tokens <= 8192
+        and (topk, experts) == (8, 288)
+        and block_size in (8, 16, 32, 48, 64)
+    ):
+        raise ValueError("canonical MoE requires bounded GLM53 top8 routing")
+    max_padded = tokens * topk + experts * (block_size - 1)
+    if tokens * topk < experts:
+        max_padded = min(tokens * topk * block_size, max_padded)
+    return (
+        max_padded,
+        (max_padded + block_size - 1) // block_size,
+        ((tokens + block_size - 1) // block_size) * block_size,
+    )
+
+
+def canonicalize(sorted_ids, expert_ids, padded_count, *, tokens, block_size):
+    import torch
+
+    from slimserve.canonical_moe_kernel import sort_expert_assignments
+
+    capacity, max_blocks, max_expert_rows = geometry(tokens, 8, 288, block_size)
+    tensors = (sorted_ids, expert_ids, padded_count)
+    if (
+        any(t.dtype != torch.int32 or not t.is_contiguous() for t in tensors)
+        or not sorted_ids.is_cuda
+        or any(t.device != sorted_ids.device for t in tensors)
+        or sorted_ids.shape != (capacity,)
+        or expert_ids.shape != (max_blocks,)
+        or padded_count.shape != (1,)
+    ):
+        raise ValueError("canonical MoE alignment tensor contract changed")
+    sort_expert_assignments(
+        sorted_ids,
+        expert_ids,
+        padded_count,
+        tokens * 8,
+        block_size,
+        max_blocks,
+        max_expert_rows,
+    )

--- a/slimserve/canonical_moe_kernel.py
+++ b/slimserve/canonical_moe_kernel.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Quarantined ordering diagnostic; loaded only by an enabled intervention."""
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _sort_expert_assignments(
+    Sorted,
+    Experts,
+    Padded,
+    NUMEL: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    MAX_BLOCKS: tl.constexpr,
+    SCAN_SIZE: tl.constexpr,
+    SORT_SIZE: tl.constexpr,
+):
+    expert = tl.program_id(0)
+    block = tl.arange(0, SCAN_SIZE)
+    used_blocks = tl.load(Padded) // BLOCK_SIZE
+    owners = tl.load(Experts + block, block < MAX_BLOCKS, other=-1)
+    owned = (block < used_blocks) & (owners == expert)
+    start = tl.min(tl.where(owned, block, MAX_BLOCKS)) * BLOCK_SIZE
+    length = tl.sum(owned.to(tl.int32)) * BLOCK_SIZE
+    # Each CTA exclusively owns one existing expert-contiguous range. There is
+    # no inter-CTA dependency and no read/write of uninitialized capacity tails.
+    if length > 0:
+        offset = tl.arange(0, SORT_SIZE)
+        values = tl.load(Sorted + start + offset, offset < length, other=NUMEL)
+        ordered = tl.sort(values, descending=False)
+        tl.store(Sorted + start + offset, ordered, offset < length)
+
+
+def sort_expert_assignments(
+    sorted_ids, expert_ids, padded_count, numel, block_size, max_blocks, max_expert_rows
+):
+    _sort_expert_assignments[(288,)](
+        sorted_ids,
+        expert_ids,
+        padded_count,
+        numel,
+        block_size,
+        max_blocks,
+        triton.next_power_of_2(max_blocks),
+        triton.next_power_of_2(max_expert_rows),
+        num_warps=4 if max_expert_rows <= 1024 else 8,
+    )

--- a/slimserve/cli.py
+++ b/slimserve/cli.py
@@ -83,9 +83,34 @@ def _parser() -> argparse.ArgumentParser:
         "--engine-log",
         help="write the engine's own log here instead of discarding it",
     )
-    parser.add_argument(
+    profiler = parser.add_mutually_exclusive_group()
+    profiler.add_argument(
         "--torch-profile-dir",
         help="capture eight steady engine iterations after /start_profile",
+    )
+    profiler.add_argument(
+        "--cuda-profile",
+        action="store_true",
+        help="bounded CUDA profiler API ranges for an external process-tree trace",
+    )
+    parser.add_argument(
+        "--route-profile-dir",
+        help="diagnostic-only GLM53 routing capture; changes scheduling and timings",
+    )
+    parser.add_argument(
+        "--request-metrics",
+        action="store_true",
+        help="include engine request timings and cached prompt-token counts",
+    )
+    parser.add_argument(
+        "--jit-monitor-verbose",
+        action="store_true",
+        help="diagnostic: log every monitored JIT compilation and specialization",
+    )
+    parser.add_argument(
+        "--deterministic-reductions",
+        action="store_true",
+        help="diagnostic: fixed reductions for native-order GLM53 RTX6000",
     )
     parser.add_argument(
         "--enable-return-routed-experts",
@@ -117,6 +142,17 @@ def _help() -> None:
         ("--dry-run", "Print the resolved plan and stop."),
         ("--engine-log FILE", "Keep the engine's own log instead of discarding it."),
         ("--torch-profile-dir DIR", "Capture a bounded engine profile trace."),
+        ("--cuda-profile", "Enable bounded CUDA profiler API ranges for Nsight."),
+        ("--route-profile-dir DIR", "Capture actual GLM53 routing, not baseline TPS."),
+        ("--jit-monitor-verbose", "Log every monitored JIT compilation for diagnosis."),
+        (
+            "--deterministic-reductions",
+            "Qualify fixed GLM53 compiler reduction choices.",
+        ),
+        (
+            "--request-metrics",
+            "Include request timings and cached prompt-token counts.",
+        ),
         (
             "--enable-return-routed-experts",
             "Diagnostic MoE routing capture; adds overhead.",
@@ -264,14 +300,26 @@ def _show(plan: Plan) -> None:
     else:
         print(f"  platform  {registry.platform_title(plan.platform)} x{plan.gpus}")
     print(f"  model     {plan.entry_file}")
+    if plan.weight_recipe:
+        print(f"  recipe    {plan.weight_recipe['id']}")
+        print(f"  weights   {plan.weight_recipe['description']}")
     for key, value in sorted(plan.engine.items()):
         print(f"  {key:<9} {value}")
     if plan.speculative:
         spec = plan.source["speculator"]
         method = spec["engine"].get("method", "dspark")
-        print(f"  spec      {method} k={spec['engine']['num_speculative_tokens']}")
+        depth = plan.speculative_overrides.get(
+            "num_speculative_tokens", spec["engine"]["num_speculative_tokens"]
+        )
+        print(f"  spec      {method} k={depth}")
     for key, value in sorted(plan.env.items()):
-        print(f"  env       {key}={value}")
+        shadow = os.environ.get(key)
+        if shadow is not None and shadow != value:
+            # The profile's env applies with setdefault (engine.apply_env,
+            # server.start): the operator's value wins, so say so.
+            print(f"  env       {key}={value}  (shadowed: environment has {shadow})")
+        else:
+            print(f"  env       {key}={value}")
     for note in plan.notes:
         print(f"  note      {note}")
 
@@ -330,7 +378,7 @@ def main(argv: list[str] | None = None) -> int:
     if not machine.known:
         term.die(
             f"unrecognized hardware ({machine.device_name}); "
-            "slimserve runs on MI300X, A100 and Apple Silicon"
+            "slimserve runs on MI300X, A100, RTX PRO 6000 and Apple Silicon"
         )
 
     if blocked := registry.profile_blocked(profile_id, machine.platform):
@@ -408,6 +456,74 @@ def main(argv: list[str] | None = None) -> int:
                 },
             },
         )
+
+    if args.cuda_profile:
+        plan = replace(
+            plan,
+            engine={
+                **plan.engine,
+                "profiler_config": {
+                    "profiler": "cuda",
+                    "ignore_frontend": True,
+                    "max_iterations": 32,
+                },
+            },
+        )
+
+    if args.route_profile_dir:
+        from slimserve.routing_journal import diagnostic_plan
+
+        try:
+            plan = diagnostic_plan(plan, args.route_profile_dir)
+        except ValueError as error:
+            term.fail(str(error))
+            return 2
+
+    if args.request_metrics:
+        plan = replace(
+            plan,
+            engine={
+                **plan.engine,
+                "enable_prompt_tokens_details": True,
+                "enable_per_request_metrics": True,
+            },
+        )
+
+    if args.jit_monitor_verbose:
+        plan = replace(plan, engine={**plan.engine, "jit_monitor_verbose": True})
+
+    try:
+        from slimserve.glm53_ordering import validate_plan
+        from slimserve.indexer_correction_diagnostic import (
+            validate_plan as validate_indexer_correction,
+        )
+        from slimserve.kv_diagnostic import validate_plan as validate_kv_plan
+        from slimserve.prompt_score_diagnostic import (
+            validate_plan as validate_prompt_score_plan,
+        )
+        from slimserve.prompt_score_shadow import validate_plan as validate_shadow_plan
+        from slimserve.rmsnorm_diagnostic import validate_plan as validate_rmsnorm_plan
+        from slimserve.rmsnorm_geometry import validate_plan as validate_geometry_plan
+
+        validate_plan(plan)
+        validate_indexer_correction(plan)
+        validate_prompt_score_plan(plan)
+        validate_shadow_plan(plan)
+        validate_kv_plan(plan)
+        validate_rmsnorm_plan(plan)
+        validate_geometry_plan(plan)
+        if args.deterministic_reductions:
+            from slimserve.deterministic_reductions import diagnostic_plan
+
+            plan = diagnostic_plan(plan)
+            validate_indexer_correction(plan)
+            validate_prompt_score_plan(plan)
+            validate_shadow_plan(plan)
+            validate_kv_plan(plan)
+            validate_geometry_plan(plan)
+    except ValueError as error:
+        term.fail(str(error))
+        return 2
 
     if args.dry_run:
         _show(plan)

--- a/slimserve/deterministic_reductions.py
+++ b/slimserve/deterministic_reductions.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in GLM53 compiler-policy candidate, expressed in the recorded engine plan.
+
+Uses a supported, cache-keyed Inductor option. No generated-source mutation,
+runtime replacement, global PyTorch determinism or production default change.
+
+Not promoted: the 2026-09-10 full-model no-combo start repeated its scores exactly
+but failed 12/32 unchanged per-window quality gates. See the performance notebook.
+"""
+
+import copy
+import os
+from dataclasses import replace
+
+from slimserve import glm53_ordering
+
+
+def diagnostic_plan(plan):
+    if not glm53_ordering.enabled():
+        raise ValueError("deterministic reductions require native GLM53 ordering")
+    glm53_ordering.validate_plan(plan)
+    if os.getenv("SLIMSERVE_GLM53_RMSNORM_DIAGNOSTIC"):
+        raise ValueError(
+            "deterministic reductions cannot combine with cached RMSNorm intervention"
+        )
+    for flag in (
+        "TORCHINDUCTOR_DETERMINISTIC",
+        "TORCHINDUCTOR_BATCH_INVARIANT",
+        "TORCHINDUCTOR_FORCE_FILTER_REDUCTION_CONFIGS",
+        "VLLM_BATCH_INVARIANT",
+    ):
+        if os.getenv(flag, "0") not in ("", "0"):
+            raise ValueError(f"use the explicit compiler plan without global {flag}")
+    engine = copy.deepcopy(plan.engine)
+    options = engine.setdefault("compilation_config", {}).setdefault(
+        "inductor_compile_config", {}
+    )
+    # vLLM otherwise enables timed combo fusion. Inductor deliberately rejects
+    # that benchmarking under deterministic=True (fresh-model qualification,
+    # 2026-09-09). Disable this optional fusion in the candidate only. Merely
+    # disabling its timing gate would accept previously unqualified combinations.
+    policy = {
+        "deterministic": True,
+        "combo_kernels": False,
+        "benchmark_combo_kernel": False,
+    }
+    for key, value in policy.items():
+        if key in options and options[key] is not value:
+            raise ValueError(f"conflicting deterministic compiler option: {key}")
+    options.update(policy)
+    return replace(plan, engine=engine)

--- a/slimserve/deterministic_reductions.py
+++ b/slimserve/deterministic_reductions.py
@@ -5,7 +5,12 @@ Uses a supported, cache-keyed Inductor option. No generated-source mutation,
 runtime replacement, global PyTorch determinism or production default change.
 
 Not promoted: the 2026-09-10 full-model no-combo start repeated its scores exactly
-but failed 12/32 unchanged per-window quality gates. See the performance notebook.
+but failed 12/32 historical per-window quality gates. Against normal compilation,
+the hypothesis was repeatable reduction scheduling. Diagnostic c1/c8/c16 rates
+were 155.740/574.245/777.768 tok/s, not a speedup or accepted baseline. Raw:
+perf/results/2026-09-10/deterministic-no-combo-serving/fresh-a/.
+Full baseline, limits and decision: docs/glm53-flash-sm120-review.md,
+"Qualification record map". Do not resume this closed diagnostic campaign.
 """
 
 import copy

--- a/slimserve/engine.py
+++ b/slimserve/engine.py
@@ -108,6 +108,10 @@ def serve_argv(plan: Plan, host: str, port: int) -> list[str]:
         if isinstance(value, bool):
             if value:
                 argv.append(flag)
+            elif key == "async_scheduling":
+                # Omission means auto, not false. The bounded routing journal
+                # requires an explicit synchronous scheduler for step metadata.
+                argv.append("--no-async-scheduling")
         elif isinstance(value, (dict, list)):
             argv += [flag, json.dumps(value)]
         else:

--- a/slimserve/f32_overrides.py
+++ b/slimserve/f32_overrides.py
@@ -12,6 +12,10 @@ This tool reads only the affected byte ranges from the native shards (no
 full load) and writes ``<model>/f32-overrides.safetensors``; the glm5_next
 loader substitutes those tensors when the file is present.
 
+The partial reads are offline preparation, not a claimed serving-speed gain.
+The F32 repair's model comparison and artifact record are linked in
+docs/glm53-flash-sm120-review.md, "Qualification record map".
+
     python -m slimserve.f32_overrides --native /path/to/GLM-5.3-Flash \\
         --model /path/to/GLM-5.3-Flash-NVFP4
 """

--- a/slimserve/f32_overrides.py
+++ b/slimserve/f32_overrides.py
@@ -1,0 +1,170 @@
+"""Rebuild the F32 tensors that an NVFP4 conversion of GLM-5.3-Flash downcast.
+
+RedHatAI/GLM-5.3-Flash-NVFP4 (2026-08) stores the MoE router bias
+(``mlp.gate.e_score_correction_bias``), the KDA decay tensors (``A_log``,
+``dt_bias``) and the mHC base/scale vectors as BF16, while the native
+checkpoint keeps them in F32 and the serving model holds F32 parameters for
+them. The BF16 copies carry up to a 0.39% relative error (one BF16 ulp at
+values of 5-15), which is the same order as the per-layer spread of the
+router bias itself.
+
+This tool reads only the affected byte ranges from the native shards (no
+full load) and writes ``<model>/f32-overrides.safetensors``; the glm5_next
+loader substitutes those tensors when the file is present.
+
+    python -m slimserve.f32_overrides --native /path/to/GLM-5.3-Flash \\
+        --model /path/to/GLM-5.3-Flash-NVFP4
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import struct
+from collections import defaultdict
+from pathlib import Path
+
+import torch
+
+OVERRIDES_FILE = "f32-overrides.safetensors"
+
+# Checkpoint-name suffixes of the tensors the conversion downcast.
+SUFFIXES = (
+    "hc_attn_base",
+    "hc_attn_scale",
+    "hc_ffn_base",
+    "hc_ffn_scale",
+    "mlp.gate.e_score_correction_bias",
+    "self_attn.A_log",
+    "self_attn.dt_bias",
+)
+
+_DTYPES = {
+    "F32": torch.float32,
+    "BF16": torch.bfloat16,
+    "F16": torch.float16,
+    "F8_E4M3": torch.float8_e4m3fn,
+    "F8_E5M2": torch.float8_e5m2,
+}
+
+
+def _headers(model_dir: str) -> dict[str, tuple[dict, str, int]]:
+    """name -> (header entry, shard path, data section offset)."""
+    out: dict[str, tuple[dict, str, int]] = {}
+    index = Path(model_dir) / "model.safetensors.index.json"
+    if index.is_file():
+        names = set(json.loads(index.read_text())["weight_map"].values())
+        # The MTP shard ships outside the target's index.
+        if (Path(model_dir) / "model_mtp.safetensors").is_file():
+            names.add("model_mtp.safetensors")
+        shards = [str(Path(model_dir) / name) for name in sorted(names)]
+    else:
+        shards = sorted(glob.glob(os.path.join(model_dir, "*.safetensors")))
+        shards = [
+            path
+            for path in shards
+            if Path(path).name not in {OVERRIDES_FILE, "fp8-swapset.safetensors"}
+        ]
+    for shard in shards:
+        with open(shard, "rb") as fh:
+            n = struct.unpack("<Q", fh.read(8))[0]
+            header = json.loads(fh.read(n))
+        for name, entry in header.items():
+            if name != "__metadata__":
+                out[name] = (entry, shard, 8 + n)
+    return out
+
+
+def _read(entry: dict, shard: str, base: int) -> torch.Tensor:
+    start, end = entry["data_offsets"]
+    with open(shard, "rb") as fh:
+        fh.seek(base + start)
+        buf = bytearray(fh.read(end - start))
+    return torch.frombuffer(buf, dtype=_DTYPES[entry["dtype"]]).reshape(entry["shape"])
+
+
+def select(native: dict, converted: dict, skip_layer: int | None) -> list[str]:
+    """Names that are F32 in the native checkpoint but not in the conversion."""
+    names = []
+    for name, (entry, _, _) in native.items():
+        if not name.endswith(SUFFIXES) or entry["dtype"] != "F32":
+            continue
+        if skip_layer is not None and f".layers.{skip_layer}." in name:
+            continue
+        other = converted.get(name)
+        if other is None or other[0]["dtype"] == "F32":
+            continue
+        names.append(name)
+    return sorted(names)
+
+
+def build(
+    native_dir: str, model_dir: str, out: str | None = None, skip_layer: int | None = 45
+) -> Path:
+    native = _headers(native_dir)
+    converted = _headers(model_dir)
+    names = select(native, converted, skip_layer)
+    if not names:
+        raise SystemExit(
+            "nothing to override: the conversion already keeps these tensors in F32"
+        )
+    tensors: dict[str, torch.Tensor] = {}
+    err: dict[str, list[float]] = defaultdict(list)
+    for name in names:
+        t = _read(*native[name]).contiguous()
+        tensors[name] = t
+        c = _read(*converted[name]).float()
+        key = name.split(".", 3)[-1].split(".", 1)[-1] if ".layers." in name else name
+        err[key].append(((t - c).abs() / (t.abs() + 1e-9)).max().item())
+    from safetensors.torch import save_file
+
+    out_path = Path(out or os.path.join(model_dir, OVERRIDES_FILE))
+    save_file(
+        tensors,
+        str(out_path),
+        metadata={
+            "source": os.path.abspath(native_dir),
+            "purpose": "F32 tensors the NVFP4 conversion downcast to BF16",
+        },
+    )
+    print(
+        f"{len(tensors)} tensors, "
+        f"{sum(t.numel() * 4 for t in tensors.values())} bytes -> {out_path}"
+    )
+    for key, rel in sorted(err.items()):
+        print(
+            f"  {key:36s} n={len(rel):3d} "
+            f"max rel error of the conversion's copy {max(rel):.3%}"
+        )
+    return out_path
+
+
+def main(argv: list[str] | None = None) -> None:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument(
+        "--native",
+        required=True,
+        help="directory of the native (F32-carrying) checkpoint",
+    )
+    ap.add_argument(
+        "--model", required=True, help="directory of the converted checkpoint to serve"
+    )
+    ap.add_argument("--out", help=f"output file (default <model>/{OVERRIDES_FILE})")
+    ap.add_argument(
+        "--keep-mtp-layer",
+        action="store_true",
+        help="also override layer 45 (the MTP layer)",
+    )
+    args = ap.parse_args(argv)
+    build(
+        args.native,
+        args.model,
+        args.out,
+        skip_layer=None if args.keep_mtp_layer else 45,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/slimserve/fetch.py
+++ b/slimserve/fetch.py
@@ -220,6 +220,11 @@ def ensure(plan: Plan, assume_yes: bool = False) -> None:
     if plan.quant.assembly:
         _assemble(plan)
 
+    if plan.weight_recipe:
+        from slimserve.weight_recipe import ensure
+
+        ensure(plan)
+
 
 def _confirm() -> bool:
     try:

--- a/slimserve/fp8_swapset.py
+++ b/slimserve/fp8_swapset.py
@@ -173,6 +173,8 @@ def quantize_beta(w: torch.Tensor, tp_size: int) -> tuple[torch.Tensor, torch.Te
     block r of a [tp_size * BETA_ROWS, K] tensor (zeros after them), one scale
     row per rank, so the merged loader's plain row slice gives each rank its
     heads with a whole block scale of its own."""
+    if tp_size < 1:
+        raise ValueError("tp_size must be positive")
     n, k = w.shape
     if n % tp_size or n // tp_size > BETA_ROWS:
         raise ValueError(f"{n} beta rows do not shard over tp={tp_size}")
@@ -238,13 +240,15 @@ def build(
     self_quant_kda: bool = False,
     tp_size: int | None = None,
 ) -> Path:
+    if self_quant_kda and (tp_size is None or tp_size < 1):
+        raise SystemExit("--self-quant-kda requires a positive --tp-size")
     native = _headers(native_dir)
     converted = _headers(model_dir)
     names = select(native, converted, skip_layer)
     if not names:
         raise SystemExit("nothing to swap: no FP8 twins of BF16 conversion tensors")
     kda = select_kda(converted, skip_layer) if self_quant_kda else []
-    if self_quant_kda and (not kda or not tp_size):
+    if self_quant_kda and not kda:
         raise SystemExit("--self-quant-kda needs KDA BF16 tensors and --tp-size")
     group = _fp8_group_template(model_dir)
     group["targets"] = targets_for(names + kda)

--- a/slimserve/fp8_swapset.py
+++ b/slimserve/fp8_swapset.py
@@ -1,0 +1,422 @@
+"""Serve ZAI's own FP8 block tensors in place of a conversion's BF16 twins.
+
+The native GLM-5.3-Flash checkpoint stores the dense MLP, the shared experts
+and the DSA ``q_b_proj`` / ``o_proj`` (and ``q_a_proj`` / ``kv_a_proj_with_mqa``)
+as e4m3 with 128x128 F32 block scales; NVFP4 conversions such as
+RedHatAI/GLM-5.3-Flash-NVFP4 (2026-08) keep those modules as the BF16
+dequant of the same bytes, at twice the size (0.72 GB per GPU per token at
+TP=4). This tool reads only the affected byte ranges from the native shards
+and writes two files next to the served checkpoint:
+
+* ``<model>/fp8-swapset.safetensors``: the FP8 weights under their checkpoint
+  names and the scales renamed from ``weight_scale_inv`` to ``weight_scale``
+  (the compressed-tensors parameter name);
+* ``<model>/fp8-swapset.json``: the manifest - tensor list, the vLLM modules
+  they load into, and the compressed-tensors config group that quantizes
+  exactly those modules (copied from the checkpoint's own FP8 group so the
+  schema matches what the loader parses).
+
+When both files are present the loader substitutes the weights, injects the
+scales, and the quantization config gains the group; set
+``SLIMSERVE_FP8_SWAPSET=0`` to serve the BF16 twins for an A/B.
+
+``self_attn.q_a_proj`` / ``kv_a_proj_with_mqa`` are left out: they load into
+``fused_qkv_a_proj`` together with three indexer shards the native
+checkpoint keeps in BF16, and one module takes one scheme.
+
+``--self-quant-kda`` adds the KDA (linear-attention) projections, which every
+GLM-5.3-Flash checkpoint keeps in BF16: ``q/k/v/b/f_a/g_a_proj`` (the merged
+``in_proj_qkvgfab``) and the KDA ``o_proj`` are quantized here to the same
+128x128 block format (per-block absmax / 448). The merged projection's beta
+shard is 16 rows per rank, so its block scales cannot be sharded by the
+loader; the sidecar stores ``b_proj`` per rank, padded to 128 rows (zeros
+after the rank's rows) with one scale row per rank, and the model reserves
+128 beta rows per rank when the manifest lists the module. That layout is
+tensor-parallel specific: the manifest records ``tp_size`` and the loader
+refuses another. Quality is the experiment's gate, not a given.
+
+    python -m slimserve.fp8_swapset --native /path/to/GLM-5.3-Flash \\
+        --model /path/to/GLM-5.3-Flash-NVFP4
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+from collections import defaultdict
+from pathlib import Path
+
+import torch
+
+from slimserve.f32_overrides import _headers, _read
+
+SWAPSET_FILE = "fp8-swapset.safetensors"
+MANIFEST_FILE = "fp8-swapset.json"
+SWAPSET_ENV = "SLIMSERVE_FP8_SWAPSET"
+GROUP_NAME = "slimserve_fp8_swapset"
+BLOCK = 128
+
+# Checkpoint module suffix (after ``layers.N.``) -> vLLM module suffix it loads into.
+SWAP_MODULES = {
+    "mlp.gate_proj": "mlp.gate_up_proj",
+    "mlp.up_proj": "mlp.gate_up_proj",
+    "mlp.down_proj": "mlp.down_proj",
+    "mlp.shared_experts.gate_proj": "mlp.shared_experts.gate_up_proj",
+    "mlp.shared_experts.up_proj": "mlp.shared_experts.gate_up_proj",
+    "mlp.shared_experts.down_proj": "mlp.shared_experts.down_proj",
+    "self_attn.q_b_proj": "self_attn.q_b_proj",
+    "self_attn.o_proj": "self_attn.o_proj",
+    # KDA layers (self-quantized only; BF16 in the native checkpoint).
+    "self_attn.q_proj": "self_attn.in_proj_qkvgfab",
+    "self_attn.k_proj": "self_attn.in_proj_qkvgfab",
+    "self_attn.v_proj": "self_attn.in_proj_qkvgfab",
+    "self_attn.b_proj": "self_attn.in_proj_qkvgfab",
+    "self_attn.f_a_proj": "self_attn.in_proj_qkvgfab",
+    "self_attn.g_a_proj": "self_attn.in_proj_qkvgfab",
+}
+KDA_SUFFIXES = (
+    "self_attn.q_proj",
+    "self_attn.k_proj",
+    "self_attn.v_proj",
+    "self_attn.b_proj",
+    "self_attn.f_a_proj",
+    "self_attn.g_a_proj",
+    "self_attn.o_proj",
+)
+KDA_MARKER = "self_attn.b_proj"  # a tensor only the KDA layers carry
+BETA_SUFFIX = "self_attn.b_proj"
+BETA_ROWS = BLOCK  # rows per rank reserved for the beta shard of in_proj_qkvgfab
+FP8_MAX = 448.0  # float8_e4m3fn
+_LAYER_RE = re.compile(
+    r"^(?P<prefix>.*\.layers\.)(?P<layer>\d+)\.(?P<suffix>.+)\.weight$"
+)
+
+
+def enabled() -> bool:
+    return os.environ.get(SWAPSET_ENV, "1") != "0"
+
+
+def manifest_path(model_path: str | None) -> str | None:
+    if not model_path or not enabled():
+        return None
+    path = os.path.join(model_path, MANIFEST_FILE)
+    return path if os.path.isfile(path) else None
+
+
+def _split(name: str) -> tuple[str, int, str] | None:
+    m = _LAYER_RE.match(name)
+    if m is None:
+        return None
+    return m.group("prefix"), int(m.group("layer")), m.group("suffix")
+
+
+def select(native: dict, converted: dict, skip_layer: int | None) -> list[str]:
+    """Weight names that are FP8 in the native checkpoint, belong to a swap
+    module, have a block-scale companion, and are BF16 in the conversion."""
+    names = []
+    for name, (entry, _, _) in native.items():
+        parts = _split(name)
+        if parts is None or entry["dtype"] != "F8_E4M3":
+            continue
+        _, layer, suffix = parts
+        if suffix not in SWAP_MODULES or layer == skip_layer:
+            continue
+        scale = native.get(name[: -len(".weight")] + ".weight_scale_inv")
+        other = converted.get(name)
+        if scale is None or scale[0]["dtype"] != "F32":
+            continue
+        if other is None or other[0]["dtype"] != "BF16":
+            continue
+        names.append(name)
+    return sorted(names)
+
+
+def select_kda(converted: dict, skip_layer: int | None) -> list[str]:
+    """BF16 KDA projection weights of the conversion (layers that carry the
+    beta projection), to be self-quantized."""
+    names = []
+    for name, (entry, _, _) in converted.items():
+        parts = _split(name)
+        if parts is None or entry["dtype"] != "BF16":
+            continue
+        prefix, layer, suffix = parts
+        if suffix not in KDA_SUFFIXES or layer == skip_layer:
+            continue
+        if f"{prefix}{layer}.{KDA_MARKER}.weight" not in converted:
+            continue  # DSA layer: its o_proj is a native FP8 twin, not KDA
+        names.append(name)
+    return sorted(names)
+
+
+def quantize_block(w: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """128x128 block e4m3 (per-block absmax / 448) of a [N, K] weight; N may
+    end in a partial block, K must be a multiple of 128. Returns (fp8 [N, K],
+    f32 scale [ceil(N/128), K/128])."""
+    n, k = w.shape
+    if k % BLOCK:
+        raise ValueError(f"K={k} is not a multiple of {BLOCK}")
+    rows = (n + BLOCK - 1) // BLOCK
+    wp = torch.zeros(rows * BLOCK, k, dtype=torch.float32, device=w.device)
+    wp[:n] = w.float()
+    blocks = wp.view(rows, BLOCK, k // BLOCK, BLOCK)
+    amax = blocks.abs().amax(dim=(1, 3), keepdim=True).clamp(min=1e-12)
+    scale = amax / FP8_MAX
+    q = (blocks / scale).clamp(-FP8_MAX, FP8_MAX).to(torch.float8_e4m3fn)
+    return q.view(rows * BLOCK, k)[:n].contiguous(), scale.view(rows, k // BLOCK)
+
+
+def quantize_beta(w: torch.Tensor, tp_size: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """The beta projection [num_heads, K] laid out per rank: rank r's rows in
+    block r of a [tp_size * BETA_ROWS, K] tensor (zeros after them), one scale
+    row per rank, so the merged loader's plain row slice gives each rank its
+    heads with a whole block scale of its own."""
+    n, k = w.shape
+    if n % tp_size or n // tp_size > BETA_ROWS:
+        raise ValueError(f"{n} beta rows do not shard over tp={tp_size}")
+    local = n // tp_size
+    padded = torch.zeros(tp_size * BETA_ROWS, k, dtype=w.dtype, device=w.device)
+    for r in range(tp_size):
+        padded[r * BETA_ROWS : r * BETA_ROWS + local] = w[r * local : (r + 1) * local]
+    return quantize_block(padded)
+
+
+def targets_for(names: list[str]) -> list[str]:
+    """compressed-tensors ``re:`` targets on the vLLM module names, one per
+    (module suffix, layer set); explicit layer lists so a KDA ``o_proj``
+    never matches a DSA target."""
+    layers: dict[str, set[int]] = defaultdict(set)
+    for name in names:
+        _, layer, suffix = _split(name)
+        layers[SWAP_MODULES[suffix]].add(layer)
+    out = []
+    for suffix in sorted(layers):
+        ids = "|".join(str(i) for i in sorted(layers[suffix]))
+        out.append(rf"re:.*\.layers\.({ids})\.{re.escape(suffix)}$")
+    return out
+
+
+def _fp8_group_template(model_dir: str) -> dict:
+    """The checkpoint's own float-quantized block group (schema source)."""
+    with open(os.path.join(model_dir, "config.json")) as fh:
+        cfg = json.load(fh)
+    qc = cfg.get("quantization_config") or cfg.get("text_config", {}).get(
+        "quantization_config"
+    )
+    if not qc or qc.get("quant_method") != "compressed-tensors":
+        raise SystemExit("the served checkpoint is not a compressed-tensors model")
+    for group in qc.get("config_groups", {}).values():
+        w = group.get("weights") or {}
+        if (
+            group.get("format") == "float-quantized"
+            and w.get("strategy") == "block"
+            and list(w.get("block_structure") or []) == [BLOCK, BLOCK]
+        ):
+            return json.loads(json.dumps(group))
+    raise SystemExit(
+        "no float-quantized 128x128 block group in the checkpoint's "
+        "quantization_config to copy the schema from"
+    )
+
+
+def dequant_bf16(weight: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    n, k = weight.shape
+    rows, cols = scale.shape
+    w = torch.zeros(rows * BLOCK, cols * BLOCK, dtype=torch.float32)
+    w[:n, :k] = weight.float()
+    w = w.view(rows, BLOCK, cols, BLOCK) * scale.view(rows, 1, cols, 1)
+    return w.view(rows * BLOCK, cols * BLOCK)[:n, :k].to(torch.bfloat16)
+
+
+def build(
+    native_dir: str,
+    model_dir: str,
+    out: str | None = None,
+    skip_layer: int | None = 45,
+    self_quant_kda: bool = False,
+    tp_size: int | None = None,
+) -> Path:
+    native = _headers(native_dir)
+    converted = _headers(model_dir)
+    names = select(native, converted, skip_layer)
+    if not names:
+        raise SystemExit("nothing to swap: no FP8 twins of BF16 conversion tensors")
+    kda = select_kda(converted, skip_layer) if self_quant_kda else []
+    if self_quant_kda and (not kda or not tp_size):
+        raise SystemExit("--self-quant-kda needs KDA BF16 tensors and --tp-size")
+    group = _fp8_group_template(model_dir)
+    group["targets"] = targets_for(names + kda)
+    tensors: dict[str, torch.Tensor] = {}
+    mismatch: dict[str, list[tuple[int, int]]] = defaultdict(list)
+    qerr: dict[str, list[tuple[float, float]]] = defaultdict(list)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    for name in kda:
+        base = name[: -len(".weight")]
+        w = _read(*converted[name]).to(device)
+        if _split(name)[2] == BETA_SUFFIX:
+            q, sc = quantize_beta(w, tp_size)
+        else:
+            q, sc = quantize_block(w)
+        d = dequant_bf16(q.cpu(), sc.cpu()).float()
+        ref = torch.zeros_like(d)
+        if _split(name)[2] == BETA_SUFFIX:
+            local = w.shape[0] // tp_size
+            for r in range(tp_size):
+                ref[r * BETA_ROWS : r * BETA_ROWS + local] = (
+                    w[r * local : (r + 1) * local].float().cpu()
+                )
+        else:
+            ref = w.float().cpu()
+        err = d - ref
+        key = base.split(".layers.", 1)[1].split(".", 1)[1]
+        qerr[key].append(
+            (
+                (err.norm() / ref.norm().clamp(min=1e-12)).item(),
+                (err.abs().max() / ref.abs().max().clamp(min=1e-12)).item(),
+            )
+        )
+        tensors[name] = q.cpu()
+        tensors[base + ".weight_scale"] = sc.cpu()
+        del w, q, sc, d, ref, err
+    for name in names:
+        base = name[: -len(".weight")]
+        w = _read(*native[name]).contiguous()
+        s = _read(*native[base + ".weight_scale_inv"]).contiguous()
+        c = _read(*converted[name])
+        d = dequant_bf16(w, s)
+        diff = (d.view(torch.int16).int() - c.view(torch.int16).int()).abs()
+        key = base.split(".layers.", 1)[1].split(".", 1)[1]
+        mismatch[key].append((int((diff > 0).sum()), int(diff.max())))
+        tensors[name] = w
+        tensors[base + ".weight_scale"] = s
+    from safetensors.torch import save_file
+
+    out_path = Path(out or os.path.join(model_dir, SWAPSET_FILE))
+    save_file(
+        tensors,
+        str(out_path),
+        metadata={
+            "source": os.path.abspath(native_dir),
+            "purpose": "FP8 block tensors of the native checkpoint (weights + "
+            "weight_scale) replacing the conversion's BF16 dequant",
+        },
+    )
+    manifest = {
+        "source": os.path.abspath(native_dir),
+        "file": out_path.name,
+        "tensors": sorted(tensors),
+        "modules": sorted(
+            {
+                _split(n)[0].replace("model.language_model.", "language_model.model.")
+                + f"{_split(n)[1]}."
+                + SWAP_MODULES[_split(n)[2]]
+                for n in names + kda
+            }
+        ),
+        "config_group": group,
+    }
+    if kda:
+        manifest["self_quantized"] = kda
+        manifest["tp_size"] = tp_size
+        manifest["beta_rows"] = BETA_ROWS
+    manifest_file = out_path.with_name(MANIFEST_FILE)
+    with open(manifest_file, "w") as fh:
+        json.dump(manifest, fh, indent=1)
+    nbytes = sum(t.numel() * t.element_size() for t in tensors.values())
+    print(
+        f"{len(tensors)} tensors, {nbytes} bytes -> {out_path}; "
+        f"manifest {manifest_file}"
+    )
+    for key, rows in sorted(mismatch.items()):
+        elems = sum(n for n, _ in rows)
+        print(
+            f"  {key:36s} n={len(rows):3d} dequant vs conversion BF16: "
+            f"{elems} elements differ, max {max(m for _, m in rows)} bf16 ulp"
+        )
+    for key, rows in sorted(qerr.items()):
+        print(
+            f"  {key:36s} n={len(rows):3d} self-quantized: rel Frobenius error "
+            f"mean {sum(f for f, _ in rows) / len(rows):.4f} max "
+            f"{max(f for f, _ in rows):.4f}; worst element "
+            f"{max(m for _, m in rows):.4f} of the tensor's absmax"
+        )
+    return out_path
+
+
+def _manifest(model_path: str | None) -> dict | None:
+    path = manifest_path(model_path)
+    if path is None:
+        return None
+    with open(path) as fh:
+        return json.load(fh)
+
+
+def beta_shard_rows(model_path: str | None, module: str) -> int | None:
+    """Rows per rank the KDA layer must reserve for its beta shard when the
+    swap-set self-quantized ``module`` (a vLLM ``in_proj_qkvgfab`` name); None
+    keeps the model's own layout."""
+    manifest = _manifest(model_path)
+    if not manifest or not manifest.get("self_quantized"):
+        return None
+    # Compare from ``layers.N`` on: the model's prefix above it depends on the
+    # wrapping (multimodal vs text-only) while the manifest stores one form.
+    tail = module.split(".layers.", 1)[-1]
+    listed = {m.split(".layers.", 1)[-1] for m in manifest["modules"]}
+    return manifest["beta_rows"] if tail in listed else None
+
+
+def apply_config_group(model_path: str | None, hf_quant_config: dict | None) -> bool:
+    """Add the manifest's config group to a compressed-tensors quantization
+    config when the swap-set is present and enabled. Returns True if added."""
+    path = manifest_path(model_path)
+    if path is None or not hf_quant_config:
+        return False
+    if hf_quant_config.get("quant_method") != "compressed-tensors":
+        raise ValueError(f"{path}: the swap-set needs a compressed-tensors model")
+    with open(path) as fh:
+        manifest = json.load(fh)
+    groups = hf_quant_config.setdefault("config_groups", {})
+    groups[GROUP_NAME] = manifest["config_group"]
+    return True
+
+
+def hash_factor(model_path: str | None) -> str:
+    """Compile-cache factor: the manifest's digest, or 'off'."""
+    path = manifest_path(model_path)
+    if path is None:
+        return "fp8_swapset=off"
+    with open(path, "rb") as fh:
+        return "fp8_swapset=" + hashlib.sha256(fh.read()).hexdigest()[:16]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--native", required=True, help="native (FP8) checkpoint dir")
+    ap.add_argument("--model", required=True, help="served (converted) checkpoint dir")
+    ap.add_argument("--out", help=f"output file (default <model>/{SWAPSET_FILE})")
+    ap.add_argument(
+        "--skip-layer", type=int, default=45, help="layer to leave out (MTP head)"
+    )
+    ap.add_argument(
+        "--self-quant-kda",
+        action="store_true",
+        help="also quantize the BF16 KDA projections (needs --tp-size)",
+    )
+    ap.add_argument(
+        "--tp-size", type=int, help="tensor-parallel size the KDA beta layout is for"
+    )
+    args = ap.parse_args()
+    build(
+        args.native,
+        args.model,
+        args.out,
+        args.skip_layer,
+        self_quant_kda=args.self_quant_kda,
+        tp_size=args.tp_size,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/slimserve/glm53_serving_diagnostic.py
+++ b/slimserve/glm53_serving_diagnostic.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Explicit schema dispatch for the shared diagnostic serving harness."""
+
+from slimserve import (
+    indexer_correction_diagnostic,
+    kv_diagnostic,
+    prompt_score_diagnostic,
+    rmsnorm_geometry,
+)
+
+
+def policy(manifest):
+    for candidate in (
+        rmsnorm_geometry,
+        kv_diagnostic,
+        indexer_correction_diagnostic,
+        prompt_score_diagnostic,
+    ):
+        if manifest["serving_schema"] == candidate.SERVING_SCHEMA:
+            return candidate
+    raise ValueError("unknown diagnostic serving schema")
+
+
+def cases(manifest):
+    selected = policy(manifest)
+    if selected is not rmsnorm_geometry:
+        return selected.CASES
+    from benchmarks.kernels.prepare_glm53_geometry_serving import CASES
+
+    return CASES

--- a/slimserve/glm53_serving_diagnostic.py
+++ b/slimserve/glm53_serving_diagnostic.py
@@ -22,9 +22,4 @@ def policy(manifest):
 
 
 def cases(manifest):
-    selected = policy(manifest)
-    if selected is not rmsnorm_geometry:
-        return selected.CASES
-    from benchmarks.kernels.prepare_glm53_geometry_serving import CASES
-
-    return CASES
+    return policy(manifest).CASES

--- a/slimserve/hardware.py
+++ b/slimserve/hardware.py
@@ -166,6 +166,8 @@ def _classify(device_name: str) -> str | None:
         return "a100"
     if "3090" in lowered:
         return "rtx3090"
+    if "rtx pro 6000" in lowered:
+        return "rtx6000"
     return None
 
 

--- a/slimserve/index_journal.py
+++ b/slimserve/index_journal.py
@@ -1,0 +1,436 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded read-only selector trace for one repeated 8199-token GLM request.
+
+All hooks are absent when disabled. Copies/hashes are diagnostic synchronization;
+no GPU values are changed. Undefined logit tails are zeroed ONLY in private CPU
+copies before hashing. Save one configured layer's first chunk for offline replay.
+"""
+
+import hashlib
+import inspect
+import json
+import os
+import re
+from contextvars import ContextVar
+from functools import wraps
+from pathlib import Path
+
+import torch
+
+from slimserve.glm53_ordering import enabled as native_order_enabled
+
+ACTIVE = ContextVar("glm53_index_request", default=None)
+LAYER = ContextVar("glm53_index_layer", default=None)
+LAYERS = tuple(range(3, 44, 4))
+MAX_FILE_BYTES = 1024**3
+MAX_TENSOR_BYTES = 128 * 1024**2
+
+
+def enabled():
+    path = os.environ.get("SLIMSERVE_GLM53_INDEX_JOURNAL")
+    if path and (
+        os.environ.get("SLIMSERVE_GLM53_MODEL_JOURNAL") != "1"
+        or (
+            not native_order_enabled()
+            and os.environ.get("SLIMSERVE_GLM53_CANONICAL_MOE") != "1"
+        )
+    ):
+        raise ValueError(
+            "index journal requires bounded model journal and canonical MoE"
+        )
+    return bool(path)
+
+
+def cpu_logits(logits, starts, ends):
+    """Keep exactly the native operation's defined row ranges, without aliasing."""
+    if logits.dim() != 2:
+        raise ValueError("invalid indexer logit dimensions")
+    host = logits.detach().to(device="cpu", copy=True).contiguous()
+    lo, hi = (t.detach().cpu().contiguous() for t in (starts, ends))
+    rows, columns = host.shape
+    if (
+        host.dtype != torch.float32
+        or lo.dtype != torch.int32
+        or hi.dtype != torch.int32
+        or lo.shape != (rows,)
+        or hi.shape != (rows,)
+        or not bool(((lo >= 0) & (hi >= lo) & (hi <= columns)).all())
+    ):
+        raise ValueError("invalid indexer logit ranges")
+    col = torch.arange(columns)
+    host.masked_fill_((col[None, :] < lo[:, None]) | (col[None, :] >= hi[:, None]), 0)
+    return host, lo, hi
+
+
+class IndexJournal:
+    def __init__(self, config_path):
+        raw = config_path.read_bytes()
+        config = json.loads(raw)
+        if (
+            not isinstance(config, dict)
+            or set(config) - {"capture_layer"}
+            != {"schema", "prompt_ids", "max_matches", "output_directory"}
+            or type(config["schema"]) is not int
+            or config["schema"] != 1
+            or not isinstance(config["prompt_ids"], list)
+            or len(config["prompt_ids"]) != 8199
+            or any(type(i) is not int or i < 0 for i in config["prompt_ids"])
+            or type(config["max_matches"]) is not int
+            or not 1 <= config["max_matches"] <= 3
+            or not isinstance(config["output_directory"], str)
+            or not config["output_directory"]
+            or type(config.get("capture_layer", 3)) is not int
+            or config.get("capture_layer", 3) not in LAYERS
+        ):
+            raise ValueError(
+                "index journal requires 8199 token IDs, 1..3 matches "
+                "and a DSA capture layer"
+            )
+        self.prompt_ids = config["prompt_ids"]
+        self.limit = config["max_matches"]
+        self.capture_layer = config.get("capture_layer", 3)
+        self.match = self.cursor = self.chunk = self.saved_bytes = 0
+        self.request = self.device = None
+        self.in_forward = False
+        self.layers = []
+        self.layer_calls = 0
+        self.records = set()
+        directory = Path(config["output_directory"])
+        directory.mkdir(parents=True, exist_ok=True)
+        self.path = directory / f"index-{os.getpid()}.jsonl"
+        self.stream = self.path.open("x", buffering=1)
+        self.archive = directory / f"index-{os.getpid()}"
+        self.archive.mkdir(exist_ok=False)
+        root = Path(__file__).resolve().parents[1]
+        sources = (
+            "slimserve/canonical_indexer.py",
+            "slimserve/canonical_indexer_kernel.py",
+            "slimserve/index_journal.py",
+            "vllm/_custom_ops.py",
+            "vllm/model_executor/layers/glm5_next_indexer.py",
+            "vllm/v1/worker/gpu_model_runner.py",
+            "slimserve/canonical_moe.py",
+            "slimserve/glm53_ordering.py",
+            "slimserve/canonical_moe_kernel.py",
+            "vllm/model_executor/layers/fused_moe/experts/marlin_moe.py",
+        )
+        self.write(
+            {
+                "kind": "header",
+                "schema": 1,
+                "diagnostic_only": True,
+                "pid": os.getpid(),
+                "config_sha256": hashlib.sha256(raw).hexdigest(),
+                "prompt_ids": self.prompt_ids,
+                "max_matches": self.limit,
+                "max_chunks_per_match": 8,
+                "expected_layers": list(LAYERS),
+                "capture_layer": self.capture_layer,
+                "max_tensor_bytes": MAX_TENSOR_BYTES,
+                "max_worker_archive_bytes": MAX_FILE_BYTES,
+                "undefined_logit_tails": "zeroed in private CPU copies only",
+                "selection_order": (
+                    "canonical-pool-id"
+                    if native_order_enabled()
+                    or os.getenv("SLIMSERVE_GLM53_CANONICAL_INDEX_ORDER") == "1"
+                    else "native"
+                ),
+                "selection_ties": (
+                    "smaller-pool-id"
+                    if native_order_enabled()
+                    or os.getenv("SLIMSERVE_GLM53_CANONICAL_INDEX_TIES") == "1"
+                    else "native"
+                ),
+                "selection_order_implementation": (
+                    "native-bitonic"
+                    if native_order_enabled()
+                    or os.getenv("SLIMSERVE_GLM53_CANONICAL_INDEX_FUSED") == "1"
+                    else "post-sort"
+                    if os.getenv("SLIMSERVE_GLM53_CANONICAL_INDEX_ORDER") == "1"
+                    else "native"
+                ),
+                "implementation_sha256": {
+                    p: hashlib.sha256((root / p).read_bytes()).hexdigest()
+                    for p in sources
+                },
+            }
+        )
+
+    def write(self, item):
+        self.stream.write(json.dumps(item, separators=(",", ":")) + "\n")
+
+    def begin(self, request, computed, tokens, device):
+        if self.in_forward:
+            raise ValueError("overlapping index forward")
+        if computed == 0:
+            if self.request is not None or self.match >= self.limit:
+                raise ValueError("extra or overlapping index request")
+            self.match += 1
+            self.cursor = self.chunk = 0
+            self.request = request
+            self.device = str(device)
+            self.write(
+                {"kind": "request_begin", "match": self.match, "request_id": request}
+            )
+        if (
+            request != self.request
+            or computed != self.cursor
+            or str(device) != self.device
+            or not 1 <= tokens <= 8192
+            or computed + tokens > 8199
+            or self.chunk >= 8
+        ):
+            raise ValueError("index request chunk contract changed")
+        self.chunk += 1
+        self.in_forward = True
+        self.tokens = tokens
+        self.layers = []
+        self.write(
+            {
+                "kind": "forward_begin",
+                "match": self.match,
+                "chunk": self.chunk,
+                "computed_tokens": computed,
+                "tokens": tokens,
+                "device": self.device,
+            }
+        )
+
+    def snapshot(self, stage, tensor, save=False):
+        if not self.in_forward or re.fullmatch(r"[a-z0-9_.-]+", stage) is None:
+            raise ValueError("invalid index snapshot stage")
+        key = self.match, self.chunk, stage
+        if key in self.records:
+            raise ValueError("duplicate index snapshot")
+        self.records.add(key)
+        nbytes = tensor.numel() * tensor.element_size()
+        if not 0 < nbytes <= MAX_TENSOR_BYTES:
+            raise ValueError("index snapshot exceeds byte bound")
+        host = tensor.detach().cpu().contiguous()
+        digest = hashlib.sha256(
+            memoryview(host.reshape(-1).view(torch.uint8).numpy())
+        ).hexdigest()
+        item = {
+            "kind": "tensor",
+            "match": self.match,
+            "chunk": self.chunk,
+            "stage": stage,
+            "shape": list(host.shape),
+            "dtype": str(host.dtype),
+            "nbytes": nbytes,
+            "sha256": digest,
+        }
+        if save:
+            if host.storage_offset() or host.untyped_storage().nbytes() != nbytes:
+                host = host.clone()
+            if self.saved_bytes + nbytes + 65536 > MAX_FILE_BYTES:
+                raise ValueError("index archive exceeds worker byte bound")
+            path = self.archive / f"match-{self.match}-chunk-{self.chunk}-{stage}.pt"
+            with path.open("xb") as stream:
+                torch.save(host, stream)
+            size = path.stat().st_size
+            if size > nbytes + 65536:
+                raise ValueError("unexpected index archive overhead")
+            self.saved_bytes += size
+            with path.open("rb") as stream:
+                file_sha = hashlib.file_digest(stream, "sha256").hexdigest()
+            item["archive"] = {
+                "path": str(path),
+                "bytes": size,
+                "sha256": file_sha,
+                "worker_saved_bytes": self.saved_bytes,
+            }
+        self.write(item)
+
+    def finish(self):
+        if not self.in_forward or tuple(self.layers) != LAYERS:
+            raise ValueError("incomplete GLM indexer layer coverage")
+        self.in_forward = False
+        self.cursor += self.tokens
+        self.write(
+            {
+                "kind": "forward_complete",
+                "match": self.match,
+                "chunk": self.chunk,
+                "computed_tokens": self.cursor,
+                "layers": self.layers,
+            }
+        )
+        if self.cursor == 8199:
+            self.write(
+                {
+                    "kind": "request_complete",
+                    "match": self.match,
+                    "chunks": self.chunk,
+                    "worker_saved_bytes": self.saved_bytes,
+                }
+            )
+            self.request = None
+
+    def close(self):
+        self.stream.close()
+
+
+def instrument_pooled_indexer(function):
+    if not enabled():
+        return function
+    signature = inspect.signature(function)
+
+    @wraps(function)
+    def traced(*args, **kwargs):
+        journal = ACTIVE.get()
+        if journal is None:
+            return function(*args, **kwargs)
+        bound = signature.bind(*args, **kwargs)
+        bound.apply_defaults()
+        prefix = bound.arguments["k_cache_prefix"]
+        match = re.search(r"(?:^|\.)layers\.(\d+)\.", prefix)
+        if match is None or LAYER.get() is not None:
+            raise ValueError("unrecognized or nested indexer layer")
+        layer = int(match.group(1))
+        if len(journal.layers) >= len(LAYERS) or layer != LAYERS[len(journal.layers)]:
+            raise ValueError("indexer layer order changed")
+        journal.layers.append(layer)
+        journal.layer_calls = 0
+        journal.layer_rows = 0
+        token = LAYER.set(layer)
+        try:
+            result = function(*args, **kwargs)
+            if journal.layer_calls == 0 or journal.layer_rows != journal.tokens:
+                raise ValueError("incomplete indexer selector row coverage")
+            return result
+        finally:
+            LAYER.reset(token)
+
+    return traced
+
+
+def instrument_topk(function):
+    if not enabled():
+        return function
+    signature = inspect.signature(function)
+
+    @wraps(function)
+    def traced(*args, **kwargs):
+        journal, layer = ACTIVE.get(), LAYER.get()
+        if journal is None:
+            return function(*args, **kwargs)
+        if layer is None or journal.layer_calls >= 8:
+            raise ValueError("missing indexer layer or excess selector calls")
+        bound = signature.bind(*args, **kwargs)
+        bound.apply_defaults()
+        a = bound.arguments
+        logits, starts, ends, indices = (
+            a[k] for k in ("logits", "cu_seqlen_ks", "cu_seqlen_ke", "raw_topk_indices")
+        )
+        rows = a["num_rows"]
+        if (
+            not 1 <= rows <= journal.tokens
+            or logits.dim() != 2
+            or logits.shape[0] != rows
+            or not 1 <= logits.shape[1] <= 2049
+            or a["stride0"] != logits.stride(0)
+            or a["stride1"] != 1
+            or logits.stride(1) != 1
+            or a["topk_tokens"] != 512
+            or indices.shape != (rows, 512)
+            or indices.dtype != torch.int32
+            or any(
+                str(t.device) != journal.device for t in (logits, starts, ends, indices)
+            )
+        ):
+            raise ValueError("long-context index selector shape/recipe changed")
+        stage = f"layer-{layer:02d}.call-{journal.layer_calls}"
+        save = (
+            layer == journal.capture_layer
+            and journal.chunk == 1
+            and journal.layer_calls == 0
+        )
+        journal.layer_calls += 1
+        journal.layer_rows += rows
+        if journal.layer_rows > journal.tokens:
+            raise ValueError("excess indexer selector rows")
+        host, lo, hi = cpu_logits(logits, starts, ends)
+        journal.snapshot(stage + ".logits", host, save)
+        journal.snapshot(stage + ".starts", lo, save)
+        journal.snapshot(stage + ".ends", hi, save)
+        result = function(*args, **kwargs)
+        journal.snapshot(stage + ".indices", indices, save)
+        return result
+
+    return traced
+
+
+def install_index_journal(runner):
+    if not enabled():
+        return
+    config = runner.model_config.hf_text_config
+    if (
+        config.hidden_size != 4096
+        or config.num_hidden_layers != 45
+        or runner.parallel_config.tensor_parallel_size != 4
+        or runner.parallel_config.pipeline_parallel_size != 1
+        or runner.speculative_config is not None
+    ):
+        raise ValueError("index journal requires GLM53 TP4 no-spec")
+    journal = IndexJournal(Path(os.environ["SLIMSERVE_GLM53_INDEX_JOURNAL"]))
+    runner._slimserve_index_journal = journal
+    original = runner._model_forward
+
+    @wraps(original)
+    def traced(**kwargs):
+        requests = [
+            rid
+            for rid in runner.num_prompt_logprobs
+            if runner.requests[rid].prompt_token_ids == journal.prompt_ids
+        ]
+        if not requests:
+            if journal.request is not None:
+                raise ValueError("incomplete long-context request disappeared")
+            return original(**kwargs)
+        if len(requests) != 1 or runner.input_batch.num_reqs != 1:
+            raise ValueError("index journal requires one unmixed request")
+        rid = requests[0]
+        if runner.num_prompt_logprobs[rid] != 0:
+            raise ValueError("index journal requires target-only prompt scores")
+        input_ids, embeds, positions = (
+            kwargs.get(k) for k in ("input_ids", "inputs_embeds", "positions")
+        )
+        tokens = input_ids if input_ids is not None else embeds
+        if (
+            tokens is None
+            or not tokens.is_cuda
+            or torch.cuda.is_current_stream_capturing()
+        ):
+            raise ValueError("index journal requires uncaptured CUDA prefill")
+        computed = runner.requests[rid].num_computed_tokens
+        journal.begin(rid, computed, tokens.shape[0], tokens.device)
+        if positions.cpu().tolist() != list(
+            range(computed, computed + tokens.shape[0])
+        ):
+            raise ValueError("index request positions changed")
+        if input_ids is not None:
+            if (
+                input_ids.cpu().tolist()
+                != journal.prompt_ids[computed : computed + tokens.shape[0]]
+            ):
+                raise ValueError("index request token IDs changed")
+            journal.snapshot("forward.input_ids", input_ids)
+        if embeds is not None:
+            journal.snapshot("forward.inputs_embeds", embeds)
+        journal.snapshot("forward.positions", positions)
+        token = ACTIVE.set(journal)
+        try:
+            result = original(**kwargs)
+            if not isinstance(result, torch.Tensor) or result.shape != (
+                tokens.shape[0],
+                4096,
+            ):
+                raise ValueError("long-context model output changed")
+            journal.snapshot("forward.output", result)
+            journal.finish()
+            return result
+        finally:
+            ACTIVE.reset(token)
+
+    runner._model_forward = traced

--- a/slimserve/indexer_correction_diagnostic.py
+++ b/slimserve/indexer_correction_diagnostic.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Explicit indexer cancellation diagnostic; inert on production profiles."""
+
+import os
+import sys
+
+from slimserve import glm53_ordering, kv_diagnostic
+
+FLAG = "SLIMSERVE_GLM53_INDEXER_CORRECTION"
+MANIFEST = "SLIMSERVE_GLM53_INDEXER_CORRECTION_MANIFEST"
+SCHEMA = "glm53-indexer-correction-loader-v1"
+SERVING_SCHEMA = "glm53-indexer-correction-serving-v1"
+AOT_PAIR_SHA = "89fecf567bfe98ebcdb8ae6b948db7ad7387f4492877cba52c1f90ba65206061"
+CASES = (
+    ("control", "control"),
+    ("correction", "correction"),
+    ("return-control", "control"),
+)
+
+
+def mode():
+    value = os.getenv(FLAG, "")
+    if value not in ("", "control", "correction"):
+        raise ValueError(f"{FLAG} must be absent, control or correction")
+    return value
+
+
+def validate_environment():
+    kv_diagnostic.validate_environment()
+    if os.getenv(kv_diagnostic.FLAG):
+        raise ValueError("indexer correction cannot combine with KV diagnostic")
+
+
+def read_manifest():
+    from benchmarks.kernels import prepare_glm53_indexer_correction_serving
+
+    return kv_diagnostic.read_manifest(
+        workflow=sys.modules[__name__],
+        preparation=prepare_glm53_indexer_correction_serving,
+    )
+
+
+def validate_plan(plan):
+    if not mode():
+        return
+    validate_environment()
+    glm53_ordering.validate_plan(plan)
+    options = plan.engine.get("compilation_config", {}).get(
+        "inductor_compile_config", {}
+    )
+    if (
+        plan.engine.get("kv_cache_dtype", "auto") != "auto"
+        or plan.engine.get("dtype", "auto") not in ("auto", "bfloat16", "bf16")
+        or options.get("deterministic")
+        or options.get("combo_kernels") is False
+    ):
+        raise ValueError(
+            "indexer correction preserves BF16 and original compiler policy"
+        )
+    read_manifest()
+
+
+def install(runner):
+    if not mode():
+        return
+    validate_environment()
+    import torch
+
+    from benchmarks.kernels.glm53_indexer_correction_serving import (
+        ServingIndexerCorrection,
+        runtime_envelope,
+    )
+
+    config, parallel = runner.model_config.hf_text_config, runner.parallel_config
+    options = runner.compilation_config.inductor_compile_config
+    if (
+        config.hidden_size != 4096
+        or config.num_hidden_layers != 45
+        or parallel.tensor_parallel_size != 4
+        or parallel.pipeline_parallel_size != 1
+        or parallel.enable_expert_parallel
+        or runner.speculative_config is not None
+        or torch.cuda.get_device_capability() != (12, 0)
+        or runner.dtype is not torch.bfloat16
+        or runner.kv_cache_dtype is not torch.bfloat16
+        or options.get("deterministic")
+        or options.get("combo_kernels") is False
+        or getattr(runner, "_slimserve_indexer_correction", None) is not None
+    ):
+        raise ValueError(
+            "indexer correction requires original-policy GLM53 SM120 TP4, once"
+        )
+    manifest, path = read_manifest()
+    runtime_envelope(runner, manifest["selection_capacity"])
+    diagnostic = ServingIndexerCorrection(parallel.rank, manifest, path)
+    diagnostic.install(runner)
+    runner._slimserve_indexer_correction = diagnostic

--- a/slimserve/kv_diagnostic.py
+++ b/slimserve/kv_diagnostic.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in GLM53 KV arithmetic isolation; never a production compiler policy."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from slimserve import glm53_ordering, rmsnorm_diagnostic, rmsnorm_geometry
+
+FLAG = "SLIMSERVE_GLM53_KV_DIAGNOSTIC"
+MANIFEST = "SLIMSERVE_GLM53_KV_MANIFEST"
+SERVING_SCHEMA = "glm53-kv-serving-v1"
+AOT_PAIR_SHA = "e650a2a5f806085ab6f748169b1d54cf8950a2fd7656dfeda11d5e6f25a018f7"
+CASES = (("control", "control"), ("kv", "kv"), ("return-control", "control"))
+
+
+def mode():
+    value = os.getenv(FLAG, "")
+    if value not in ("", "control", "kv"):
+        raise ValueError(f"{FLAG} must be absent, control or kv")
+    return value
+
+
+def validate_environment():
+    rmsnorm_geometry.validate_environment()
+    if os.getenv(rmsnorm_geometry.FLAG):
+        raise ValueError("KV cannot combine with the RMSNorm geometry diagnostic")
+
+
+def read_manifest(*, workflow=None, preparation=None):
+    from benchmarks.kernels.check_glm53_attention_norms import require, verify
+    from benchmarks.kernels.glm53_kv_loader import SCHEMA as KV_SCHEMA
+
+    if preparation is None:
+        from benchmarks.kernels import prepare_glm53_kv_serving as preparation
+    workflow = workflow or sys.modules[__name__]
+    schema = getattr(workflow, "SCHEMA", KV_SCHEMA)
+
+    selected = workflow.mode()
+    workflow.validate_environment()
+    require(
+        bool(selected) and bool(os.getenv(workflow.MANIFEST)),
+        "diagnostic manifest required",
+    )
+    path = Path(os.environ[workflow.MANIFEST]).resolve()
+    data = json.loads(path.read_text())
+    private, original = (
+        Path(data["private_namespace"]),
+        Path(data["original_namespace"]),
+    )
+    cache = path.parent / "cache"
+    require(
+        data["serving_schema"] == workflow.SERVING_SCHEMA
+        and data["schema"] == schema
+        and data["mode"] == selected
+        and data["namespace"] == rmsnorm_diagnostic.NAMESPACE
+        and data["aot_qualification_sha256"] == workflow.AOT_PAIR_SHA
+        and data["cache_root"] == str(cache)
+        and private
+        == cache / "torch_compile_cache/torch_aot_compile" / data["namespace"]
+        and data["receipts"] == str(path.parent / "receipts")
+        and data["worker_receipts"] == str(path.parent / "worker-receipts")
+        and path.parent.name == data["label"]
+        and (data["label"], selected) in workflow.CASES,
+        "unexpected KV serving manifest or private paths",
+    )
+    require(
+        private.resolve() == private
+        and original.resolve() == original
+        and not private.is_relative_to(original)
+        and not original.is_relative_to(private)
+        and os.getenv("VLLM_CACHE_ROOT") == str(cache)
+        and os.getenv("TORCHINDUCTOR_CACHE_DIR") == str(private / "inductor_cache"),
+        "KV requires exact nonoverlapping private caches",
+    )
+    prepared = json.loads((path.parent.parent / "preparation.json").read_text())
+    require(
+        prepared["status"] == "prepared"
+        and prepared["sources"] == data["sources"]
+        and prepared["integration_changes"] == data["integration_changes"]
+        and prepared["git_commit"]
+        == data["git_commit"]
+        == subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+        and [(r["label"], r["mode"]) for r in prepared["runs"]] == list(workflow.CASES),
+        "prepared KV serving identity or case order changed",
+    )
+    for row in prepared["runs"]:
+        expected = path.parent.parent / row["label"] / "manifest.json"
+        require(
+            row["manifest"] == str(expected)
+            and row["manifest_sha256"] == rmsnorm_diagnostic.sha(expected),
+            "prepared KV serving manifest changed",
+        )
+    qualified, graphs, reference, receipts = preparation.completed_evidence(
+        Path(data["aot_pair_path"])
+    )
+    sources, changes = preparation.serving_sources(qualified["sources"])
+    sources.update(receipts)
+    require(
+        data["qualified_manifest"] == reference
+        and data["qualified_graphs"] == graphs
+        and data["integration_changes"] == changes
+        and all(data["sources"].get(p) == h for p, h in sources.items())
+        and all(
+            data[k] == qualified[k] for k in preparation.COMMON_FIELDS if k != "sources"
+        ),
+        "KV serving differs from completed AOT qualification",
+    )
+    verify(data)
+    return data, path
+
+
+def validate_plan(plan):
+    if not mode():
+        return
+    validate_environment()
+    glm53_ordering.validate_plan(plan)
+    options = plan.engine.get("compilation_config", {}).get(
+        "inductor_compile_config", {}
+    )
+    if (
+        plan.engine.get("kv_cache_dtype", "auto") != "auto"
+        or plan.engine.get("dtype", "auto") not in ("auto", "bfloat16", "bf16")
+        or options.get("deterministic")
+        or options.get("combo_kernels") is False
+    ):
+        raise ValueError(
+            "KV diagnostic preserves BF16 activation/KV and original compiler policy"
+        )
+    read_manifest()
+
+
+def install(runner):
+    if not mode():
+        return
+    validate_environment()
+    import torch
+
+    from benchmarks.kernels.glm53_kv_serving import ServingKV
+
+    config, parallel = runner.model_config.hf_text_config, runner.parallel_config
+    options = runner.compilation_config.inductor_compile_config
+    if (
+        config.hidden_size != 4096
+        or config.num_hidden_layers != 45
+        or parallel.tensor_parallel_size != 4
+        or parallel.pipeline_parallel_size != 1
+        or parallel.enable_expert_parallel
+        or runner.speculative_config is not None
+        or torch.cuda.get_device_capability() != (12, 0)
+        or runner.dtype is not torch.bfloat16
+        or runner.kv_cache_dtype is not torch.bfloat16
+        or options.get("deterministic")
+        or options.get("combo_kernels") is False
+        or getattr(runner, "_slimserve_kv_diagnostic", None) is not None
+    ):
+        raise ValueError(
+            "KV diagnostic requires original-policy GLM53 SM120 TP4, installed once"
+        )
+    manifest, path = read_manifest()
+    diagnostic = ServingKV(parallel.rank, manifest, path)
+    diagnostic.install(runner)
+    runner._slimserve_kv_diagnostic = diagnostic

--- a/slimserve/profiles.json
+++ b/slimserve/profiles.json
@@ -1,5 +1,9 @@
 {
   "schema": 1,
+  "profile_aliases": {
+    "glm53-nvfp4-4": "glm53f-nvfp4-4",
+    "glm53-nvfp4-8": "glm53f-nvfp4-8"
+  },
   "comment": "A profile is model x quant x platform x config. The id a user types carries no platform -- the CLI detects it -- so each id holds one record per platform under `variants`, and every record states its own platform. Ids follow <model>-<quant>-<gpus>. Quant tags: xxs=IQ2_XXS(-Q2_K), q4ktail=Q4K-tail, mxfp4=MXFP4, q4k=Q4_K, q2k=Q2_K, q2kxl=UD-Q2_K_XL, nvfp4=NVFP4.",
   "sources": {
     "glm52-vision": {
@@ -1172,7 +1176,8 @@
       ],
       "format": "safetensors",
       "repo": "RedHatAI/GLM-5.3-Flash-NVFP4",
-      "base_url": "https://huggingface.co/RedHatAI/GLM-5.3-Flash-NVFP4/resolve/main",
+      "revision": "36c184c6cda000a481711306df5adde42f63321a",
+      "base_url": "https://huggingface.co/RedHatAI/GLM-5.3-Flash-NVFP4/resolve/36c184c6cda000a481711306df5adde42f63321a",
       "local_dir": "GLM-5.3-Flash-NVFP4",
       "shared_note": "Safetensors checkpoint served from its directory; the vision tower, MTP head (model_mtp.safetensors), tokenizer and processor configs ship in the same repo. Requires transformers >= 5.16.1 for the native glm5_next config and processor.",
       "speculator": {
@@ -1187,11 +1192,12 @@
       },
       "quants": {
         "NVFP4": {
-          "title": "NVFP4 (group-16 FP4 experts, FP8 tail layer, BF16 backbone)",
+          "title": "NVFP4 (group-16 target experts, separate FP8 MTP head)",
           "bytes": 197881155500,
-          "summary": "RedHatAI's LLM Compressor release of the 169B GLM-5.3-Flash: 42 MoE layers in NVFP4 (group 16), the last expert layer in FP8, attention/KDA/mHC/embeddings/vision in BF16. On Ampere the experts run through the Marlin W4A16 NVFP4 kernels.",
+          "summary": "RedHatAI's LLM Compressor release of the 169B GLM-5.3-Flash: all 42 target MoE layers in NVFP4 (group 16); the separate MTP head at layer 45 has FP8 experts. The source backbone is BF16. Platform-specific recipes may restore native FP32 tensors and replace selected backbone weights with FP8; the RTX6000 record pins its complete derived recipe. Experts use Marlin W4A16 on the A100 and RTX6000 records.",
           "min_gpus": {
-            "a100": 4
+            "a100": 4,
+            "rtx6000": 4
           },
           "files": [
             {
@@ -1461,6 +1467,20 @@
       "notes": [
         "GeForce driver disables GPU peer-to-peer, so every tensor-parallel collective stages through host memory. Profiles on this platform should prefer expert parallelism and host-offloaded tables over designs that add per-step all-reduces.",
         "SM86 has no FP8 tensor cores; FP8 checkpoints serve through the Marlin W8A16 weight-only kernels."
+      ]
+    },
+    "rtx6000": {
+      "title": "NVIDIA RTX PRO 6000 Blackwell",
+      "compute_capability": [
+        12,
+        0
+      ],
+      "vram_bytes": 102642417664,
+      "gate": "gpus",
+      "status": "supported",
+      "notes": [
+        "Workstation Blackwell (GB202, sm_120): 188 SMs, 128 MiB L2, 100 KB shared memory per SM (99 KB opt-in per block), 96 GB GDDR7 at 1.79 TB/s, PCIe 5 x16 and no NVLink. On a four-card box the cards pair up under two host bridges (GPU0-GPU1, GPU2-GPU3) with the cross-pair path through the root complex; peer reads work on every pair, so tensor-parallel collectives run over PCIe and each all-reduce is a latency cost the record must budget for.",
+        "Family cubin 12.0f needs CUDA >= 13.0; older toolkits fall back to 12.0a;12.1a. The sm_120 tensor cores do NVFP4, but the stock CUTLASS and FlashInfer grouped FP4 GEMMs produced garbage on this card class in vLLM (issue #54150, cutlass #3096), so NVFP4 experts serve through Marlin W4A16 until a QuixiCore sm_120 kernel is qualified. DeepGEMM, TileLang v2 DSA schedules and the SM90/SM100 attention kernels do not run here."
       ]
     }
   },
@@ -2895,6 +2915,103 @@
             "reasoning_parser and tool_call_parser glm47: GLM-5.3 uses the GLM-4.7-family thinking and tool-call markup; enable_auto_tool_choice and thinking are the registry serving defaults.",
             "Host KV tier ENABLED (2026-09-03): 72 GiB pinned host RAM per rank (cudaHostRegister-ed at exact size) plus a 256 GiB per-rank NVMe/disk third tier under it (per-rank O_TMPFILE in SLIMSERVE_KV_TIER_DIR - operator environment, never a profile field; on this box the tier directory sits on the 4.9 TB /dev/sda2 filesystem). The layout is the packed cross-layer slab (enable_cross_layers_blocks) over 56 layers: 4 KDA state groups + the MLA and indexer groups. Hybrid page-size unification gives the indexer group (512 B/token) 2176-token blocks beside the MLA group's 1088 (TP4; 576/1152 at TP8), so the connector runs per-group block ratios: the wider group is offloaded/restored only where its block completes and resume boundaries align to the ratios' lcm. Every kernel on this path addresses pages by block stride (no flattening of the packed view). Validation: host tier at TP4 (48 GiB/rank): 6/6 probes hit and restored at block 36 (39,168 tokens), 58 restore ops each, VLLM_KV_TIER_VERIFY 0/58 mismatched; disk tier at TP4 (8 GiB host + 64 GiB disk, restores forced from disk): promotions from NVMe, verify 0/58 mismatched, 0 disk round-trip mismatches, 6/6 recalled after a 1.9M-token churn of a 1.24M-token pool (perf/results/2026-09-03/kvtier-acceptance/glm53-tp4-{host48,disk9}/); the TP8 record validated through slimserve on 2026-09-04 (perf/results/2026-09-04/glm53f-nvfp4-8-tier/).",
             "Reasoning effort: the GLM-5.3-Flash chat template implements the GLM-5.3 Low / High / Max levels (default Max) from the reasoning_effort chat_template_kwargs; thinking itself stays always-on (serving policy). No server flag is involved."
+          ]
+        },
+        "rtx6000": {
+          "platform": "rtx6000",
+          "default_quant": "NVFP4",
+          "weight_recipe": {
+            "id": "glm53-redhatai-nvfp4-fp8-kda-tp4-v1",
+            "description": "RedHatAI group-16 NVFP4 routed experts; native FP32 router/KDA/mHC repairs; native block-FP8 dense/shared/DSA weights; self-quantized block-FP8 KDA projections; BF16 KV and target vocabulary head.",
+            "local_dir": "GLM-5.3-Flash-NVFP4-FP8-KDA-TP4",
+            "target_revision": "36c184c6cda000a481711306df5adde42f63321a",
+            "native": {
+              "repo": "zai-org/GLM-5.3-Flash",
+              "revision": "3f1971b7b5f7a528c9c4ef6212c8785298a8c24a",
+              "local_dir": "GLM-5.3-Flash"
+            },
+            "tp_size": 4,
+            "artifact_digests": {
+              "f32-overrides.safetensors": "1c55137b1724151218d92c06735a16dbc9d9e3b7cdabd5c2ddfc842d8881f2e4",
+              "fp8-swapset.safetensors": "27e8aaf0e3cc3517c0e40622f176b3734924a0944bc0959c9eac3d3a6e74b327",
+              "fp8-swapset.json": "2f5fca340d60153ce80f9491db4167d7cf6fb2e8b8e32b35b3a0d2f21b29d1fb"
+            }
+          },
+          "engine": {
+            "tensor_parallel_size": 4,
+            "enable_expert_parallel": false,
+            "max_num_seqs": 16,
+            "block_size": 64,
+            "gpu_memory_utilization": 0.85,
+            "kv_cache_dtype": "auto",
+            "attention_config": {
+              "backend": "QUIXICORE_MLA_SPARSE",
+              "sparse_mla_force_mqa": true
+            },
+            "moe_backend": "marlin",
+            "linear_backend": "auto",
+            "kernel_config": {
+              "moe_backend": "marlin",
+              "linear_backend": "auto"
+            },
+            "compilation_config": {
+              "cudagraph_mode": "FULL_DECODE_ONLY",
+              "max_cudagraph_capture_size": 64
+            },
+            "limit_mm_per_prompt": {
+              "image": 2
+            },
+            "reasoning_parser": "glm47",
+            "tool_call_parser": "glm47",
+            "served_model_name": "GLM-5.3-Flash",
+            "enable_prefix_caching": true
+          },
+          "speculative": false,
+          "speculative_overrides": {
+            "num_speculative_tokens": 3
+          },
+          "speculator": {
+            "repo": "RedHatAI/GLM-5.3-Flash-NVFP4",
+            "revision": "36c184c6cda000a481711306df5adde42f63321a",
+            "local_dir": "GLM-5.3-Flash-NVFP4",
+            "engine": {
+              "method": "mtp",
+              "num_speculative_tokens": 1,
+              "index_share_for_mtp_iteration": true,
+              "moe_backend": "triton",
+              "attention_backend": "QUIXICORE_MLA_SPARSE"
+            },
+            "note": "RTX6000 diagnostic opt-in only; the retained recipe serves without speculation. Preserve its checkpoint MTP adapter and FP8 draft experts rather than inheriting the A100 DFlash2 source default."
+          },
+          "env": {
+            "VLLM_CUSTOM_AR_ALLOW_PCIE": "1",
+            "VLLM_GLM5_INDEXER_SM120_TILES": "1",
+            "VLLM_GLM5_MHC_BF16_FN": "1",
+            "VLLM_GLM53_MARLIN_PREFILL_WIDE": "1",
+            "VLLM_GLM53_INDEXER_TP_PREFILL": "1",
+            "VLLM_GLM53_SPARSE_PREFILL_SWAPAB": "1",
+            "VLLM_USE_V2_MODEL_RUNNER": "0",
+            "NCCL_P2P_DISABLE": "0",
+            "NCCL_P2P_LEVEL": "SYS"
+          },
+          "notes": [
+            "VLLM_USE_V2_MODEL_RUNNER=0 preserves the recorded SM120 recipe's V1 runner during the merge with main's A100/V2 work. A100 keeps its V2/DFlash2 defaults. Migrating this recipe to V2 requires separate graph/sampler/serving qualification and is not implied by the existing measurements.",
+            "VLLM_GLM5_INDEXER_SM120_TILES=1 (2026-09-08): RT2/PT128/four-warps pooled-indexer prefill scoring avoids the original RT8/PT64 register spills without changing quant, arithmetic, pooling, visibility or selection. Three fixed starts x three repeats plus a prescribed return-to-original control validate cold 32K/128K engine TTFT at 2.606/10.933 s versus 2.634/11.433 s in the return control; all exact-token, text/image and expanded quality checks pass. Decode is unchanged. Full selection tests, memcheck, racecheck and synccheck pass. See indexer-tile-serving/ and indexer-tile-return-control/ under perf/results/2026-09-08/. Set the environment value to 0 before launch for a controlled original-geometry comparison; other platforms retain their existing geometry.",
+            "NCCL_P2P_DISABLE=0 NCCL_P2P_LEVEL=SYS (2026-09-08): NCCL carries every TP all-reduce above the custom all-reduce's 8 MiB cap, i.e. the prefill chunks ([tokens, 4096] bf16: 57 MB at 7001 tokens, 67 MB at 8192). The four GPUs sit PHB/NODE (two per host bridge, no PCIe switch), which NCCL's default P2P level refuses, so it fell back to host-memory SHM at 15 GB/s and the reduce was 37% of a 7001-token prefill step. Over P2P: c8 prefill 811-831 -> 666-678 ms, c16 1354-1361 -> 1103-1106 ms, aggregates +4% c8 / +5-6% c16, decode untouched, gate in band (notebook 2026-09-08 'Prefill: the all-reduce arms'; the custom-AR cap at 64/128 MiB, VLLM_CUSTOM_AR_MAX_SIZE_MB, gave -14% and lost to this). Profile env applies with setdefault: a shell that exports NCCL_P2P_DISABLE=1 (tinybox's fish config does, for the CUDA 13.3 B12X container on the 13.0 driver) silently wins and the launcher prints the shadow; unset it for this record.",
+            "VLLM_CUSTOM_AR_ALLOW_PCIE=1 (2026-09-07): vLLM's custom all-reduce on the PCIe-only TP4 topology (P2P functional on every pair, BAR1 128 GiB). Replaces 91 NCCL ring-LL launches x 11.2 us with 90 x 5.1 us on the compute stream and removes their cross-stream graph gaps: exact-token c1 123.8 -> 137.4, c8 478 -> 499, c16 628 -> 657 on the swap-set tree, six gates in band (notebook 2026-09-07 'Custom all-reduce'). Off = unset the key (NCCL).",
+            "Validated cold-prefix reference (2026-09-08): recipe glm53-redhatai-nvfp4-fp8-kda-tp4-v1, repaired Marlin library and spill-free indexer geometry, three starts x three repetitions at c1/c8/c16, all 27 exact 1000/300 measurements retained with zero cached tokens. E2E medians 155.90/575.56/779.06 tok/s; cold 32K/128K engine TTFT 2.600/10.968 s. Text/image canaries, per-start 4096-token quality and six needle contrasts pass. This reference has mHC BF16 storage OFF; the subsequent paired-staging qualification below enables it. See cold-recipe-baseline/ and perf/baseline_status.md for commands, spread and limits. Unexplained historical startup throughput variation and broader quality/context qualification remain open; node-profiled gaps are not proof of unprofiled causality.",
+            "VLLM_GLM5_MHC_BF16_FN=1 (2026-09-08): losslessly store checkpoint mHC fn values in BF16 with qualified paired SM120 prefill staging; FP32 arithmetic and native FP32 base/scale stay unchanged. Same-binary one-FP32/three-BF16/one-FP32 control series passes all 45 exact-token rounds, text/image, 4096 scored tokens and six needle contrasts per start, and cold 32K/128K checks. Candidate E2E medians 156.79/578.99/779.94 tok/s versus controls 156.21/576.19/779.28 and 155.91/576.56/776.83. Retained for the small c1 gain (0.38-0.57%; all nine candidate readings above both controls); batched decode and prefill are effectively neutral. An owned-worker driver-cleanup race interrupted the chain after candidate one; only the two remaining prescribed candidates and return were resumed after a teardown-only harness fix. No discarded or replacement starts. See mhc-paired-* raw directories and the combined analysis. Set the environment value to 0 for the FP32-storage control; other platforms remain unchanged.",
+            "VLLM_GLM53_MARLIN_PREFILL_WIDE=1 (2026-09-10): M64/N512/K64, 256 threads, three-stage SM120 Marlin kernel removes cross-warp K reduction for target NVFP4/BF16 expert GEMMs at 2048..8192 input tokens. No quant/precision change; decode, smaller prefills and explicit schedules stay on existing kernels. Complete expert-path microbenchmarks improve 6.75-10.03% across 18 actual-weight fixtures, sampled independent FP64 checks pass, targeted memcheck reports zero errors, and installed outputs match the probe exactly. Same-binary one-control/one-candidate serving comparison, three repeats each, gives cold32K/128K engine TTFT 2585.249/10862.210 -> 2534.443/10710.859 ms (-1.97/-1.39%); every candidate reading is below every control reading. E2E c16 779.195 -> 784.687 tok/s (+0.70%); c1/c8 changes -0.26/+0.05% are within control spread, not decode gains. Text/image, exact tokens and all long-context retrieval contrasts pass. This is one fixed pair, not an across-start variance estimate or resolution of historical scoring-repeatability failures. Raw marlin-wide-serving-{control,candidate}/ under perf/results/2026-09-10. Set the environment flag to 0 before launch for the original kernel.",
+            "VLLM_GLM53_INDEXER_TP_PREFILL=1 (2026-09-11): shard independent long-prefill indexer query rows across TP4 and exchange 512 pool IDs before 4x token expansion, once per forward. Existing arithmetic kernels/quant unchanged. SM120 TP4 only, no PCP/DCP, at least 2048 prefill rows and 32768 context; decode and short prefills keep the original path. Completed control/corrected-candidate serving comparison gives cold-prefix 128K engine TTFT 10658.466 -> 10009.430 ms (-6.09%, effective prefill +6.48%); all three candidate timings beat all three controls. 32K TTFT +0.20% and c1/c8/c16 E2E +0.004/+0.195/+0.153% are effectively neutral, not decode wins. Component selected sets/tails match on all four ranks; legacy selector order is not bit-exact. Six standard retrieval contrasts and two additional cold128K generated-retrieval checks pass. First candidate failed before timing on an upstream-only metadata field; that failure is retained, and the corrected gate uses this fork's chunk lengths. No best-of/replacement timing selection or across-start variance claim. Initial-use JIT overhead is separate from these warmed-kernel/cold-prefix timings. Raw indexer-shard*, indexer-shard-serving-* and indexer-shard-128k-needle under perf/results/2026-09-11. Flag0 restores replicated prefill. Historical scoring-repeatability limits remain unchanged.",
+            "VLLM_GLM53_SPARSE_PREFILL_SWAPAB=1 (2026-09-11): native SM120 H16 BF16 sparse prefill uses register-resident queries, two math warps plus one IO warp, padded double-buffered KV staging and transposed value matrix loads. BF16 Q/KV and FP16 P/V boundaries are unchanged. Active for 2048..8192 rows; decode/other shapes stay on the existing route. Corrected same-binary flag0/flag1 pair on 6b2fea199 reduces cold32K/128K engine TTFT 2526.339/10001.190 -> 2519.428/9949.508 ms (-0.274/-0.517%); all three candidate readings beat all controls at each length. E2E c1/c8/c16 156.893/581.076/781.150 -> 156.663/579.222/780.644 tok/s (-0.146/-0.319/-0.065%) has overlapping ranges and is treated as neutral, not a decode improvement. Ten GPU tests, sampled FP64 comparisons, memcheck/racecheck, exact tokens, text/image and six retrieval contrasts pass. First H32 pair was a no-op: actual checkpoint64 heads / TP4 = H16. Its results are preserved and do not count as kernel evidence. Native dispatch is explicitly asserted in tests and logged on rank0 in serving. Raw sparse-swapab/h16* and sparse-swapab-h16-serving-{control,candidate}/ under perf/results/2026-09-11. This one fixed pair does not estimate across-start variance or resolve historical scoring-repeatability limits. Flag0 restores Triton prefill.",
+            "Same model facts as a100: context from config.json (1048576), ~17 KiB/token per rank of MLA + indexer KV, fixed-size KDA state; block_size 64 for the pooled-indexer cache; parsers glm47; TP4 with experts sharded (EP was 4-6% slower on a100; the PCIe all-reduce cost here is the reason to re-measure, not to assume).",
+            "moe_backend marlin: group-16 NVFP4 weights with BF16 activations, built for 12.0f. SM120 has native FP4 tensor cores, but changing this W4A16 path to W4A4 would also quantize activations and requires a separately identified recipe and quality comparison. Current kernel work preserves the selected quant and measures scheduling, layout and fusion changes against the serving baseline.",
+            "attention_config QUIXICORE_MLA_SPARSE: QuixiCore sparse NoPE MLA compiled for sm_120, covered by the kernel parity suite and fixed-start serving canaries. FlashInfer's SM120 GLM53_NOPE sparse MLA (#4802) is a reference for further measured work. Startup or local parity alone does not qualify every context length.",
+            "kv_cache_dtype auto resolves to BF16 and remains fixed in recipe v1, as does the BF16 lm_head. FP8 KV is a separate quant experiment, not an unannounced performance change to this reference.",
+            "Host and NVMe KV tiers are disabled on this record. No host/disk allocation is qualified for this 188 GB host; do not inherit A100 allocations or promise 32 GiB per rank without a complete host-memory budget and benchmark_kv_tier_eviction.py with VLLM_KV_TIER_VERIFY=1 on this machine.",
+            "Speculation: MTP (NextN) draft path ported and validated 2026-09-04 (perf/optimization_status.md, GLM-5.3-Flash MTP entries). OFF by default on this record: on the Foundry pipeline's real 8-wide fan-out (8 concurrent director commitments, ~4K-token specs, chat template with thinking, temperature 1.0 / top-p 0.95, 4096-token outputs) MTP k=3 measured 377/379 tok/s aggregate vs 453/480 spec-off (-20%, 0.82 accepted per step of 3) and 411 vs 504 greedy; single-stream 113 vs 109 (inside the 2.5% boot band). MTP wins only on short single-stream deterministic/structured cells (+17..+46% greedy: JSON triage, ctx0, code chat) and loses on the dense-prose exact-token harness at temp 1.0 (c1 95 vs 112, c8 323 vs 457). Opt-in for single-stream deterministic serving: set `speculative: true` on this record (speculative_overrides keeps num_speculative_tokens 3, the measured depth). The a100 record stays non-speculative.",
+            "Competitive target: strongest reproducible B12X result under matched workloads. The fixed three-start R28.1 cold-prefix control now completes on this box with qualified host-driver/native-FA2 adaptations, no-spec/DCP1 and its stock scheduling. Its different W4A4/FP8-KV configuration yields 132.59/466.69/589.28 E2E tok/s at c1/c8/c16, versus 155.90/575.56/779.06 here (+17.6/+23.3/+32.2%). Batched client arrivals are close during the interval when every request is generating; both reported client-decode windows include staggered prefill. This is not a kernel-only gain or a claim against every B12X configuration. Cold 32K engine TTFT is 4.2% lower here; 128K is 1.3% higher. See the two cold-prefix baselines, not published context-zero decode or old best-start ratios.",
+            "The selected recipe owns preparation and digest verification of the FP32 repair sidecar (router bias, KDA decay, mHC base/scale) and FP8 swap-set including self-quantized KDA. SlimServe prepares an isolated derived directory from pinned RedHatAI and native ZAI revisions before serving. Do not manually mutate source checkpoints or silently omit either sidecar. mHC projection fn is checkpoint BF16 upcast to FP32; only its base/scale vectors are native FP32 repairs."
           ]
         }
       }

--- a/slimserve/prompt_score_diagnostic.py
+++ b/slimserve/prompt_score_diagnostic.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prompt-score memory comparison with unchanged, qualified model kernels."""
+
+import os
+import sys
+
+from slimserve import glm53_ordering, indexer_correction_diagnostic, kv_diagnostic
+
+FLAG = "SLIMSERVE_GLM53_PROMPT_SCORE_DIAGNOSTIC"
+MANIFEST = "SLIMSERVE_GLM53_PROMPT_SCORE_MANIFEST"
+CHUNKS = "SLIMSERVE_GLM53_PROMPT_SCORE_CHUNKS"
+SCHEMA = indexer_correction_diagnostic.SCHEMA
+SERVING_SCHEMA = "glm53-prompt-score-serving-v1"
+AOT_PAIR_SHA = indexer_correction_diagnostic.AOT_PAIR_SHA
+CASES = (("control", "control"), ("chunked", "control"), ("return-control", "control"))
+
+
+def mode():
+    value = os.getenv(FLAG, "")
+    if value not in ("", "control"):
+        raise ValueError(f"{FLAG} permits only the unchanged control loader")
+    return value
+
+
+def validate_environment():
+    indexer_correction_diagnostic.validate_environment()
+    if os.getenv(indexer_correction_diagnostic.FLAG):
+        raise ValueError("prompt scoring cannot combine with indexer correction")
+
+
+def read_manifest():
+    from benchmarks.kernels import prepare_glm53_prompt_score_serving as preparation
+
+    data, path = kv_diagnostic.read_manifest(
+        workflow=sys.modules[__name__], preparation=preparation
+    )
+    if os.getenv(CHUNKS) != ("1" if data["label"] == "chunked" else "0"):
+        raise ValueError("prompt-score chunk flag differs from prescribed arm")
+    return data, path
+
+
+def validate_plan(plan):
+    if not mode():
+        return
+    validate_environment()
+    glm53_ordering.validate_plan(plan)
+    options = plan.engine.get("compilation_config", {}).get(
+        "inductor_compile_config", {}
+    )
+    if (
+        plan.engine.get("kv_cache_dtype", "auto") != "auto"
+        or plan.engine.get("dtype", "auto") not in ("auto", "bfloat16", "bf16")
+        or options.get("deterministic")
+        or options.get("combo_kernels") is False
+    ):
+        raise ValueError("prompt scoring preserves BF16 and original compiler policy")
+    read_manifest()
+
+
+def install(runner):
+    if not mode():
+        return
+    validate_environment()
+    import torch
+
+    from benchmarks.kernels.glm53_indexer_correction_serving import (
+        ServingIndexerCorrection,
+    )
+
+    config, parallel = runner.model_config.hf_text_config, runner.parallel_config
+    options = runner.compilation_config.inductor_compile_config
+    if (
+        config.hidden_size != 4096
+        or config.num_hidden_layers != 45
+        or parallel.tensor_parallel_size != 4
+        or parallel.pipeline_parallel_size != 1
+        or parallel.enable_expert_parallel
+        or runner.speculative_config is not None
+        or torch.cuda.get_device_capability() != (12, 0)
+        or runner.dtype is not torch.bfloat16
+        or runner.kv_cache_dtype is not torch.bfloat16
+        or options.get("deterministic")
+        or options.get("combo_kernels") is False
+        or getattr(runner, "_slimserve_prompt_score_diagnostic", None) is not None
+    ):
+        raise ValueError(
+            "prompt scoring diagnostic requires original GLM53 SM120 TP4, once"
+        )
+    manifest, path = read_manifest()
+    # All three arms use the exact qualified control loader and lifecycle.
+    # No indexer correction kernel or selection arena is activated.
+    diagnostic = ServingIndexerCorrection(parallel.rank, manifest, path)
+    diagnostic.install(runner)
+    runner._slimserve_prompt_score_diagnostic = diagnostic

--- a/slimserve/prompt_score_shadow.py
+++ b/slimserve/prompt_score_shadow.py
@@ -1,0 +1,291 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in same-live-input scoring comparison, never a timing/default policy.
+
+Runs the existing full scorer and (above 1024 rows) the unchanged chunked scorer.
+Blocking CPU copies deliberately verify input preservation and exact output bits.
+Only small score outputs and hashes are retained, never the vocabulary matrices.
+"""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+FLAG = "SLIMSERVE_GLM53_PROMPT_SCORE_SHADOW"
+ROOT = Path(__file__).resolve().parents[1]
+VOCAB = 154880
+MAX_ROWS = 8192
+COPY_BYTES = 32 * 1024**2
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def prompt_digest(ids):
+    return hashlib.sha256(json.dumps(ids, separators=(",", ":")).encode()).hexdigest()
+
+
+def validate_environment():
+    if not os.getenv(FLAG):
+        return
+    require(
+        os.getenv("SLIMSERVE_GLM53_PROMPT_SCORE_CHUNKS") == "1",
+        "shadow requires chunks=1",
+    )
+    allowed = {FLAG, "SLIMSERVE_GLM53_PROMPT_SCORE_CHUNKS"}
+    conflicts = [
+        key
+        for key, value in os.environ.items()
+        if key.startswith("SLIMSERVE_GLM53_")
+        and key not in allowed
+        and value not in ("", "0")
+    ]
+    require(
+        not conflicts,
+        f"shadow cannot combine with other model diagnostics: {conflicts}",
+    )
+    require(
+        os.getenv("VLLM_FORCE_AOT_LOAD", "0") in ("", "0"),
+        "shadow uses normal compilation",
+    )
+    require(os.getenv("VLLM_GLM5_MHC_PREFILL_TC", "0") == "0", "shadow preserves TC0")
+    directory = Path(os.environ[FLAG]).resolve()
+    require(
+        directory.is_relative_to(ROOT / "perf/results"),
+        "shadow output must be under perf/results",
+    )
+
+
+def validate_plan(plan):
+    if not os.getenv(FLAG):
+        return
+    validate_environment()
+    engine = plan.engine
+    options = engine.get("compilation_config", {}).get("inductor_compile_config", {})
+    require(
+        plan.profile_id in ("glm53-nvfp4-4", "glm53f-nvfp4-4")
+        and plan.platform == "rtx6000"
+        and plan.gpus == 4
+        and plan.quant.name == "NVFP4"
+        and (plan.weight_recipe or {}).get("id")
+        == "glm53-redhatai-nvfp4-fp8-kda-tp4-v1"
+        and engine.get("tensor_parallel_size") == 4
+        and not engine.get("enable_expert_parallel", False)
+        and not plan.speculative
+        and engine.get("moe_backend") == "marlin"
+        and engine.get("kv_cache_dtype", "auto") == "auto"
+        and engine.get("dtype", "auto") in ("auto", "bfloat16", "bf16")
+        and not options.get("deterministic")
+        and options.get("combo_kernels") is not False,
+        "shadow requires the unchanged GLM53 SM120 TP4 recipe/compiler policy",
+    )
+
+
+def device_check(logits):
+    import torch
+
+    require(
+        logits.is_cuda and torch.cuda.get_device_capability(logits.device) == (12, 0),
+        "shadow requires SM120 CUDA logits",
+    )
+
+
+def tensor_digest(tensor):
+    """Hash logical tensor bytes using at most COPY_BYTES of host staging."""
+    import torch
+
+    require(tensor.ndim > 0 and tensor.shape[0] > 0, "empty shadow tensor")
+    bytes_per_row = tensor[0].numel() * tensor.element_size()
+    require(0 < bytes_per_row <= COPY_BYTES, "shadow row exceeds host staging bound")
+    rows = max(1, COPY_BYTES // bytes_per_row)
+    digest = hashlib.sha256()
+    for start in range(0, tensor.shape[0], rows):
+        host = tensor[start : start + rows].detach().cpu().contiguous()
+        digest.update(memoryview(host.view(torch.uint8).numpy()))
+        del host
+    return digest.hexdigest()
+
+
+class PromptScoreShadow:
+    @classmethod
+    def from_env(cls, runner):
+        if not os.getenv(FLAG):
+            return None
+        import torch
+
+        validate_environment()
+        config, parallel = runner.model_config.hf_text_config, runner.parallel_config
+        require(
+            config.model_type in ("glm5_next", "glm5_next_text")
+            and config.hidden_size == 4096
+            and config.num_hidden_layers == 45
+            and parallel.tensor_parallel_size == 4
+            and parallel.pipeline_parallel_size == 1
+            and not parallel.enable_expert_parallel
+            and runner.speculative_config is None
+            and runner.dtype is torch.bfloat16
+            and runner.kv_cache_dtype is torch.bfloat16,
+            "shadow worker must match fixed GLM53 TP4 BF16 recipe",
+        )
+        return cls(Path(os.environ[FLAG]), parallel.rank)
+
+    def __init__(self, directory, rank):
+        require(type(rank) is int and 0 <= rank < 4, "invalid shadow rank")
+        directory.mkdir(parents=True, exist_ok=True)
+        self.path = directory / f"shadow-rank{rank}-pid{os.getpid()}.jsonl"
+        self.stream = self.path.open("x", buffering=1)
+        self.calls = 0
+        sources = (
+            "slimserve/prompt_score_shadow.py",
+            "vllm/v1/worker/gpu_model_runner.py",
+            "vllm/v1/sample/prompt_logprobs.py",
+            "vllm/v1/sample/sampler.py",
+            "vllm/v1/sample/ops/logprobs.py",
+        )
+        self.write(
+            dict(
+                kind="header",
+                schema=1,
+                rank=rank,
+                pid=os.getpid(),
+                diagnostic_only=True,
+                copy_bytes=COPY_BYTES,
+                max_rows=MAX_ROWS,
+                vocab=VOCAB,
+                sources={
+                    name: hashlib.sha256((ROOT / name).read_bytes()).hexdigest()
+                    for name in sources
+                },
+            )
+        )
+
+    def write(self, row):
+        self.stream.write(
+            json.dumps(row, separators=(",", ":"), allow_nan=False) + "\n"
+        )
+
+    def gather(
+        self,
+        logits,
+        targets,
+        count,
+        mode,
+        *,
+        sampler,
+        prompt_ids,
+        start_idx,
+        request_id,
+    ):
+        import torch
+
+        from vllm.v1.sample.prompt_logprobs import CHUNK_ROWS, gather_prompt_logprobs
+
+        self.calls += 1
+        require(self.calls <= 512, "shadow exceeds prescribed call bound")
+        self.write(
+            dict(
+                kind="begin",
+                call=self.calls,
+                request_id=request_id,
+                prompt_sha256=prompt_digest(prompt_ids),
+                prompt_tokens=len(prompt_ids),
+                start_idx=start_idx,
+                rows=logits.shape[0],
+            )
+        )
+        try:
+            device_check(logits)
+            require(
+                logits.ndim == 2
+                and 0 < logits.shape[0] <= MAX_ROWS
+                and logits.shape[1] == VOCAB
+                and logits.dtype is torch.bfloat16
+                and targets.dtype is torch.int64
+                and targets.shape == (logits.shape[0],)
+                and targets.device == logits.device
+                and type(count) is int
+                and 0 <= count <= 5
+                and mode == "raw_logprobs"
+                and type(start_idx) is int
+                and start_idx >= 0
+                and start_idx + logits.shape[0] <= len(prompt_ids) - 1,
+                "shadow input contract changed",
+            )
+            require(
+                targets.cpu().tolist()
+                == prompt_ids[start_idx + 1 : start_idx + 1 + logits.shape[0]],
+                "shadow target offsets changed",
+            )
+            paired = logits.shape[0] > CHUNK_ROWS
+            before = (tensor_digest(logits), tensor_digest(targets)) if paired else None
+            # Reference is exactly the unchunked runner's existing operations.
+            scores = sampler.compute_logprobs(logits)
+            reference = sampler.gather_logprobs(scores, count, targets)
+            del scores
+            require(
+                reference.cu_num_generated_tokens is None, "unexpected packed reference"
+            )
+            if paired:
+                require(
+                    before == (tensor_digest(logits), tensor_digest(targets)),
+                    "reference mutated inputs",
+                )
+                actual = gather_prompt_logprobs(
+                    logits, targets, count, mode, sampler=sampler
+                )
+                require(
+                    before == (tensor_digest(logits), tensor_digest(targets)),
+                    "chunked scorer mutated inputs",
+                )
+            else:
+                # Preserve normal small-request dispatch. These rows are NOT
+                # reported as evidence for the chunked scorer.
+                actual = reference
+            require(
+                actual.cu_num_generated_tokens is None, "unexpected packed candidate"
+            )
+            require(
+                torch.isfinite(reference.logprobs).all().item()
+                and torch.isfinite(actual.logprobs).all().item(),
+                "nonfinite prompt scores",
+            )
+            fields = []
+            for expected, observed in zip(reference[:3], actual[:3], strict=True):
+                require(
+                    expected.shape == observed.shape
+                    and expected.dtype == observed.dtype,
+                    "shadow output geometry changed",
+                )
+                expected_sha, actual_sha = (
+                    tensor_digest(expected),
+                    tensor_digest(observed),
+                )
+                require(expected_sha == actual_sha, "shadow output bits differ")
+                fields.append(
+                    dict(
+                        shape=list(observed.shape),
+                        dtype=str(observed.dtype),
+                        reference_sha256=expected_sha,
+                        chunked_sha256=actual_sha,
+                    )
+                )
+            self.write(
+                dict(
+                    kind="complete",
+                    call=self.calls,
+                    paired=paired,
+                    count=count,
+                    mode=mode,
+                    input_sha256=before,
+                    outputs=fields,
+                    token_ids=actual.logprob_token_ids[:, 0].cpu().tolist(),
+                    logprobs=actual.logprobs[:, 0].cpu().tolist(),
+                    ranks=actual.selected_token_ranks.cpu().tolist(),
+                )
+            )
+            return actual
+        except BaseException as error:
+            self.write(dict(kind="failed", call=self.calls, error=repr(error)))
+            raise

--- a/slimserve/reduction_receipts.py
+++ b/slimserve/reduction_receipts.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Read-only startup graph receipts for the opt-in deterministic compiler candidate."""
+
+import hashlib
+import json
+import os
+from functools import wraps
+from pathlib import Path
+
+from slimserve import glm53_ordering
+
+
+def sha(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def graph_snapshot(modules, cache_root):
+    """Inspect actual globals, without resolving futures or touching autotuners.
+
+    Keep module/object references alive throughout enumeration. Bare IDs are
+    useful only inside this process; never compare them across independent runs.
+    Missing/uninspectable named RMSNorm bindings are violations, not exclusions.
+    """
+    root = str(Path(cache_root).resolve())
+    files, graphs, bindings, violations, references = {}, [], [], [], []
+
+    def file_receipt(filename):
+        if not isinstance(filename, str) or not Path(filename).is_file():
+            raise ValueError(f"missing generated source: {filename}")
+        if filename not in files:
+            source = Path(filename).read_bytes()
+            files[filename] = dict(
+                sha256=hashlib.sha256(source).hexdigest(),
+                normalized_sha256=hashlib.sha256(
+                    source.replace(root.encode(), b"<CACHE>")
+                ).hexdigest(),
+            )
+        return files[filename]
+
+    seen = set()
+    for module in list(modules):
+        if id(module) in seen or not callable(getattr(module, "call", None)):
+            continue
+        seen.add(id(module))
+        references.append(module)
+        graph = dict(module_id=id(module), module=module.__file__)
+        try:
+            graph.update(file_receipt(module.__file__))
+        except ValueError as error:
+            violations.append(str(error))
+        graphs.append(graph)
+        for symbol, value in list(vars(module).items()):
+            state = getattr(value, "__dict__", {})
+            metadata = state.get("inductor_meta")
+            named_norm = symbol.startswith("triton_") and "rms_norm" in symbol
+            if not isinstance(metadata, dict):
+                if named_norm:
+                    violations.append(f"uninspectable RMSNorm global: {symbol}")
+                continue
+            references.append(value)
+            kernel = metadata.get("kernel_name", symbol)
+            norm = named_norm or "rms_norm" in kernel
+            reduction = norm or bool(metadata.get("num_reduction", 0))
+            row = dict(
+                module_id=id(module),
+                module=module.__file__,
+                symbol=symbol,
+                object_id=id(value),
+                filename=state.get("filename"),
+                kernel=kernel,
+                rmsnorm=norm,
+                reduction=reduction,
+                heuristic=str(state.get("heuristic_type")),
+                deterministic=metadata.get("deterministic"),
+                batch_invariant=metadata.get("batch_invariant"),
+                global_deterministic=metadata.get(
+                    "are_deterministic_algorithms_enabled"
+                ),
+                runtime_deterministic=state.get("deterministic_mode"),
+                coordinate_descent_configured=metadata.get(
+                    "coordinate_descent_tuning", False
+                ),
+                dynamic_rblock_cached=state.get("_could_rblock_scale"),
+                size_hints=state.get("size_hints"),
+                selected=[],
+            )
+            try:
+                row.update(file_receipt(row["filename"]))
+                for launcher in state.get("launchers", []):
+                    # Config.__dict__ includes kwargs and all backend options;
+                    # don't silently discard num_ctas/maxnreg or future fields.
+                    row["selected"].append(
+                        dict(
+                            hash=launcher.cache_hash,
+                            config=dict(vars(launcher.config)),
+                        )
+                    )
+            except (AttributeError, TypeError, ValueError) as error:
+                violations.append(f"{symbol}: {error}")
+            if reduction:
+                if (
+                    row["deterministic"] is not True
+                    or row["runtime_deterministic"] is not True
+                ):
+                    violations.append(f"non-deterministic reduction: {symbol}")
+                if row["batch_invariant"] or row["global_deterministic"]:
+                    violations.append(f"unexpected global numerical mode: {symbol}")
+                if len(row["selected"]) != 1:
+                    violations.append(
+                        f"reduction has no single selected binary: {symbol}"
+                    )
+                if row["dynamic_rblock_cached"] is True:
+                    violations.append(
+                        f"dynamic reduction scaling remains active: {symbol}"
+                    )
+            bindings.append(row)
+    if not graphs or not any(row["rmsnorm"] for row in bindings):
+        violations.append("missing graph-held RMSNorm coverage")
+    return dict(graphs=graphs, bindings=bindings, violations=violations, files=files)
+
+
+def install(runner):
+    # No work or torch import on the default path or other profiles.
+    if not glm53_ordering.enabled():
+        return
+    options = runner.compilation_config.inductor_compile_config
+    if options.get("deterministic") is not True:
+        return
+    import torch
+    from torch._inductor.codecache import PyCodeCache
+    from torch._inductor.runtime import triton_heuristics
+
+    config = runner.model_config.hf_text_config
+    parallel = runner.parallel_config
+    if (
+        config.hidden_size != 4096
+        or config.num_hidden_layers != 45
+        or parallel.tensor_parallel_size != 4
+        or parallel.pipeline_parallel_size != 1
+        or parallel.enable_expert_parallel
+        or runner.speculative_config is not None
+        or torch.cuda.get_device_capability() != (12, 0)
+    ):
+        raise ValueError("graph receipts require native-order GLM53 SM120 TP4")
+    if not os.environ.get("VLLM_CACHE_ROOT"):
+        raise ValueError("graph receipts require an explicit private cache root")
+    root = Path(os.environ["VLLM_CACHE_ROOT"]).resolve()
+    folder = root / "glm53-reduction-receipts"
+    folder.mkdir(parents=True, exist_ok=True)
+    path = folder / f"rank-{parallel.rank}-pid-{os.getpid()}.json"
+    if path.exists() or getattr(runner, "_glm53_reduction_receipts", False):
+        raise ValueError("graph receipts cannot overwrite a prior capture")
+    runner._glm53_reduction_receipts = True
+    original = runner.capture_model
+
+    @wraps(original)
+    def capture(*args, **kwargs):
+        result = dict(
+            status="running",
+            rank=parallel.rank,
+            pid=os.getpid(),
+            cache_root=str(root),
+            source_sha256=sha(__file__),
+            heuristic_source_sha256=sha(triton_heuristics.__file__),
+            compiler_options=options,
+            snapshots={},
+        )
+        # Exclusive creation preserves any failed capture as well as successes.
+        with path.open("x") as stream:
+            try:
+                for phase in ("before", "after"):
+                    snapshot = graph_snapshot(PyCodeCache.modules, root)
+                    result["snapshots"][phase] = snapshot
+                    if snapshot["violations"]:
+                        raise ValueError(
+                            f"{phase} capture graph receipt: {snapshot['violations']}"
+                        )
+                    if phase == "before":
+                        captured = original(*args, **kwargs)
+                result["status"] = "complete"
+                return captured
+            except BaseException as error:
+                result.update(status="failed", error=repr(error))
+                raise
+            finally:
+                json.dump(result, stream, indent=2, default=repr)
+                stream.write("\n")
+
+    runner.capture_model = capture

--- a/slimserve/registry.py
+++ b/slimserve/registry.py
@@ -41,6 +41,11 @@ def profile_ids() -> list[str]:
     return list(_registry()["profiles"])
 
 
+def canonical_profile_id(profile_id: str) -> str:
+    """Preserve recorded commands without listing duplicate serving profiles."""
+    return _registry().get("profile_aliases", {}).get(profile_id, profile_id)
+
+
 def platform_title(platform: str) -> str:
     entry = _registry()["platforms"].get(platform)
     return entry["title"] if entry else platform
@@ -156,6 +161,7 @@ class Plan:
     # Variant-level drafter when platforms diverge; falls back to the
     # source-level speculator.
     variant_speculator: dict[str, Any] | None = None
+    weight_recipe: dict[str, Any] | None = None
 
     @property
     def speculator(self) -> dict[str, Any] | None:
@@ -171,6 +177,8 @@ class Plan:
         if self.source.get("format") == "safetensors":
             # A safetensors checkpoint is a directory of shards plus config
             # and tokenizer files; the engine takes the directory itself.
+            if self.weight_recipe:
+                return cache_root() / self.weight_recipe["local_dir"]
             return self.model_dir
         if self.quant.assembly:
             return self.model_dir / self.quant.assembly["output"]
@@ -213,6 +221,7 @@ def describe(profile_id: str) -> dict[str, Any]:
     the platform list, and `variant()` returns the record for one platform.
     """
     profiles = _registry()["profiles"]
+    profile_id = canonical_profile_id(profile_id)
     if profile_id not in profiles:
         raise ProfileError(
             f"unknown profile {profile_id!r}; available: {', '.join(profiles)}"
@@ -267,6 +276,10 @@ def _merge_platform(profile: dict[str, Any], platform: str) -> dict[str, Any]:
         # qwen38-nvfp4-1: the MI300X variant reuses the checkpoint's MTP
         # head, the Metal variant serves the measured DFlash2 drafter).
         "speculator": record.get("speculator"),
+        # A record may enable or disable speculation for its platform alone
+        # (glm53-nvfp4-4: MTP validated on rtx6000 first, a100 stays off).
+        "speculative": record.get("speculative"),
+        "weight_recipe": copy.deepcopy(record.get("weight_recipe")),
     }
 
 
@@ -433,11 +446,16 @@ def resolve(
         quant=chosen,
         engine=merged["engine"],
         env=merged["env"],
-        speculative=bool(profile.get("speculative")),
+        speculative=bool(
+            profile.get("speculative")
+            if merged["speculative"] is None
+            else merged["speculative"]
+        ),
         speculative_overrides=merged["speculative_overrides"],
         chat_template_kwargs=dict(profile.get("chat_template_kwargs") or {}),
         notes=merged["notes"],
         variant_speculator=merged["speculator"],
+        weight_recipe=merged["weight_recipe"],
     )
     validate_cache_policy(plan.engine)
     if plan.speculator:

--- a/slimserve/rmsnorm_diagnostic.py
+++ b/slimserve/rmsnorm_diagnostic.py
@@ -1,0 +1,404 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Startup-only, source-bound RMSNorm intervention. Never a production policy.
+
+The control reconstructs the recorded native-order launchers without changing
+their binary hashes. The legacy arm substitutes only the four identified legacy
+configurations. Both require cached AOT loading and private compilation caches.
+"""
+
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+import threading
+from functools import wraps
+from pathlib import Path
+
+from slimserve import glm53_ordering
+
+FLAG = "SLIMSERVE_GLM53_RMSNORM_DIAGNOSTIC"
+MANIFEST = "SLIMSERVE_GLM53_RMSNORM_MANIFEST"
+AUDIT_SHA = "249d26192e4a2ecc509f437e3560f982aa0b8eb82e2c53954c7212077bc636fb"
+NAMESPACE = "c8b11c6e1ba1746d15afa3aa68486eb07d2a49251573b93de0cbddf72ad47a8f"
+
+
+def sha(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def mode():
+    value = os.getenv(FLAG, "")
+    if value not in ("", "control", "legacy"):
+        raise ValueError(f"{FLAG} must be absent, control or legacy")
+    return value
+
+
+def validate_plan(plan):
+    if not mode():
+        return
+    validate_environment()
+    glm53_ordering.validate_plan(plan)
+    read_manifest()
+
+
+def validate_environment():
+    if not glm53_ordering.enabled():
+        raise ValueError("RMSNorm diagnostic requires native ordering")
+    for suffix in ("MODEL_JOURNAL", "MOE_JOURNAL", "INDEX_JOURNAL", "SCORE_JOURNAL"):
+        if os.getenv("SLIMSERVE_GLM53_" + suffix, "0") not in ("", "0"):
+            raise ValueError("RMSNorm diagnostic forbids tensor journals")
+    if (
+        os.getenv("CUDA_LAUNCH_BLOCKING", "0") != "0"
+        or os.getenv("VLLM_FORCE_AOT_LOAD") != "1"
+        or os.getenv("VLLM_GLM5_MHC_PREFILL_TC", "0") != "0"
+        or os.getenv("VLLM_GLM5_MHC_BF16_FN", "1") != "1"
+    ):
+        raise ValueError("RMSNorm diagnostic requires async, forced AOT, TC0, BF16fn1")
+
+
+def read_manifest():
+    if not os.environ.get(MANIFEST) or not os.environ.get("VLLM_CACHE_ROOT"):
+        raise ValueError("RMSNorm diagnostic requires manifest and private cache paths")
+    path = Path(os.environ[MANIFEST]).resolve()
+    data = json.loads(path.read_text())
+    if (
+        data["schema"] != 1
+        or data["audit_sha256"] != AUDIT_SHA
+        or data["namespace"] != NAMESPACE
+        or set(data["targets"]) != {str(i) for i in range(4)}
+    ):
+        raise ValueError("unexpected source-bound RMSNorm manifest")
+    private = Path(data["cache_root"]).resolve()
+    original = Path(data["original_namespace"]).resolve()
+    if (
+        private == original
+        or original in private.parents
+        or private in original.parents
+    ):
+        raise ValueError("private cache must not overlap original namespace")
+    if Path(os.environ["VLLM_CACHE_ROOT"]).resolve() != private:
+        raise ValueError("RMSNorm diagnostic requires its private VLLM cache")
+    return data, path
+
+
+def single_launcher_receipt(launcher):
+    return dict(
+        hash=launcher.cache_hash,
+        config={
+            **launcher.config.kwargs,
+            "num_warps": launcher.config.num_warps,
+            "num_stages": launcher.config.num_stages,
+        },
+    )
+
+
+def launcher_receipt(autotuner):
+    return [single_launcher_receipt(launcher) for launcher in autotuner.launchers]
+
+
+def expected_receipt(saved):
+    return [
+        dict(
+            hash=saved["triton_cache_hash"],
+            config={
+                k: saved[k] for k in ("XBLOCK", "R0_BLOCK", "num_warps", "num_stages")
+            },
+        )
+    ]
+
+
+class Intervention:
+    def __init__(self, rank, manifest, manifest_path, selected_mode):
+        self.rank = rank
+        self.manifest = manifest
+        self.mode = selected_mode
+        self.target = manifest["targets"][str(rank)]
+        self.lock = threading.RLock()
+        # Keep the objects alive: bare id() values can be recycled by Python.
+        self.replaced = {}
+        self.resolutions = 0
+        self.compiled_replacement = None
+        self.graph_bindings = {}
+        self.sealed = False
+        folder = Path(manifest["receipts"])
+        folder.mkdir(exist_ok=True)
+        self.path = folder / f"rank-{rank}.jsonl"
+        self.stream = self.path.open("x")
+        self.emit(
+            dict(
+                event="begin",
+                rank=rank,
+                mode=selected_mode,
+                pid=os.getpid(),
+                manifest_sha256=sha(manifest_path),
+                source_sha256=sha(__file__),
+            )
+        )
+
+    def emit(self, record):
+        self.stream.write(json.dumps(record, sort_keys=True) + "\n")
+        self.stream.flush()
+
+    def relocate(self, autotuner):
+        """Static artifacts contain old filenames; avoid old cache writes."""
+        if autotuner.filename is None:
+            return
+        path = Path(autotuner.filename)
+        old = Path(self.manifest["original_namespace"])
+        if path.is_relative_to(old):
+            new = Path(self.manifest["private_namespace"]) / path.relative_to(old)
+            if sha(path) != sha(new):
+                raise ValueError("relocated generated source differs")
+            autotuner.filename = str(new)
+            # A serialized save hook can also retain the original local-cache
+            # key. This diagnostic reads fixed choices and never persists tuning.
+            autotuner.save_cache_hook = None
+
+    def resolve(self, future, original_result, compile_replacement, timeout=None):
+        """Resolve and transform atomically across concurrent AOT submodules.
+
+        A cached future may be shared by concurrent source imports. Once its
+        object has been selected, don't let another cache recheck undo that
+        choice. Revalidate it and return the same object on subsequent calls.
+        """
+        with self.lock:
+            autotuner = future.static_autotuner
+            self.relocate(autotuner)
+            if id(autotuner) in self.replaced:
+                return self.replace(autotuner, compile_replacement, "reuse")
+            autotuner = original_result(future, timeout=timeout)
+            return self.replace(autotuner, compile_replacement, "upstream")
+
+    def replace(self, autotuner, compile_replacement, resolved_by="direct"):
+        """Hash-check every resolution; apply the selected config idempotently."""
+        with self.lock:
+            filename = Path(autotuner.filename or "")
+            before = launcher_receipt(autotuner)
+            target = filename.name == self.target["filename"]
+            record = dict(
+                event="launcher",
+                rank=self.rank,
+                filename=str(filename),
+                target=target,
+                before=before,
+                resolved_by=resolved_by,
+                sealed=self.sealed,
+            )
+            known = self.replaced.get(id(autotuner))
+            if known is not None and (known is not autotuner or not target):
+                raise ValueError("RMSNorm binding identity/source changed")
+            if target:
+                if self.sealed and known is None:
+                    raise ValueError("new RMSNorm target binding after seal")
+                if sha(filename) != self.target["source_sha256"]:
+                    raise ValueError("RMSNorm target source changed")
+                native = self.target["configs"][1]
+                saved = self.target["configs"][int(self.mode == "control")]
+                allowed = [expected_receipt(saved)] if known is not None else []
+                if not self.sealed:
+                    allowed.append(expected_receipt(native))
+                if before not in allowed:
+                    raise ValueError("RMSNorm native cached launcher does not match")
+                if not self.sealed:
+                    compiled = self.compiled_replacement or compile_replacement(saved)
+                    launcher = compiled.make_launcher()
+                    if [single_launcher_receipt(launcher)] != expected_receipt(saved):
+                        raise ValueError(
+                            "RMSNorm replacement binary/config does not match"
+                        )
+                    self.compiled_replacement = compiled
+                    autotuner.compile_results = [compiled]
+                    autotuner.launchers = [launcher]
+                    autotuner.configs = None
+                    autotuner._cached_launcher = None
+                    autotuner.save_cache_hook = None
+                # After seal, known exact-selected objects are read-only. New
+                # objects or changed binaries fail before touching captured work.
+                self.replaced[id(autotuner)] = autotuner
+                self.resolutions += 1
+                record.update(
+                    binding_index=list(self.replaced).index(id(autotuner)) + 1,
+                    resolution_index=self.resolutions,
+                    repeated=known is not None,
+                )
+            record["after"] = launcher_receipt(autotuner)
+            if not target and record["before"] != record["after"]:
+                raise ValueError("unrelated launcher changed")
+            self.emit(record)
+            return autotuner
+
+    def bind_graph(self, module, compile_replacement):
+        """Cover actual graph globals, including ordinary compilation futures.
+
+        Forced AOT loading does not imply every Triton kernel resolves through
+        StaticAutotunerFuture. Inspect the finished module before its callable
+        can be returned to the model, rather than inferring graph coverage from
+        the number of static callbacks.
+        """
+        if not callable(getattr(module, "call", None)):
+            return
+        with self.lock:
+            for name, autotuner in list(vars(module).items()):
+                filename = getattr(autotuner, "filename", None)
+                if not isinstance(filename, str):
+                    continue
+                if Path(filename).name != self.target["filename"]:
+                    continue
+                key = (id(module), name)
+                if self.sealed and key not in self.graph_bindings:
+                    raise ValueError("new RMSNorm graph binding after seal")
+                self.relocate(autotuner)
+                self.replace(autotuner, compile_replacement, "graph")
+                self.graph_bindings[key] = (module, autotuner)
+                self.emit(
+                    dict(
+                        event="graph_binding",
+                        rank=self.rank,
+                        symbol=name,
+                        module=module.__file__,
+                        module_sha256=sha(module.__file__),
+                        filename=autotuner.filename,
+                        binding_index=list(self.replaced).index(id(autotuner)) + 1,
+                        selected=launcher_receipt(autotuner),
+                    )
+                )
+
+    def verify_graphs(self, modules):
+        """Independently verify all loaded target globals without changing them."""
+        count = 0
+        selected = expected_receipt(self.target["configs"][int(self.mode == "control")])
+        with self.lock:
+            for (_, symbol), (module, autotuner) in self.graph_bindings.items():
+                if (
+                    vars(module).get(symbol) is not autotuner
+                    or Path(autotuner.filename or "").name != self.target["filename"]
+                ):
+                    raise ValueError("uncovered or changed RMSNorm graph binding")
+            for module in modules:
+                if not callable(getattr(module, "call", None)):
+                    continue
+                for name, autotuner in vars(module).items():
+                    filename = getattr(autotuner, "filename", None)
+                    if not isinstance(filename, str):
+                        continue
+                    if Path(filename).name != self.target["filename"]:
+                        continue
+                    binding = self.graph_bindings.get((id(module), name))
+                    if (
+                        binding is None
+                        or binding[0] is not module
+                        or binding[1] is not autotuner
+                        or self.replaced.get(id(autotuner)) is not autotuner
+                        or sha(filename) != self.target["source_sha256"]
+                        or launcher_receipt(autotuner) != selected
+                    ):
+                        raise ValueError("uncovered or changed RMSNorm graph binding")
+                    count += 1
+            if not count:
+                raise ValueError("missing RMSNorm graph coverage")
+            self.emit(dict(event="graph_coverage", rank=self.rank, bindings=count))
+
+    def seal(self):
+        with self.lock:
+            # Separate AOT submodules can own distinct autotuner objects for
+            # the same generated source. Every occurrence is hash-checked and
+            # replaced above; source coverage is not object uniqueness.
+            if not self.replaced:
+                raise ValueError(
+                    f"missing source-bound RMSNorm binding on rank{self.rank}"
+                )
+            self.sealed = True
+            self.emit(
+                dict(
+                    event="sealed",
+                    rank=self.rank,
+                    targets=len(self.replaced),
+                    resolutions=self.resolutions,
+                    sources=1,
+                )
+            )
+
+
+def install(runner, *, require_graph_coverage=True):
+    selected_mode = mode()
+    if not selected_mode:
+        return
+    validate_environment()
+    import torch
+    import triton
+    from torch._inductor.codecache import PyCodeCache, StaticAutotunerFuture
+
+    from benchmarks.kernels.check_glm53_cached_rmsnorm import checked_config
+
+    config = runner.model_config.hf_text_config
+    parallel = runner.parallel_config
+    if (
+        config.hidden_size != 4096
+        or config.num_hidden_layers != 45
+        or parallel.tensor_parallel_size != 4
+        or parallel.pipeline_parallel_size != 1
+        or parallel.enable_expert_parallel
+        or runner.speculative_config is not None
+        or torch.cuda.get_device_capability() != (12, 0)
+        or not glm53_ordering.enabled()
+        or os.getenv("VLLM_FORCE_AOT_LOAD") != "1"
+    ):
+        raise ValueError(
+            "RMSNorm diagnostic requires cached native-order GLM53 SM120 TP4"
+        )
+    manifest, path = read_manifest()
+    diagnostic = Intervention(parallel.rank, manifest, path, selected_mode)
+    original_result = StaticAutotunerFuture.result
+    original_load = PyCodeCache.__dict__["load_by_key_path"]
+    if getattr(original_result, "_glm53_rmsnorm_diagnostic", False) or getattr(
+        original_load.__func__, "_glm53_rmsnorm_diagnostic", False
+    ):
+        raise ValueError("RMSNorm diagnostic installed twice")
+
+    def compile_replacement(saved):
+        source = Path(diagnostic.target["injection_source"])
+        if sha(source) != diagnostic.target["source_sha256"]:
+            raise ValueError("RMSNorm copied source changed")
+        name = f"glm53_rmsnorm_intervention_rank{parallel.rank}"
+        spec = importlib.util.spec_from_file_location(name, source)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        template = getattr(module, diagnostic.target["kernel"])
+        cfg = checked_config(saved)
+        with torch.cuda.device(parallel.rank):
+            return template._precompile_config(
+                triton.Config(
+                    {k: cfg[k] for k in ("XBLOCK", "R0_BLOCK")},
+                    num_warps=cfg["num_warps"],
+                    num_stages=cfg["num_stages"],
+                )
+            )
+
+    @wraps(original_result)
+    def result(future, timeout=None):
+        return diagnostic.resolve(future, original_result, compile_replacement, timeout)
+
+    result._glm53_rmsnorm_diagnostic = True
+    StaticAutotunerFuture.result = result
+
+    @wraps(original_load.__func__)
+    def load_by_key_path(cls, *args, **kwargs):
+        module = original_load.__func__(cls, *args, **kwargs)
+        diagnostic.bind_graph(module, compile_replacement)
+        return module
+
+    load_by_key_path._glm53_rmsnorm_diagnostic = True
+    PyCodeCache.load_by_key_path = classmethod(load_by_key_path)
+    original_capture = runner.capture_model
+
+    @wraps(original_capture)
+    def capture(*args, **kwargs):
+        if require_graph_coverage:
+            diagnostic.verify_graphs(PyCodeCache.modules)
+        diagnostic.seal()
+        return original_capture(*args, **kwargs)
+
+    runner.capture_model = capture
+    runner._slimserve_rmsnorm_diagnostic = diagnostic

--- a/slimserve/rmsnorm_geometry.py
+++ b/slimserve/rmsnorm_geometry.py
@@ -15,6 +15,11 @@ from slimserve import glm53_ordering, rmsnorm_diagnostic
 FLAG = "SLIMSERVE_GLM53_RMSNORM_GEOMETRY"
 MANIFEST = "SLIMSERVE_GLM53_GEOMETRY_MANIFEST"
 SERVING_SCHEMA = "glm53-rmsnorm-geometry-serving-v1"
+CASES = (
+    ("control", "control"),
+    ("geometry", "geometry"),
+    ("return-control", "control"),
+)
 AOT_PAIR_SHA = "46b9c695c2734759deb55d3c15ee085dc8e3bd8eea67153ab074cdd1cb4fe946"
 AOT_CLOSURE_SHA = "ff9b29e175d6d8ac2f1c787d6ca35ee522786e20541a4ac5f3ffdf6fdfd98242"
 

--- a/slimserve/rmsnorm_geometry.py
+++ b/slimserve/rmsnorm_geometry.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in, source-qualified GLM53 RMSNorm geometry causal experiment.
+
+No compiler policy or production default. The historical four-source diagnostic
+has its own flag/schema and cannot be combined with this thirteen-source test.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from slimserve import glm53_ordering, rmsnorm_diagnostic
+
+FLAG = "SLIMSERVE_GLM53_RMSNORM_GEOMETRY"
+MANIFEST = "SLIMSERVE_GLM53_GEOMETRY_MANIFEST"
+SERVING_SCHEMA = "glm53-rmsnorm-geometry-serving-v1"
+AOT_PAIR_SHA = "46b9c695c2734759deb55d3c15ee085dc8e3bd8eea67153ab074cdd1cb4fe946"
+AOT_CLOSURE_SHA = "ff9b29e175d6d8ac2f1c787d6ca35ee522786e20541a4ac5f3ffdf6fdfd98242"
+
+
+def mode():
+    value = os.getenv(FLAG, "")
+    if value not in ("", "control", "geometry"):
+        raise ValueError(f"{FLAG} must be absent, control or geometry")
+    return value
+
+
+def validate_environment():
+    rmsnorm_diagnostic.validate_environment()
+    if os.getenv(rmsnorm_diagnostic.FLAG):
+        raise ValueError("geometry cannot combine with the legacy RMSNorm diagnostic")
+    for name in (
+        "TORCHINDUCTOR_DETERMINISTIC",
+        "TORCHINDUCTOR_BATCH_INVARIANT",
+        "TORCHINDUCTOR_FORCE_FILTER_REDUCTION_CONFIGS",
+        "VLLM_BATCH_INVARIANT",
+    ):
+        if os.getenv(name, "0") not in ("", "0"):
+            raise ValueError(f"geometry forbids conflicting compiler flag: {name}")
+
+
+def canonical_sources(sources):
+    """Match the preparer's resolved paths without losing conflicting receipts."""
+    result = {}
+    for name, digest in sources.items():
+        path = str(Path(name).resolve())
+        if result.setdefault(path, digest) != digest:
+            raise ValueError(f"conflicting qualified source aliases: {path}")
+    return result
+
+
+def read_manifest():
+    from benchmarks.kernels.check_glm53_attention_norms import require, verify
+    from benchmarks.kernels.glm53_rmsnorm_geometry import SCHEMA
+
+    selected = mode()
+    validate_environment()
+    require(bool(selected) and bool(os.getenv(MANIFEST)), "geometry manifest required")
+    path = Path(os.environ[MANIFEST]).resolve()
+    data = json.loads(path.read_text())
+    private = Path(data["private_namespace"])
+    original = Path(data["original_namespace"])
+    cache = path.parent / "cache"
+    require(
+        data["serving_schema"] == SERVING_SCHEMA
+        and data["schema"] == SCHEMA
+        and data["mode"] == selected
+        and data["namespace"] == rmsnorm_diagnostic.NAMESPACE
+        and data["aot_qualification_sha256"] == AOT_PAIR_SHA
+        and data["aot_closure_sha256"] == AOT_CLOSURE_SHA
+        and data["cache_root"] == str(cache)
+        and private
+        == cache / "torch_compile_cache/torch_aot_compile" / data["namespace"]
+        and data["receipts"] == str(path.parent / "receipts")
+        and data["worker_receipts"] == str(path.parent / "worker-receipts"),
+        "unexpected serving geometry manifest or private paths",
+    )
+    require(
+        private.resolve() == private
+        and original.resolve() == original
+        and not private.is_relative_to(original)
+        and not original.is_relative_to(private)
+        and os.getenv("VLLM_CACHE_ROOT") == str(cache)
+        and os.getenv("TORCHINDUCTOR_CACHE_DIR") == str(private / "inductor_cache"),
+        "geometry requires exact nonoverlapping private caches",
+    )
+    require(
+        set(data["targets"])
+        == set(data["artifact_roots"])
+        == set(data["expected_graphs"])
+        == {str(r) for r in range(4)}
+        and [len(data["targets"][str(r)]) for r in range(4)] == [3, 3, 3, 4]
+        and all(
+            len(data["artifact_roots"][str(r)])
+            == len(data["expected_graphs"][str(r)])
+            == 7
+            and sum(len(t["submodules"]) for t in data["artifact_roots"][str(r)]) == 46
+            for r in range(4)
+        ),
+        "incomplete all-rank geometry qualification",
+    )
+    from benchmarks.kernels.prepare_glm53_geometry_serving import (
+        CASES,
+        INTEGRATION_SITES,
+        completed_evidence,
+    )
+
+    preparation = json.loads((path.parent.parent / "preparation.json").read_text())
+    require(
+        preparation["status"] == "prepared"
+        and preparation["sources"] == data["sources"]
+        and preparation["git_commit"]
+        == data["git_commit"]
+        == subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+        and [(r["label"], r["mode"]) for r in preparation["runs"]] == list(CASES),
+        "prepared serving source identity or case order changed",
+    )
+    for row in preparation["runs"]:
+        expected = path.parent.parent / row["label"] / "manifest.json"
+        require(
+            row["manifest"] == str(expected)
+            and row["manifest_sha256"] == rmsnorm_diagnostic.sha(expected),
+            "prepared serving manifest changed",
+        )
+    require(
+        path.parent.name == data["label"] and (data["label"], selected) in CASES,
+        "wrong serving case or intervention mode",
+    )
+    qualified, graphs, reference, _ = completed_evidence(
+        Path(data["aot_pair_path"]), Path(data["aot_closure_path"])
+    )
+    sources = canonical_sources(qualified["sources"])
+    require(
+        data["qualified_manifest"] == reference
+        and data["qualified_graphs"] == graphs
+        and set(sources) <= set(data["sources"])
+        and all(
+            data["sources"][name] == digest
+            for name, digest in sources.items()
+            if Path(name).resolve() not in INTEGRATION_SITES
+        )
+        and all(
+            data[k] == qualified[k]
+            for k in (
+                "targets",
+                "artifact_roots",
+                "expected_graphs",
+                "original_files",
+                "original_namespace",
+            )
+        ),
+        "serving targets/roots or frozen implementation differ from AOT qualification",
+    )
+    verify(data)
+    return data, path
+
+
+def validate_plan(plan):
+    if not mode():
+        return
+    validate_environment()
+    glm53_ordering.validate_plan(plan)
+    if plan.engine.get("kv_cache_dtype", "auto") != "auto" or plan.engine.get(
+        "dtype", "auto"
+    ) not in ("auto", "bfloat16", "bf16"):
+        raise ValueError("geometry preserves the recipe's BF16 activation/KV settings")
+    options = plan.engine.get("compilation_config", {}).get(
+        "inductor_compile_config", {}
+    )
+    if options.get("deterministic") or options.get("combo_kernels") is False:
+        raise ValueError(
+            "geometry requires original compiler and attention combo policy"
+        )
+    read_manifest()
+
+
+def install(runner):
+    # Inert for every default profile; no Torch or diagnostic-loader import here.
+    if not mode():
+        return
+    validate_environment()
+    import torch
+
+    from benchmarks.kernels.glm53_geometry_serving import ServingGeometry
+
+    config = runner.model_config.hf_text_config
+    parallel = runner.parallel_config
+    options = runner.compilation_config.inductor_compile_config
+    if (
+        config.hidden_size != 4096
+        or config.num_hidden_layers != 45
+        or parallel.tensor_parallel_size != 4
+        or parallel.pipeline_parallel_size != 1
+        or parallel.enable_expert_parallel
+        or runner.speculative_config is not None
+        or torch.cuda.get_device_capability() != (12, 0)
+        or runner.dtype is not torch.bfloat16
+        or runner.kv_cache_dtype is not torch.bfloat16
+        or options.get("deterministic")
+        or options.get("combo_kernels") is False
+        or getattr(runner, "_slimserve_geometry", None) is not None
+    ):
+        raise ValueError(
+            "geometry requires original-policy GLM53 SM120 TP4, installed once"
+        )
+    manifest, path = read_manifest()
+    diagnostic = ServingGeometry(parallel.rank, manifest, path)
+    diagnostic.install(runner)
+    runner._slimserve_geometry = diagnostic

--- a/slimserve/routing_journal.py
+++ b/slimserve/routing_journal.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded CPU-side routing evidence, disconnected unless explicitly enabled.
+
+Record actual scheduler steps, not an inferred alignment of independent request
+histories. Enabling worker routing capture changes scheduling and adds copies;
+these records must never be used as authoritative serving-throughput timings.
+"""
+
+import json
+import os
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+
+
+def diagnostic_plan(plan, directory):
+    """Opt into a deliberately non-baseline capture on the target profile only."""
+    if (
+        plan.profile_id not in ("glm53-nvfp4-4", "glm53f-nvfp4-4")
+        or plan.platform != "rtx6000"
+    ):
+        raise ValueError("routing journal currently supports GLM-5.3 on RTX6000 TP4")
+    if plan.speculative:
+        raise ValueError("routing journal requires the no-spec profile")
+    additional = dict(plan.engine.get("additional_config") or {})
+    additional["slimserve_routing_journal"] = str(Path(directory).resolve())
+    return replace(
+        plan,
+        engine={
+            **plan.engine,
+            "enable_return_routed_experts": True,
+            "async_scheduling": False,
+            "additional_config": additional,
+        },
+    )
+
+
+class RoutingJournal:
+    def __init__(
+        self,
+        directory,
+        *,
+        model,
+        num_layers,
+        first_moe_layer,
+        num_experts,
+        top_k,
+        max_tokens=16,
+        max_records=4096,
+    ):
+        if not 0 <= first_moe_layer < num_layers:
+            raise ValueError("invalid contiguous MoE layer range")
+        if min(num_experts, top_k, max_tokens, max_records) < 1:
+            raise ValueError("journal dimensions and bounds must be positive")
+        if top_k > num_experts:
+            raise ValueError("top_k exceeds the expert count")
+        self.num_layers = num_layers
+        self.first_moe_layer = first_moe_layer
+        self.num_experts = num_experts
+        self.top_k = top_k
+        self.max_tokens = max_tokens
+        self.max_records = max_records
+        self.max_steps = 4 * max_records
+        self.steps = self.recorded = 0
+        directory = Path(directory)
+        directory.mkdir(parents=True, exist_ok=True)
+        self.path = directory / f"routing-{os.getpid()}.jsonl"
+        self.stream = self.path.open("x", buffering=1)
+        self._write(
+            {
+                "kind": "header",
+                "schema": 1,
+                "model": model,
+                "diagnostic_only": True,
+                "source": "scheduler step; model-runner request order",
+                "num_layers": num_layers,
+                "first_moe_layer": first_moe_layer,
+                "num_experts": num_experts,
+                "top_k": top_k,
+                "max_tokens": max_tokens,
+                "max_records": max_records,
+                "max_steps": self.max_steps,
+            }
+        )
+
+    def _write(self, record):
+        self.stream.write(json.dumps(record, separators=(",", ":")) + "\n")
+
+    def close(self):
+        self.stream.close()
+
+    def record(self, data, slots, req_ids, scheduled, computed, prompt_lengths):
+        """Called with fully D2H'd routing data and this step's request metadata.
+
+        Only all-decode steps with one token per request and <= max_tokens are
+        retained. Prefill/mixed steps are counted as skips; the capture limit is
+        explicit in the journal. No request ordering is reconstructed from dicts.
+        """
+        self.steps += 1
+        if self.recorded >= self.max_records:
+            return
+        if self.steps > self.max_steps:
+            if self.steps == self.max_steps + 1:
+                self._write({"kind": "step_limit", "steps": self.max_steps})
+            return
+        counts = [scheduled[rid] for rid in req_ids]
+        is_decode = all(
+            count == 1 and computed[rid] > prompt_lengths[rid]
+            for rid, count in zip(req_ids, counts)
+        )
+        if not req_ids or not is_decode or len(req_ids) > self.max_tokens:
+            self._write({"kind": "skip", "step": self.steps, "counts": counts})
+            return
+        row = {
+            "kind": "decode",
+            "step": self.steps,
+            "request_ids": list(req_ids),
+            "computed_tokens": [computed[rid] for rid in req_ids],
+            "slots": np.asarray(slots).tolist(),
+            "routes": np.asarray(data)[:, self.first_moe_layer :, :].tolist()
+            if np.ndim(data) == 3
+            else np.asarray(data).tolist(),
+        }
+        try:
+            if np.shape(data) != (len(req_ids), self.num_layers, self.top_k):
+                raise ValueError("routing data does not match this scheduler step")
+            if np.shape(slots) != (len(req_ids),):
+                raise ValueError("slot mapping does not match this scheduler step")
+            active = np.asarray(data)[:, self.first_moe_layer :, :]
+            if not np.issubdtype(active.dtype, np.integer):
+                raise ValueError("expert IDs must have integer dtype")
+            if np.any(active < 0) or np.any(active >= self.num_experts):
+                raise ValueError("expert ID outside the configured range")
+            ordered = np.sort(active, axis=-1)
+            if np.any(ordered[..., 1:] == ordered[..., :-1]):
+                raise ValueError("duplicate expert IDs: capture may be unpopulated")
+        except ValueError as error:
+            row["kind"] = "invalid"
+            row["error"] = str(error)
+            self._write(row)
+            raise
+        self._write(row)
+        self.recorded += 1
+        if self.recorded == self.max_records:
+            self._write({"kind": "limit", "recorded": self.recorded})

--- a/slimserve/smoke.py
+++ b/slimserve/smoke.py
@@ -22,12 +22,12 @@ from typing import Any
 
 import pybase64 as base64
 import regex as re
-import requests
 
 from slimserve import fetch, hardware, registry
 from slimserve.engine import engine_kwargs
 from slimserve.registry import Plan, ProfileError
 from slimserve.server import Server
+from slimserve.stream import chat_completion, visible_text
 
 _TEXT_PROMPT = "What is 2 + 2? Reply with only the number."
 _IMAGE_PROMPT = "What is the dominant color in this image? Reply with one word."
@@ -96,7 +96,10 @@ def resolve_profiles(
         raise RuntimeError(f"{registry.platform_title(machine.platform)}: {blocked}")
 
     compatible = compatible_profile_ids(machine)
-    selected = requested or compatible
+    selected = (
+        list(dict.fromkeys(registry.canonical_profile_id(p) for p in requested))
+        if requested else compatible
+    )
     if not selected:
         raise RuntimeError("no compatible profiles found")
 
@@ -173,32 +176,36 @@ def _request(
             {"type": "text", "text": prompt},
         ]
     messages = [{"role": "user", "content": content}]
+    events = []
     started = time.perf_counter()
-    body = {
-        "model": plan.engine.get("served_model_name", "model"),
-        "messages": messages,
-        "max_tokens": max_tokens,
-        # Keep the registered sampling and thinking defaults.
-        "seed": 42,
-    }
-    if plan.chat_template_kwargs:
-        body["chat_template_kwargs"] = plan.chat_template_kwargs
-    with requests.post(
-        f"{base_url}/v1/chat/completions", json=body, timeout=timeout
-    ) as response:
-        response.raise_for_status()
-        result = response.json()
-    if result.get("error"):
-        raise RuntimeError(f"chat failed: {result['error']}")
-    choice = result["choices"][0]
-    answer = choice["message"].get("content") or ""
+    raw = "".join(
+        chat_completion(
+            base_url,
+            plan.engine.get("served_model_name", "model"),
+            messages,
+            max_tokens=max_tokens,
+            # No sampling overrides: the model's shipped defaults apply.
+            # Seeded for repeatable smoke answers; greedy is never used.
+            seed=42,
+            chat_template_kwargs=plan.chat_template_kwargs or None,
+            timeout=timeout,
+            on_event=events.append,
+            include_reasoning=False,
+        )
+    )
+    answer = visible_text(raw)
     # A correct-looking number in the reasoning is not a completed answer.
-    if not answer.strip() or choice["finish_reason"] == "length":
-        raise RuntimeError(f"empty or truncated chat answer: {result}")
+    if not answer.strip() or any(
+        choice.get("finish_reason") == "length"
+        for event in events
+        for choice in event.get("choices") or []
+    ):
+        raise RuntimeError(f"empty or truncated chat answer: {events}")
     return {
         "answer": answer,
         "seconds": time.perf_counter() - started,
-        "response": result,
+        "response_events": events,
+        "answer_source": "content",
     }
 
 

--- a/slimserve/stream.py
+++ b/slimserve/stream.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from typing import Any
 
 import regex as re
@@ -70,12 +70,17 @@ def chat_completion(
     seed: int | None = None,
     chat_template_kwargs: dict[str, Any] | None = None,
     timeout: float = 600.0,
+    on_event: Callable[[dict[str, Any]], None] | None = None,
+    include_reasoning: bool = True,
 ) -> Iterator[str]:
-    """Yield content deltas from a streaming chat completion.
+    """Yield text deltas from a streaming chat completion.
 
     Sampling parameters are omitted from the request unless given, so the
     server's (i.e. the model's shipped) defaults apply. Greedy decoding is
     never used in this stack; pass `seed` when a run must be repeatable.
+    An optional observer receives each decoded event before field extraction.
+    Set include_reasoning=False to evaluate only the model's final answer;
+    the default retains the interactive client's existing combined display.
     """
     import requests
 
@@ -110,6 +115,8 @@ def chat_completion(
                 chunk = json.loads(payload)
             except json.JSONDecodeError:
                 continue
+            if on_event is not None:
+                on_event(chunk)
             if error := chunk.get("error"):
                 raise RuntimeError(f"chat stream failed: {error}")
             for choice in chunk.get("choices") or []:
@@ -117,7 +124,12 @@ def chat_completion(
                 # Reasoning models split the reply across fields, and which
                 # name carries it depends on the parser. Missing one of these
                 # shows an empty answer for a model that in fact replied.
-                for key in ("reasoning_content", "reasoning", "content"):
+                keys = (
+                    ("reasoning_content", "reasoning", "content")
+                    if include_reasoning
+                    else ("content",)
+                )
+                for key in keys:
                     piece = delta.get(key)
                     if piece:
                         yield piece

--- a/slimserve/weight_recipe.py
+++ b/slimserve/weight_recipe.py
@@ -44,7 +44,10 @@ def artifact_digest(path: Path) -> str:
         ).hexdigest()
     digest = hashlib.sha256()
     with path.open("rb") as stream:
-        size = struct.unpack("<Q", stream.read(8))[0]
+        prefix = stream.read(8)
+        if len(prefix) != 8:
+            raise ValueError(f"truncated safetensors file: {path}")
+        size = struct.unpack("<Q", prefix)[0]
         if size > 100_000_000:
             raise ValueError(f"invalid safetensors header length: {path}")
         header = json.loads(stream.read(size))

--- a/slimserve/weight_recipe.py
+++ b/slimserve/weight_recipe.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prepare the exact derived weights named by a platform record.
+
+The original checkpoint stays intact. A separate directory links its registered
+files and holds the recipe's verified sidecars. Builders run in a child process
+so preparing weights never leaves a CUDA context in the serving launcher.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from slimserve import term
+from slimserve.registry import Plan, cache_root, files_for
+
+RECEIPT = "slimserve-weight-recipe.json"
+SIDECARS = (
+    "f32-overrides.safetensors",
+    "fp8-swapset.safetensors",
+    "fp8-swapset.json",
+)
+
+
+def artifact_digest(path: Path) -> str:
+    """Hash tensor layout and bytes, excluding machine-dependent provenance.
+
+    Safetensors metadata can contain a local path and its key order is not stable.
+    The tensor descriptors (including offsets) and every data byte are included.
+    The swap-set manifest similarly excludes only its informational source path.
+    """
+    if path.suffix == ".json":
+        manifest = json.loads(path.read_text())
+        manifest.pop("source", None)
+        return hashlib.sha256(
+            json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        size = struct.unpack("<Q", stream.read(8))[0]
+        if size > 100_000_000:
+            raise ValueError(f"invalid safetensors header length: {path}")
+        header = json.loads(stream.read(size))
+        header.pop("__metadata__", None)
+        digest.update(
+            json.dumps(header, sort_keys=True, separators=(",", ":")).encode()
+        )
+        while chunk := stream.read(8 << 20):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def validate(directory: Path, recipe: dict) -> None:
+    for name in SIDECARS:
+        path = directory / name
+        if not path.is_file():
+            raise ValueError(f"{recipe['id']}: missing required artifact {path}")
+        if artifact_digest(path) != recipe["artifact_digests"][name]:
+            raise ValueError(f"{recipe['id']}: artifact digest mismatch: {path}")
+
+
+def _build(plan: Plan, staging: Path) -> None:
+    recipe = plan.weight_recipe
+    assert recipe is not None
+    from huggingface_hub import snapshot_download
+
+    native = recipe["native"]
+    native_dir = snapshot_download(
+        repo_id=native["repo"],
+        revision=native["revision"],
+        local_dir=cache_root() / native["local_dir"],
+        allow_patterns=["*.safetensors", "config.json", "model.safetensors.index.json"],
+        max_workers=2,
+    )
+    # Both builders read the original shard index; existing sidecars cannot
+    # masquerade as original weights or suppress a rebuild.
+    common = ["--native", str(native_dir), "--model", str(plan.model_dir)]
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "slimserve.f32_overrides",
+            *common,
+            "--out",
+            str(staging / SIDECARS[0]),
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "slimserve.fp8_swapset",
+            *common,
+            "--out",
+            str(staging / SIDECARS[1]),
+            "--self-quant-kda",
+            "--tp-size",
+            str(recipe["tp_size"]),
+        ],
+        check=True,
+    )
+
+
+def ensure(plan: Plan) -> None:
+    recipe = plan.weight_recipe
+    assert recipe is not None
+    if plan.source.get("revision") != recipe["target_revision"]:
+        raise ValueError(f"{recipe['id']}: target revision differs from the recipe")
+    for key in ("SLIMSERVE_F32_OVERRIDES", "SLIMSERVE_FP8_SWAPSET"):
+        if os.environ.get(key, "1") != "1":
+            raise ValueError(
+                f"{recipe['id']} requires {key}=1; unset the conflicting value"
+            )
+    if plan.engine["tensor_parallel_size"] != recipe["tp_size"]:
+        raise ValueError(
+            f"{recipe['id']}: tensor parallel size differs from the recipe"
+        )
+    destination = plan.entry_file
+    if destination.exists():
+        receipt = destination / RECEIPT
+        if not receipt.is_file() or json.loads(receipt.read_text()) != recipe:
+            raise ValueError(
+                f"{destination}: existing directory has a different weight recipe"
+            )
+        validate(destination, recipe)
+        for entry in files_for(plan):
+            if entry["role"] != "model" and entry["role"] != "shared":
+                continue
+            linked = destination / entry["path"]
+            if (
+                not linked.is_symlink()
+                or linked.resolve() != (plan.model_dir / entry["path"]).resolve()
+            ):
+                raise ValueError(
+                    f"{destination}: original checkpoint link differs: {entry['path']}"
+                )
+        term.ok(f"verified weight recipe: {recipe['id']}")
+        return
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(
+        tempfile.mkdtemp(prefix=f".{destination.name}-", dir=destination.parent)
+    )
+    term.step(f"preparing {recipe['id']} in {staging}")
+    try:
+        for entry in files_for(plan):
+            if entry["role"] in {"model", "shared"}:
+                link = staging / entry["path"]
+                link.parent.mkdir(parents=True, exist_ok=True)
+                link.symlink_to((plan.model_dir / entry["path"]).resolve())
+        try:
+            validate(plan.model_dir, recipe)
+        except ValueError:
+            _build(plan, staging)
+        else:
+            # Adopt only byte-verified existing sidecars, without sharing a
+            # mutable inode with the experiment's originals.
+            for name in SIDECARS:
+                shutil.copyfile(plan.model_dir / name, staging / name)
+        validate(staging, recipe)
+        (staging / RECEIPT).write_text(json.dumps(recipe, indent=2) + "\n")
+        staging.rename(destination)
+    except BaseException:
+        term.warn(f"incomplete recipe retained for diagnosis: {staging}")
+        raise
+    term.ok(f"prepared weight recipe: {recipe['id']}")

--- a/tests/glm5_next/test_f32_overrides.py
+++ b/tests/glm5_next/test_f32_overrides.py
@@ -1,0 +1,111 @@
+"""The F32 sidecar override for GLM-5.3-Flash conversions (loader + builder)."""
+
+import json
+import struct
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from slimserve import f32_overrides
+from vllm.model_executor.models.glm5_next import (
+    F32_OVERRIDES_ENV,
+    F32_OVERRIDES_FILE,
+    _load_f32_overrides,
+    iter_with_f32_overrides,
+)
+
+NAME = "model.language_model.layers.3.mlp.gate.e_score_correction_bias"
+
+
+def _stream():
+    yield NAME, torch.full((288,), 7.0, dtype=torch.bfloat16)
+    yield "model.language_model.layers.3.mlp.gate.weight", torch.zeros(2, 2)
+
+
+def test_overrides_replace_matching_names_only(tmp_path, monkeypatch):
+    monkeypatch.delenv(F32_OVERRIDES_ENV, raising=False)
+    save_file(
+        {NAME: torch.full((288,), 7.01, dtype=torch.float32)},
+        str(tmp_path / F32_OVERRIDES_FILE),
+    )
+    overrides = _load_f32_overrides(str(tmp_path))
+    assert set(overrides) == {NAME}
+    got = dict(iter_with_f32_overrides(_stream(), overrides))
+    assert got[NAME].dtype == torch.float32 and float(got[NAME][0]) == pytest.approx(
+        7.01
+    )
+    assert (
+        got["model.language_model.layers.3.mlp.gate.weight"].dtype == torch.float32
+    )  # untouched
+
+
+def test_missing_file_and_kill_switch_are_no_ops(tmp_path, monkeypatch):
+    monkeypatch.delenv(F32_OVERRIDES_ENV, raising=False)
+    assert _load_f32_overrides(str(tmp_path)) == {}
+    assert _load_f32_overrides(None) == {}
+    save_file({NAME: torch.ones(288)}, str(tmp_path / F32_OVERRIDES_FILE))
+    monkeypatch.setenv(F32_OVERRIDES_ENV, "0")
+    assert _load_f32_overrides(str(tmp_path)) == {}
+    assert dict(iter_with_f32_overrides(_stream(), {}))[NAME].dtype == torch.bfloat16
+
+
+def test_non_f32_sidecar_is_rejected(tmp_path, monkeypatch):
+    monkeypatch.delenv(F32_OVERRIDES_ENV, raising=False)
+    save_file(
+        {NAME: torch.ones(288, dtype=torch.bfloat16)},
+        str(tmp_path / F32_OVERRIDES_FILE),
+    )
+    with pytest.raises(ValueError, match="not float32"):
+        _load_f32_overrides(str(tmp_path))
+
+
+def _write_shard(path, tensors):
+    """Minimal safetensors writer so the builder's header parser sees real files."""
+    save_file(tensors, str(path))
+
+
+def test_builder_selects_downcast_tensors_and_skips_mtp_layer(tmp_path):
+    native = tmp_path / "native"
+    conv = tmp_path / "conv"
+    native.mkdir()
+    conv.mkdir()
+    t = torch.arange(288, dtype=torch.float32) / 7
+    a_log = torch.arange(64, dtype=torch.float32) / 3
+    _write_shard(
+        native / "model-00001-of-00001.safetensors",
+        {
+            NAME: t,
+            "model.language_model.layers.0.self_attn.A_log": a_log,
+            "model.language_model.layers.45.mlp.gate.e_score_correction_bias": (
+                t.clone()
+            ),
+            "model.language_model.layers.3.mlp.gate.weight": torch.zeros(
+                4, 4, dtype=torch.bfloat16
+            ),
+        },
+    )
+    _write_shard(
+        conv / "model-00001-of-00001.safetensors",
+        {
+            NAME: t.to(torch.bfloat16),
+            # already F32 in the conversion: must not be selected
+            "model.language_model.layers.0.self_attn.A_log": a_log.clone(),
+            "model.language_model.layers.45.mlp.gate.e_score_correction_bias": t.to(
+                torch.bfloat16
+            ),
+            "model.language_model.layers.3.mlp.gate.weight": torch.zeros(
+                4, 4, dtype=torch.bfloat16
+            ),
+        },
+    )
+    out = f32_overrides.build(str(native), str(conv))
+    assert out == conv / f32_overrides.OVERRIDES_FILE
+    with open(out, "rb") as fh:
+        n = struct.unpack("<Q", fh.read(8))[0]
+        header = json.loads(fh.read(n))
+    names = {k for k in header if k != "__metadata__"}
+    assert names == {NAME}
+    assert header[NAME]["dtype"] == "F32"
+    restored = _load_f32_overrides(str(conv))
+    assert torch.equal(restored[NAME], t)

--- a/tests/glm5_next/test_fp8_swapset.py
+++ b/tests/glm5_next/test_fp8_swapset.py
@@ -1,0 +1,338 @@
+"""The FP8 swap-set for GLM-5.3-Flash conversions: builder, manifest, config
+group, loader substitution + scale injection, kill switch, hash factor."""
+
+import json
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from slimserve import fp8_swapset
+from vllm.model_executor.models.glm5_next import (
+    _load_fp8_swapset,
+    iter_with_overrides,
+)
+
+L = "model.language_model.layers"
+CT_GROUP = {
+    "format": "float-quantized",
+    "input_activations": {
+        "dynamic": True,
+        "group_size": 128,
+        "num_bits": 8,
+        "strategy": "group",
+        "symmetric": True,
+        "type": "float",
+    },
+    "output_activations": None,
+    "targets": [
+        "re:.*\\.layers\\.45\\.mlp\\.experts\\.\\d+\\.(gate_proj|up_proj|down_proj)$"
+    ],
+    "weights": {
+        "block_structure": [128, 128],
+        "dynamic": False,
+        "num_bits": 8,
+        "strategy": "block",
+        "symmetric": True,
+        "type": "float",
+    },
+}
+
+
+def _fake_checkpoints(tmp_path):
+    """A native shard with FP8 swap tensors (and BF16 ones that must be left
+    alone) and a conversion shard holding their BF16 dequant."""
+    native, conv = tmp_path / "native", tmp_path / "conv"
+    native.mkdir()
+    conv.mkdir()
+    torch.manual_seed(0)
+    nat, con = {}, {}
+
+    def fp8(name, n, k):
+        w = torch.randn(n, k) * 0.02
+        s = w.abs().amax().clamp(min=1e-6).view(1, 1) / 448.0
+        q = (w / s).clamp(-448, 448).to(torch.float8_e4m3fn)
+        nat[name + ".weight"] = q
+        nat[name + ".weight_scale_inv"] = s.expand(
+            (n + 127) // 128, k // 128
+        ).contiguous()
+        con[name + ".weight"] = (q.float() * s).to(torch.bfloat16)
+
+    fp8(f"{L}.0.mlp.gate_proj", 256, 128)
+    fp8(f"{L}.0.mlp.up_proj", 256, 128)
+    fp8(f"{L}.3.self_attn.o_proj", 128, 256)
+    fp8(f"{L}.3.mlp.shared_experts.down_proj", 128, 128)
+    fp8(f"{L}.45.mlp.shared_experts.down_proj", 128, 128)  # MTP layer: skipped
+    # KDA layer 4: BF16 in native, not a swap candidate; a self-quant one.
+    for suffix, n, k in [
+        ("o_proj", 128, 256),
+        ("q_proj", 256, 128),
+        ("k_proj", 256, 128),
+        ("v_proj", 256, 128),
+        ("b_proj", 8, 128),
+        ("f_a_proj", 128, 128),
+        ("g_a_proj", 128, 128),
+    ]:
+        w = (torch.randn(n, k) * 0.02).to(torch.bfloat16)
+        nat[f"{L}.4.self_attn.{suffix}.weight"] = w
+        con[f"{L}.4.self_attn.{suffix}.weight"] = w
+    save_file(nat, str(native / "model-00001-of-00001.safetensors"))
+    save_file(con, str(conv / "model-00001-of-00001.safetensors"))
+    (conv / "config.json").write_text(
+        json.dumps(
+            {
+                "quantization_config": {
+                    "quant_method": "compressed-tensors",
+                    "format": "mixed-precision",
+                    "config_groups": {"group_1": CT_GROUP},
+                }
+            }
+        )
+    )
+    return native, conv
+
+
+def test_builder_selects_fp8_twins_writes_manifest_and_group(tmp_path, monkeypatch):
+    monkeypatch.delenv(fp8_swapset.SWAPSET_ENV, raising=False)
+    native, conv = _fake_checkpoints(tmp_path)
+    out = fp8_swapset.build(str(native), str(conv))
+    assert out == conv / fp8_swapset.SWAPSET_FILE
+    from safetensors.torch import load_file
+
+    tensors = load_file(str(out))
+    names = sorted(tensors)
+    assert names == sorted(
+        [
+            f"{L}.0.mlp.gate_proj.weight",
+            f"{L}.0.mlp.gate_proj.weight_scale",
+            f"{L}.0.mlp.up_proj.weight",
+            f"{L}.0.mlp.up_proj.weight_scale",
+            f"{L}.3.mlp.shared_experts.down_proj.weight",
+            f"{L}.3.mlp.shared_experts.down_proj.weight_scale",
+            f"{L}.3.self_attn.o_proj.weight",
+            f"{L}.3.self_attn.o_proj.weight_scale",
+        ]
+    )
+    assert tensors[f"{L}.3.self_attn.o_proj.weight"].dtype == torch.float8_e4m3fn
+    assert tensors[f"{L}.3.self_attn.o_proj.weight_scale"].dtype == torch.float32
+    manifest = json.loads((conv / fp8_swapset.MANIFEST_FILE).read_text())
+    assert manifest["tensors"] == names
+    assert manifest["modules"] == [
+        "language_model.model.layers.0.mlp.gate_up_proj",
+        "language_model.model.layers.3.mlp.shared_experts.down_proj",
+        "language_model.model.layers.3.self_attn.o_proj",
+    ]
+    group = manifest["config_group"]
+    assert group["weights"] == CT_GROUP["weights"]
+    assert group["targets"] == [
+        "re:.*\\.layers\\.(0)\\.mlp\\.gate_up_proj$",
+        "re:.*\\.layers\\.(3)\\.mlp\\.shared_experts\\.down_proj$",
+        "re:.*\\.layers\\.(3)\\.self_attn\\.o_proj$",
+    ]
+    # The DSA target must not reach the KDA o_proj of layer 4.
+    import re
+
+    pat = group["targets"][2][len("re:") :]
+    assert re.match(pat, "language_model.model.layers.3.self_attn.o_proj")
+    assert not re.match(pat, "language_model.model.layers.4.self_attn.o_proj")
+    assert not re.match(pat, "language_model.model.layers.43.self_attn.o_proj")
+
+
+def test_config_group_merge_hash_factor_and_kill_switch(tmp_path, monkeypatch):
+    monkeypatch.delenv(fp8_swapset.SWAPSET_ENV, raising=False)
+    native, conv = _fake_checkpoints(tmp_path)
+    assert fp8_swapset.hash_factor(str(conv)) == "fp8_swapset=off"
+    assert not fp8_swapset.apply_config_group(str(conv), {"quant_method": "x"})
+    fp8_swapset.build(str(native), str(conv))
+    qc = {"quant_method": "compressed-tensors", "config_groups": {"group_1": CT_GROUP}}
+    assert fp8_swapset.apply_config_group(str(conv), qc)
+    assert set(qc["config_groups"]) == {"group_1", fp8_swapset.GROUP_NAME}
+    assert qc["config_groups"][fp8_swapset.GROUP_NAME]["weights"]["strategy"] == "block"
+    with pytest.raises(ValueError, match="compressed-tensors"):
+        fp8_swapset.apply_config_group(str(conv), {"quant_method": "fp8"})
+    on = fp8_swapset.hash_factor(str(conv))
+    assert on.startswith("fp8_swapset=") and on != "fp8_swapset=off"
+    monkeypatch.setenv(fp8_swapset.SWAPSET_ENV, "0")
+    assert fp8_swapset.hash_factor(str(conv)) == "fp8_swapset=off"
+    assert not fp8_swapset.apply_config_group(str(conv), qc)
+    assert _load_fp8_swapset(str(conv)) == ({}, {})
+
+
+def test_loader_substitutes_weights_and_injects_scales(tmp_path, monkeypatch):
+    monkeypatch.delenv(fp8_swapset.SWAPSET_ENV, raising=False)
+    native, conv = _fake_checkpoints(tmp_path)
+    fp8_swapset.build(str(native), str(conv))
+    subs, extras = _load_fp8_swapset(str(conv))
+    assert len(subs) == 4 and len(extras) == 4
+    assert all(v.dtype == torch.float8_e4m3fn for v in subs.values())
+    assert all(v.dtype == torch.float32 for v in extras.values())
+
+    def stream():
+        yield f"{L}.0.mlp.gate_proj.weight", torch.zeros(256, 128, dtype=torch.bfloat16)
+        yield f"{L}.0.mlp.up_proj.weight", torch.zeros(256, 128, dtype=torch.bfloat16)
+        yield (
+            f"{L}.3.self_attn.o_proj.weight",
+            torch.zeros(128, 256, dtype=torch.bfloat16),
+        )
+        yield (
+            f"{L}.3.mlp.shared_experts.down_proj.weight",
+            torch.zeros(128, 128, dtype=torch.bfloat16),
+        )
+        yield (
+            f"{L}.4.self_attn.o_proj.weight",
+            torch.zeros(128, 256, dtype=torch.bfloat16),
+        )
+
+    got = list(iter_with_overrides(stream(), subs, extras, strict=True))
+    names = [n for n, _ in got]
+    assert names[:5] == [n for n, _ in stream()]  # order of the stream kept
+    assert sorted(names[5:]) == sorted(extras)  # scales injected after it
+    d = dict(got)
+    assert d[f"{L}.3.self_attn.o_proj.weight"].dtype == torch.float8_e4m3fn
+    assert d[f"{L}.4.self_attn.o_proj.weight"].dtype == torch.bfloat16  # untouched
+    assert d[f"{L}.3.self_attn.o_proj.weight_scale"].shape == (1, 2)
+
+    def short_stream():
+        yield f"{L}.0.mlp.gate_proj.weight", torch.zeros(256, 128, dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="never appeared"):
+        list(iter_with_overrides(short_stream(), subs, extras, strict=True))
+
+
+def test_manifest_and_file_must_agree(tmp_path, monkeypatch):
+    monkeypatch.delenv(fp8_swapset.SWAPSET_ENV, raising=False)
+    native, conv = _fake_checkpoints(tmp_path)
+    fp8_swapset.build(str(native), str(conv))
+    manifest = json.loads((conv / fp8_swapset.MANIFEST_FILE).read_text())
+    manifest["tensors"].append("extra")
+    (conv / fp8_swapset.MANIFEST_FILE).write_text(json.dumps(manifest))
+    with pytest.raises(ValueError, match="do not match the manifest"):
+        _load_fp8_swapset(str(conv))
+
+
+def _dequant(q, scale):
+    return fp8_swapset.dequant_bf16(q, scale).float()
+
+
+def test_quantize_block_is_absmax_over_448_with_a_ragged_last_block():
+    torch.manual_seed(1)
+    w = (torch.randn(200, 256) * 0.05).to(torch.bfloat16)
+    q, s = fp8_swapset.quantize_block(w)
+    assert q.shape == (200, 256) and q.dtype == torch.float8_e4m3fn
+    assert s.shape == (2, 2) and s.dtype == torch.float32
+    blk = w[128:200, 128:256].float().abs().amax()
+    assert torch.isclose(s[1, 1], blk / 448.0)
+    err = (_dequant(q, s) - w.float()).abs()
+    # e4m3 keeps 3 mantissa bits: half an ulp of the block's absmax at worst.
+    assert err.max() <= w.float().abs().max() / 16 * 1.01
+    assert err.norm() / w.float().norm() < 0.05
+    with pytest.raises(ValueError, match="multiple of 128"):
+        fp8_swapset.quantize_block(torch.zeros(128, 100, dtype=torch.bfloat16))
+
+
+def test_quantize_beta_lays_each_rank_in_its_own_block():
+    torch.manual_seed(2)
+    w = (torch.randn(8, 256) * 0.05).to(torch.bfloat16)
+    q, s = fp8_swapset.quantize_beta(w, tp_size=2)
+    assert q.shape == (2 * fp8_swapset.BETA_ROWS, 256) and s.shape == (2, 2)
+    d = _dequant(q, s)
+    for r in range(2):
+        rows = d[r * fp8_swapset.BETA_ROWS : (r + 1) * fp8_swapset.BETA_ROWS]
+        ref = w[4 * r : 4 * r + 4].float()
+        assert (rows[:4] - ref).abs().max() <= ref.abs().max() / 16 * 1.01
+        assert (rows[4:] == 0).all()
+        # The scale is the rank's own absmax, not the whole tensor's.
+        assert torch.isclose(
+            s[r, 0], w[4 * r : 4 * r + 4, :128].float().abs().amax() / 448
+        )
+    with pytest.raises(ValueError, match="do not shard"):
+        fp8_swapset.quantize_beta(w, tp_size=3)
+
+
+def test_self_quant_kda_extends_sidecar_manifest_and_targets(tmp_path, monkeypatch):
+    monkeypatch.delenv(fp8_swapset.SWAPSET_ENV, raising=False)
+    native, conv = _fake_checkpoints(tmp_path)
+    with pytest.raises(SystemExit, match="tp-size"):
+        fp8_swapset.build(str(native), str(conv), self_quant_kda=True)
+    out = fp8_swapset.build(str(native), str(conv), self_quant_kda=True, tp_size=2)
+    from safetensors.torch import load_file
+
+    tensors = load_file(str(out))
+    kda = [n for n in tensors if f"{L}.4." in n]
+    assert sorted(kda) == sorted(
+        f"{L}.4.self_attn.{p}.{t}"
+        for p in [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "b_proj",
+            "f_a_proj",
+            "g_a_proj",
+            "o_proj",
+        ]
+        for t in ["weight", "weight_scale"]
+    )
+    assert tensors[f"{L}.4.self_attn.b_proj.weight"].shape == (256, 128)
+    assert tensors[f"{L}.4.self_attn.b_proj.weight_scale"].shape == (2, 1)
+    assert tensors[f"{L}.4.self_attn.q_proj.weight_scale"].shape == (2, 1)
+    assert tensors[f"{L}.4.self_attn.o_proj.weight_scale"].shape == (1, 2)
+    # The native-FP8 twins are still there, byte for byte.
+    assert f"{L}.3.self_attn.o_proj.weight" in tensors
+    manifest = json.loads((conv / fp8_swapset.MANIFEST_FILE).read_text())
+    assert manifest["tp_size"] == 2 and manifest["beta_rows"] == 128
+    assert manifest["self_quantized"] == sorted(n for n in kda if n.endswith(".weight"))
+    assert (
+        "language_model.model.layers.4.self_attn.in_proj_qkvgfab" in manifest["modules"]
+    )
+    assert "language_model.model.layers.4.self_attn.o_proj" in manifest["modules"]
+    targets = manifest["config_group"]["targets"]
+    assert "re:.*\\.layers\\.(4)\\.self_attn\\.in_proj_qkvgfab$" in targets
+    assert "re:.*\\.layers\\.(3|4)\\.self_attn\\.o_proj$" in targets
+    # The model asks for the padded beta shard only where the manifest says so.
+    assert (
+        fp8_swapset.beta_shard_rows(
+            str(conv), "model.layers.4.self_attn.in_proj_qkvgfab"
+        )
+        == 128
+    )
+    assert (
+        fp8_swapset.beta_shard_rows(
+            str(conv), "model.layers.3.self_attn.in_proj_qkvgfab"
+        )
+        is None
+    )
+    monkeypatch.setenv(fp8_swapset.SWAPSET_ENV, "0")
+    assert (
+        fp8_swapset.beta_shard_rows(
+            str(conv), "model.layers.4.self_attn.in_proj_qkvgfab"
+        )
+        is None
+    )
+
+
+def test_plain_sidecar_asks_for_no_beta_padding(tmp_path, monkeypatch):
+    monkeypatch.delenv(fp8_swapset.SWAPSET_ENV, raising=False)
+    native, conv = _fake_checkpoints(tmp_path)
+    fp8_swapset.build(str(native), str(conv))
+    manifest = json.loads((conv / fp8_swapset.MANIFEST_FILE).read_text())
+    assert "self_quantized" not in manifest and "tp_size" not in manifest
+    assert (
+        fp8_swapset.beta_shard_rows(
+            str(conv), "model.layers.4.self_attn.in_proj_qkvgfab"
+        )
+        is None
+    )
+
+
+def test_loader_refuses_a_self_quant_sidecar_of_another_tp(tmp_path, monkeypatch):
+    monkeypatch.delenv(fp8_swapset.SWAPSET_ENV, raising=False)
+    native, conv = _fake_checkpoints(tmp_path)
+    fp8_swapset.build(str(native), str(conv), self_quant_kda=True, tp_size=2)
+    import vllm.model_executor.models.glm5_next as m
+
+    monkeypatch.setattr(m, "get_tensor_model_parallel_world_size", lambda: 2)
+    subs, extras = _load_fp8_swapset(str(conv))
+    assert subs[f"{L}.4.self_attn.b_proj.weight"].shape == (256, 128)
+    monkeypatch.setattr(m, "get_tensor_model_parallel_world_size", lambda: 4)
+    with pytest.raises(ValueError, match="tp_size=2, serving with 4"):
+        _load_fp8_swapset(str(conv))

--- a/tests/glm5_next/test_fp8_swapset.py
+++ b/tests/glm5_next/test_fp8_swapset.py
@@ -249,6 +249,20 @@ def test_quantize_beta_lays_each_rank_in_its_own_block():
         fp8_swapset.quantize_beta(w, tp_size=3)
 
 
+@pytest.mark.parametrize("tp_size", [0, -4])
+def test_beta_quantization_rejects_nonpositive_shards(tp_size):
+    with pytest.raises(ValueError, match="must be positive"):
+        fp8_swapset.quantize_beta(torch.ones(8, 128), tp_size=tp_size)
+
+
+@pytest.mark.parametrize("tp_size", [None, 0, -4])
+def test_kda_builder_rejects_nonpositive_shards_before_reading_weights(tp_size):
+    with pytest.raises(SystemExit, match="positive --tp-size"):
+        fp8_swapset.build(
+            "unused-native", "unused-model", self_quant_kda=True, tp_size=tp_size
+        )
+
+
 def test_self_quant_kda_extends_sidecar_manifest_and_targets(tmp_path, monkeypatch):
     monkeypatch.delenv(fp8_swapset.SWAPSET_ENV, raising=False)
     native, conv = _fake_checkpoints(tmp_path)

--- a/tests/glm5_next/test_mtp_port.py
+++ b/tests/glm5_next/test_mtp_port.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from types import SimpleNamespace
 
 import torch
 from safetensors.torch import save_file
@@ -83,6 +84,43 @@ def test_rewrite_spec_layer_name_targets_the_mtp_block():
     )
     assert r(45, base + "embed_tokens.weight") == "model.embed_tokens.weight"
     assert r(45, "lm_head.weight") == "lm_head.weight"
+
+
+def test_draft_loader_populates_all_folded_indexer_shards(monkeypatch):
+    from vllm.model_executor.models import glm5_next_sm120_mtp as module
+
+    target = "model.layers.45.mtp_block.self_attn.fused_qkv_a_proj.weight"
+    fused = torch.nn.Parameter(torch.full((5, 2), float("nan")), requires_grad=False)
+    fused.weight_loader = lambda param, weight, shard: param.data[shard].copy_(weight)
+    owner = SimpleNamespace(
+        config=SimpleNamespace(
+            num_hidden_layers=45, num_nextn_predict_layers=1, n_routed_experts=288
+        ),
+        model=SimpleNamespace(mtp_start_layer_idx=45, num_mtp_layers=1),
+        named_parameters=lambda: [(target, fused)],
+        strip_hf_prefix=Glm5NextMTP.strip_hf_prefix,
+        rewrite_spec_layer_name=Glm5NextMTP.rewrite_spec_layer_name,
+        stacked_params_mapping=Glm5NextMTP.stacked_params_mapping,
+    )
+    monkeypatch.setattr(
+        module, "fused_moe_make_expert_params_mapping", lambda *args, **kwargs: []
+    )
+    names = (
+        "q_a_proj",
+        "kv_a_proj_with_mqa",
+        "indexer.wk",
+        "indexer.index_kpool_compress_gate",
+        "indexer.weights_proj",
+    )
+    weights = [
+        (
+            f"model.language_model.layers.45.self_attn.{name}.weight",
+            torch.full((2,), float(i + 1)),
+        )
+        for i, name in enumerate(names)
+    ]
+    assert Glm5NextMTP.load_weights(owner, weights) == {target}
+    torch.testing.assert_close(fused, torch.arange(1, 6).float()[:, None].expand(5, 2))
 
 
 def _fake_checkpoint(tmp_path):

--- a/tests/glm5_next/test_mtp_port.py
+++ b/tests/glm5_next/test_mtp_port.py
@@ -1,0 +1,124 @@
+"""GLM-5.3-Flash MTP port: draft config, checkpoint-name rewrite, sidecar loading."""
+
+import json
+import os
+
+import torch
+from safetensors.torch import save_file
+from transformers import PretrainedConfig
+
+from vllm.config.load import LoadConfig
+from vllm.config.speculative import SpeculativeConfig
+from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
+from vllm.model_executor.models.glm5_next_sm120_mtp import Glm5NextMTP
+
+
+def _vl_config():
+    text = PretrainedConfig(
+        model_type="glm5_next_text",
+        num_hidden_layers=45,
+        num_nextn_predict_layers=1,
+        index_share_for_mtp_iteration=True,
+    )
+    cfg = PretrainedConfig(
+        model_type="glm5_next",
+        architectures=["Glm5NextForConditionalGeneration"],
+        text_config=text,
+        quantization_config={"quant_method": "compressed-tensors", "config_groups": {}},
+    )
+    return cfg
+
+
+def test_hf_config_override_promotes_text_config_and_quant():
+    draft = SpeculativeConfig.hf_config_override(_vl_config())
+    assert draft.model_type == "glm5_next_mtp"
+    assert draft.architectures == ["Glm5NextMTPModel"]
+    assert draft.n_predict == 1
+    assert draft.num_hidden_layers == 45
+    assert draft.quantization_config["quant_method"] == "compressed-tensors"
+    # Shared config defaults remain conservative; the SM120 profile explicitly
+    # enables the older adapter's index sharing through SpeculativeConfig.
+    assert draft.index_share_for_mtp_iteration is False
+
+
+def test_spec_layer_index_is_found_after_prefix_strip():
+    from types import SimpleNamespace
+
+    from vllm.model_executor.models.utils import get_spec_layer_idx_from_weight_name
+
+    cfg = SimpleNamespace(num_hidden_layers=45, num_nextn_predict_layers=1)
+    raw = "model.language_model.layers.45.enorm.weight"
+    assert get_spec_layer_idx_from_weight_name(cfg, raw) is None  # the trap
+    assert (
+        get_spec_layer_idx_from_weight_name(cfg, Glm5NextMTP.strip_hf_prefix(raw)) == 45
+    )
+    assert (
+        get_spec_layer_idx_from_weight_name(
+            cfg, Glm5NextMTP.strip_hf_prefix("model.language_model.layers.44.x")
+        )
+        is None
+    )
+
+
+def test_rewrite_spec_layer_name_targets_the_mtp_block():
+    r = Glm5NextMTP.rewrite_spec_layer_name
+    base = "model.language_model.layers.45."
+    assert (
+        r(45, base + "self_attn.q_a_proj.weight")
+        == "model.layers.45.mtp_block.self_attn.q_a_proj.weight"
+    )
+    assert (
+        r(45, base + "mlp.experts.7.gate_proj.weight_scale")
+        == "model.layers.45.mtp_block.mlp.experts.7.gate_proj.weight_scale"
+    )
+    assert (
+        r(45, base + "mlp.gate.e_score_correction_bias")
+        == "model.layers.45.mtp_block.mlp.gate.e_score_correction_bias"
+    )
+    assert r(45, base + "enorm.weight") == "model.layers.45.enorm.weight"
+    assert r(45, base + "eh_proj.weight") == "model.layers.45.eh_proj.weight"
+    assert (
+        r(45, base + "shared_head.norm.weight")
+        == "model.layers.45.shared_head.norm.weight"
+    )
+    assert r(45, base + "embed_tokens.weight") == "model.embed_tokens.weight"
+    assert r(45, "lm_head.weight") == "lm_head.weight"
+
+
+def _fake_checkpoint(tmp_path):
+    shard = tmp_path / "model-00001-of-00001.safetensors"
+    save_file({"model.language_model.layers.0.x": torch.zeros(2)}, str(shard))
+    save_file(
+        {"model.language_model.layers.45.enorm.weight": torch.ones(2)},
+        str(tmp_path / "model_mtp.safetensors"),
+    )
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"model.language_model.layers.0.x": shard.name}})
+    )
+
+
+def test_loader_index_filter_keeps_only_indexed_shards_by_default(tmp_path):
+    _fake_checkpoint(tmp_path)
+    loader = DefaultModelLoader(LoadConfig())
+    _, files, use_st = loader._prepare_weights(str(tmp_path), None, None, True, None)
+    assert use_st and [os.path.basename(f) for f in files] == [
+        "model-00001-of-00001.safetensors"
+    ]
+
+
+def test_loader_explicit_file_override_bypasses_the_index_filter(tmp_path):
+    _fake_checkpoint(tmp_path)
+    loader = DefaultModelLoader(LoadConfig())
+    _, files, use_st = loader._prepare_weights(
+        str(tmp_path), None, None, True, ["model_mtp.safetensors"]
+    )
+    assert use_st and [os.path.basename(f) for f in files] == ["model_mtp.safetensors"]
+
+
+def test_loader_glob_override_still_filters_by_index(tmp_path):
+    _fake_checkpoint(tmp_path)
+    loader = DefaultModelLoader(LoadConfig())
+    _, files, _ = loader._prepare_weights(
+        str(tmp_path), None, None, True, ["*.safetensors"]
+    )
+    assert [os.path.basename(f) for f in files] == ["model-00001-of-00001.safetensors"]

--- a/tests/kernels/test_glm53_model_journal.py
+++ b/tests/kernels/test_glm53_model_journal.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Synthetic compile-opaque trace qualification, not a model quality test."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from benchmarks.kernels.benchmark_mhc_output_parallel import inputs
+from slimserve.model_journal import ACTIVE, install_model_journal, instrument_mhc
+from vllm.model_executor.layers import glm5_next_mhc_ops as mhc
+from vllm.quixicore.ops import quixicore_ops as qc
+from vllm.utils.torch_utils import direct_register_custom_op
+
+pytestmark = pytest.mark.skipif(
+    not (torch.cuda.is_available() and torch.cuda.get_device_capability() == (12, 0)),
+    reason="requires SM120",
+)
+
+
+def test_compiled_all90_sites_trace_without_changing_output(tmp_path, monkeypatch):
+    monkeypatch.setenv("SLIMSERVE_GLM53_MODEL_JOURNAL", "1")
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "prompt_ids": list(range(640)),
+                "max_matches": 3,
+                "output_directory": str(tmp_path / "trace"),
+            }
+        )
+    )
+    monkeypatch.setenv("SLIMSERVE_GLM53_SCORE_JOURNAL", str(config_path))
+    library = torch.library.Library("slimserve_mhc_journal_test", "FRAGMENT")
+    for name in ("glm5_mhc_pre", "glm5_mhc_fused_post_pre", "glm5_mhc_post"):
+        direct_register_custom_op(
+            op_name=name,
+            op_func=instrument_mhc(getattr(mhc, name)),
+            fake_impl=getattr(mhc, f"_{name}_fake"),
+            target_lib=library,
+        )
+    ops = torch.ops.slimserve_mhc_journal_test
+
+    def forward(residual, fn, scale, base):
+        p, c, x = ops.glm5_mhc_pre(residual, fn, scale, base, 1e-5, 1e-6, 2.0, 20)
+        for _ in range(89):
+            residual, p, c, x = ops.glm5_mhc_fused_post_pre(
+                x,
+                residual,
+                p,
+                c,
+                fn,
+                scale,
+                base,
+                1e-5,
+                1e-6,
+                2.0,
+                20,
+            )
+        out = ops.glm5_mhc_post(x, residual, p, c)
+        return out[:, 0, :].contiguous()
+
+    saved = (
+        qc.get_glm53_mhc_prefill_tc(),
+        qc.get_dsv4_mhc_mode(),
+        qc.get_dsv4_mhc_prefill_min_t(),
+    )
+    try:
+        qc.set_glm53_mhc_prefill_tc(0)
+        qc.set_dsv4_mhc_mode(2)
+        qc.set_dsv4_mhc_prefill_min_t(64)
+        data = inputs(640, 771)
+        residual, fn, scale, base = data[1], data[4].bfloat16(), data[5], data[6]
+        # Shrink the residual mixing parameters to keep the synthetic90-site
+        # recurrence finite. These are not model checkpoint parameters.
+        scale = torch.zeros_like(scale)
+        base = torch.zeros_like(base)
+        base[:8] = -8.0
+        compiled = torch.compile(forward, backend="inductor", fullgraph=True)
+        expected = forward(residual, fn, scale, base)
+        actual = compiled(residual, fn, scale, base)
+        assert torch.equal(actual.view(torch.uint8), expected.view(torch.uint8))
+        runner = SimpleNamespace(
+            model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(model_type="glm5_next"),
+                hf_text_config=SimpleNamespace(hidden_size=4096, num_hidden_layers=45),
+            ),
+            parallel_config=SimpleNamespace(
+                tensor_parallel_size=4, pipeline_parallel_size=1
+            ),
+            speculative_config=None,
+            num_prompt_logprobs={"request": 0},
+            requests={
+                "request": SimpleNamespace(
+                    prompt_token_ids=list(range(640)), num_computed_tokens=0
+                )
+            },
+            input_batch=SimpleNamespace(num_reqs=1),
+            _model_forward=lambda **kw: compiled(kw["inputs_embeds"], fn, scale, base),
+        )
+        install_model_journal(runner)
+        for match, seed in enumerate((772, 773), 1):
+            fresh = inputs(640, seed)[1]
+            expected = compiled(fresh, fn, scale, base).clone()
+            output = runner._model_forward(
+                input_ids=torch.arange(640, device="cuda"),
+                positions=torch.arange(640, device="cuda"),
+                inputs_embeds=fresh,
+            )
+            assert torch.isfinite(output).all()
+            assert torch.equal(output.view(torch.uint8), expected.view(torch.uint8))
+            assert ACTIVE.get() is None
+            path = next((tmp_path / "trace").glob("model-*.jsonl"))
+            rows = [json.loads(line) for line in path.read_text().splitlines()]
+            assert rows[-1] == {
+                "kind": "complete",
+                "match": match,
+                "operations": 91,
+                "tensor_records": 996,
+            }
+            assert len([r for r in rows if r["kind"] == "operation"]) == match * 91
+        runner._slimserve_score_journal.close()
+    finally:
+        qc.set_glm53_mhc_prefill_tc(saved[0])
+        qc.set_dsv4_mhc_mode(saved[1])
+        qc.set_dsv4_mhc_prefill_min_t(saved[2])

--- a/tests/kernels/test_glm53_moe_journal.py
+++ b/tests/kernels/test_glm53_moe_journal.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Actual layer3 weights, synthetic640-token inputs/routes; observer parity only."""
+
+import json
+from pathlib import Path
+
+import pytest
+import torch
+
+import vllm._custom_ops as ops
+from benchmarks.kernels.profile_glm53_marlin import load_layer
+from slimserve.model_journal import ACTIVE, ModelJournal
+from slimserve.moe_journal import (
+    instrument_marlin_gemm,
+    instrument_moe_sum,
+    instrument_router,
+)
+from slimserve.score_journal import ScoreJournal
+from vllm.model_executor.layers.fused_moe.experts.marlin_moe import fused_marlin_moe
+from vllm.quixicore.ops import quixicore_ops as qc
+from vllm.scalar_type import scalar_types
+
+MODEL = Path("/raid/weights/GLM-5.3-Flash-NVFP4")
+pytestmark = pytest.mark.skipif(
+    not (
+        torch.cuda.is_available()
+        and torch.cuda.get_device_capability() == (12, 0)
+        and MODEL.is_dir()
+    ),
+    reason="requires SM120 and pinned GLM53 NVFP4 weights",
+)
+
+
+@pytest.mark.parametrize("canonical", [False, True])
+def test_native_marlin_and_shared_sum_observers_preserve_bits(
+    tmp_path, monkeypatch, canonical
+):
+    from vllm.model_executor.layers.fused_moe.experts import marlin_moe
+
+    monkeypatch.setattr(marlin_moe, "_CANONICAL_MOE_DIAGNOSTIC", canonical)
+    monkeypatch.setenv("SLIMSERVE_GLM53_MODEL_JOURNAL", "1")
+    monkeypatch.setenv("SLIMSERVE_GLM53_MOE_JOURNAL", "1")
+    monkeypatch.setattr(
+        ops, "moe_wna16_marlin_gemm", instrument_marlin_gemm(ops.moe_wna16_marlin_gemm)
+    )
+    monkeypatch.setattr(
+        qc, "moe_sum_add", staticmethod(instrument_moe_sum(qc.moe_sum_add))
+    )
+    config = tmp_path / "config.json"
+    config.write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "prompt_ids": list(range(640)),
+                "max_matches": 3,
+                "output_directory": str(tmp_path / "trace"),
+            }
+        )
+    )
+    score = ScoreJournal(config)
+    journal = ModelJournal(score)
+    weights, _ = load_layer(MODEL, 3, 0)
+    w13, s13, g13, w2, s2, g2, workspace = weights
+    ids = ((torch.arange(640 * 8, device="cuda") * 37) % 288).reshape(640, 8).int()
+    topk_weights = torch.full((640, 8), 2.5 / 8, device="cuda", dtype=torch.float32)
+    logits = torch.zeros(640, 288, device="cuda")
+
+    @instrument_router
+    def router(hidden_states, router_logits):
+        return topk_weights, ids
+
+    def call(x, shared):
+        selected_weights, selected_ids = router(x, logits)
+
+        def reduce(moe_out, out, topk_ids, expert_map):
+            qc.moe_sum_add(moe_out, shared, out)
+            return out
+
+        return fused_marlin_moe(
+            x,
+            w13,
+            w2,
+            None,
+            None,
+            s13,
+            s2,
+            selected_weights,
+            selected_ids,
+            scalar_types.float4_e2m1f.id,
+            global_scale1=g13,
+            global_scale2=g2,
+            workspace=workspace,
+            clamp_limit=10.0,
+            moe_sum=reduce,
+        )
+
+    try:
+        for match, seed in enumerate((871, 872), 1):
+            generator = torch.Generator(device="cuda").manual_seed(seed)
+            x = torch.randn(
+                640, 4096, device="cuda", dtype=torch.bfloat16, generator=generator
+            )
+            shared = torch.randn(
+                640, 4096, device="cuda", dtype=torch.bfloat16, generator=generator
+            )
+            expected = call(x, shared).clone()
+            repeated = call(x, shared)
+            assert torch.equal(
+                expected.view(torch.uint8), repeated.view(torch.uint8)
+            ), "untraced repeat differs"
+            # This is a MoE-only synthetic fixture, not a complete model trace.
+            journal.begin(f"synthetic-{match}")
+            journal.operations = 8
+            token = ACTIVE.set(journal)
+            try:
+                actual = call(x, shared)
+            finally:
+                ACTIVE.reset(token)
+            assert torch.isfinite(actual).all()
+            assert torch.equal(actual.view(torch.uint8), expected.view(torch.uint8))
+            assert journal.records == 29
+            assert journal.moe_capture.completed == set(range(1, match + 1))
+            journal.active = None
+        assert journal.moe_capture.saved_bytes < 2 * 1024**3
+        assert len(list(journal.moe_capture.directory.glob("*-parameter.pt"))) == 6
+    finally:
+        journal.close()
+        score.close()

--- a/tests/kernels/test_glm5_next_indexer_prefill.py
+++ b/tests/kernels/test_glm5_next_indexer_prefill.py
@@ -1,0 +1,386 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The GLM-5.3-Flash pooled indexer's prefill path (pooled keys once per
+request, tiled tensor-core matmul) against the per-row kernel, on a
+synthetic paged cache with uneven requests and cached prefixes; and the
+query-row -> block-table-row map of a prefill chunk."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.layers import glm5_next_indexer as gi
+from vllm.platforms import current_platform
+from vllm.v1.attention.backends.mla.indexer import (
+    DeepseekV32IndexerPrefillMetadata,
+    build_prefill_chunk_metadata,
+)
+
+H, D, KP, ROW = 32, 128, 4, gi._ROW_DIM
+BLOCK_SIZE = 1088  # the served hybrid block size (a multiple of 64)
+KSEL = 512  # index_topk 2048 // index_kpool 4
+DEV = "cuda"
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="CUDA-only Triton kernels"
+)
+
+
+@pytest.fixture(params=[(8, 64), (2, 128)])
+def prefill_tiles(request, monkeypatch):
+    """Exercise the original and isolated SM120 candidate through full selection."""
+    rt, pt = request.param
+    monkeypatch.setattr(gi, "_ROW_TILE", rt)
+    monkeypatch.setattr(gi, "_POOL_TILE", pt)
+
+
+def _synth(query_lens, cached, seed=0):
+    """A paged indexer cache for one prefill chunk: request i has
+    cached[i] KV tokens before its query_lens[i] query rows (a cached
+    prefix), so its visibility runs to cached[i] + row + 1."""
+    g = torch.Generator(device=DEV).manual_seed(seed)
+    n_req = len(query_lens)
+    seq_lens = [c + q for c, q in zip(cached, query_lens)]
+    blocks_per = [-(-s // BLOCK_SIZE) for s in seq_lens]
+    num_blocks = sum(blocks_per) + 3
+    cache = torch.randn((num_blocks, BLOCK_SIZE, ROW), generator=g, device=DEV).to(
+        torch.bfloat16
+    )
+    perm = torch.randperm(num_blocks - 1, generator=g, device=DEV) + 1
+    bt = torch.zeros((n_req, max(blocks_per)), dtype=torch.int32, device=DEV)
+    at = 0
+    for i, nb in enumerate(blocks_per):
+        bt[i, :nb] = perm[at : at + nb].to(torch.int32)
+        at += nb
+    R = sum(query_lens)
+    q = torch.randn((R, H, D), generator=g, device=DEV).to(torch.bfloat16)
+    w = torch.rand((R, H), generator=g, device=DEV) * H**-0.5
+    ape = torch.randn((KP, D), generator=g, device=DEV)
+    row_req = torch.cat(
+        [torch.full((n,), i, dtype=torch.int32) for i, n in enumerate(query_lens)]
+    ).to(DEV)
+    visible = torch.cat(
+        [
+            c + torch.arange(1, n + 1, dtype=torch.int32)
+            for c, n in zip(cached, query_lens)
+        ]
+    ).to(DEV)
+    max_pools = max(1, max(seq_lens) // KP)
+    return q, w, ape, cache, bt, row_req, visible, max_pools
+
+
+def _select(by_request, q, w, ape, cache, bt, row_req, visible, max_pools):
+    R = q.shape[0]
+    logits = torch.full((R, max_pools), float("nan"), device=DEV)
+    topk = torch.full((R, KSEL * KP + KP), -7, dtype=torch.int32, device=DEV)
+    gi._pooled_select(
+        q,
+        w,
+        ape,
+        cache,
+        bt,
+        row_req,
+        visible,
+        logits,
+        max_pools,
+        BLOCK_SIZE,
+        0.1,
+        KSEL,
+        topk,
+        KP,
+        by_request=by_request,
+    )
+    return logits, topk
+
+
+@pytest.mark.parametrize(
+    "query_lens,cached",
+    [
+        ([1000, 700, 1300, 5, 1000], [0, 0, 0, 0, 0]),
+        ([500, 1000, 3, 900], [1500, 0, 2000, 64]),  # cached prefixes
+        ([1], [0]),  # a single one-token chunk
+        ([7, 9], [3, 2500]),  # tiny queries, one over a long context
+    ],
+)
+def test_matches_per_row_kernel(query_lens, cached, prefill_tiles):
+    q, w, ape, cache, bt, row_req, visible, max_pools = _synth(query_lens, cached)
+    ref_logits, ref_topk = _select(
+        False, q, w, ape, cache, bt, row_req, visible, max_pools
+    )
+    new_logits, new_topk = _select(
+        True, q, w, ape, cache, bt, row_req, visible, max_pools
+    )
+    torch.cuda.synchronize()
+    n_pools = visible // KP
+    R = q.shape[0]
+    p = torch.arange(max_pools, device=DEV)
+    written = p[None, :] < n_pools[:, None]  # both leave the rest unwritten
+    torch.testing.assert_close(
+        new_logits[written], ref_logits[written], atol=1e-5, rtol=1e-5
+    )
+    assert not torch.isnan(new_logits[written]).any()
+    # Same tokens per row. The two kernels accumulate in a different order,
+    # so pools whose logits sit within float noise of the k-th largest may
+    # legitimately swap in and out when a row has more pools than KSEL.
+    ref_sets = ref_topk.sort(dim=1).values
+    new_sets = new_topk.sort(dim=1).values
+    for r in (ref_sets != new_sets).any(dim=1).nonzero().flatten().tolist():
+        a = set(ref_topk[r][ref_topk[r] >= 0].tolist())
+        b = set(new_topk[r][new_topk[r] >= 0].tolist())
+        assert len(a) == len(b), r
+        np_r = int(n_pools[r])
+        assert np_r > KSEL, (r, sorted(a ^ b))
+        kth = ref_logits[r, :np_r].topk(KSEL).values[-1]
+        for tok in a ^ b:
+            assert abs(float(ref_logits[r, tok // KP]) - float(kth)) < 1e-4, r
+    for r in range(0, R, max(1, R // 16)):
+        valid = ref_topk[r][ref_topk[r] >= 0]
+        assert valid.numel() == min(int(n_pools[r]), KSEL) * KP + (
+            int(visible[r]) - int(n_pools[r]) * KP
+        )
+
+
+@pytest.mark.parametrize("by_request", [False, True])
+def test_tail_tokens_survive(by_request, prefill_tiles):
+    """The incomplete tail pool's tokens (including the query's own token,
+    three rows in four) sit right after the selected pools in every row,
+    on every run: the expansion loop used to write -1 over those columns
+    from other threads of the program and raced the tail store."""
+    q, w, ape, cache, bt, row_req, visible, max_pools = _synth(
+        [500, 1000, 3, 900], [1500, 0, 2000, 64]
+    )
+    n_pools = visible // KP
+    n_sel = torch.clamp(n_pools, max=KSEL)
+    tail_count = visible - n_pools * KP
+    m = torch.arange(KP, device=DEV)
+    cols = (n_sel * KP)[:, None] + m[None, :]
+    want = torch.where(
+        m[None, :] < tail_count[:, None], (n_pools * KP)[:, None] + m[None, :], -1
+    )
+    for _ in range(5):
+        _, topk = _select(by_request, q, w, ape, cache, bt, row_req, visible, max_pools)
+        torch.cuda.synchronize()
+        got = torch.gather(topk, 1, cols.long())
+        bad = (got != want).any(dim=1).nonzero().flatten()
+        assert bad.numel() == 0, bad[:8].tolist()
+        # and nothing valid after the tail
+        after = topk[:, :].clone()
+        after[torch.arange(after.shape[0], device=DEV)[:, None], cols.long()] = -1
+        past = torch.arange(after.shape[1], device=DEV)[None, :] >= cols[:, :1]
+        assert (after[past] == -1).all()
+
+
+def test_prefill_row_req_uses_query_rows():
+    """Request 0 has a cached prefix (more KV tokens than query rows), so
+    the chunk's KV-indexed token_to_seq read by query row would put the
+    later requests' rows on the wrong block-table row."""
+    seq_lens = torch.tensor([1500, 1000, 1200], dtype=torch.int32)
+    query_lens = torch.tensor([500, 1000, 1200], dtype=torch.int32)
+    qsl_cpu = torch.zeros(4, dtype=torch.int32)
+    qsl_cpu[1:] = torch.cumsum(query_lens, 0)
+    chunk = build_prefill_chunk_metadata(
+        0,
+        3,
+        qsl_cpu.to(DEV),
+        qsl_cpu,
+        seq_lens.to(DEV),
+        seq_lens.to(DEV),
+        seq_lens,
+        torch.zeros((3, 4), dtype=torch.int32, device=DEV),
+        1,
+    )
+    R = chunk.token_end - chunk.token_start
+    assert int(query_lens.sum()) == R
+    expect = torch.repeat_interleave(torch.arange(3, dtype=torch.int32), query_lens).to(
+        DEV
+    )
+    assert torch.equal(gi._prefill_row_req(chunk, R), expect)
+    assert not torch.equal(chunk.token_to_seq[:R].to(torch.int32), expect)
+    visible = chunk.cu_seqlen_ke - chunk.cu_seqlen_ks
+    assert int(visible[0]) == 1001 and int(visible[499]) == 1500
+    assert int(visible[500]) == 1 and int(visible[R - 1]) == 1200
+
+
+@pytest.mark.parametrize("capability", [(8, 0), (9, 0), (12, 0)])
+@pytest.mark.parametrize("override", [None, "0", "1"])
+def test_prefill_matmul_platform_default(monkeypatch, capability, override):
+    monkeypatch.setattr(
+        gi,
+        "current_platform",
+        SimpleNamespace(
+            is_cuda=lambda: True,
+            is_device_capability=lambda wanted: capability == wanted,
+        ),
+    )
+    if override is None:
+        monkeypatch.delenv("VLLM_GLM5_INDEXER_PREFILL_MATMUL", raising=False)
+    else:
+        monkeypatch.setenv("VLLM_GLM5_INDEXER_PREFILL_MATMUL", override)
+    expected = capability == (12, 0) if override is None else override != "0"
+    assert gi._prefill_matmul_enabled() == expected
+
+
+def test_tp_shard_dispatch_uses_fork_chunk_metadata(monkeypatch):
+    monkeypatch.setattr(gi, "_TP_PREFILL_SHARD", True)
+    monkeypatch.setattr(gi, "_PREFILL_MATMUL", True)
+    chunks = [SimpleNamespace(token_start=3, token_end=3003, max_seq_len=32768)]
+    metadata = DeepseekV32IndexerPrefillMetadata(chunks=chunks)
+    assert not hasattr(metadata, "max_prefill_seq_len")
+    assert gi._prefill_row_sharding_enabled(metadata.chunks)
+    assert not gi._prefill_row_sharding_enabled([])
+    chunks[0].token_end = 2050
+    assert not gi._prefill_row_sharding_enabled(metadata.chunks)
+    chunks[0].token_end = 3003
+    chunks[0].max_seq_len = 32767
+    assert not gi._prefill_row_sharding_enabled(metadata.chunks)
+    chunks[0].max_seq_len = 32768
+    monkeypatch.setattr(gi, "_TP_PREFILL_SHARD", False)
+    assert not gi._prefill_row_sharding_enabled(metadata.chunks)
+
+
+@pytest.mark.parametrize(
+    "query_lens,cached", [([2], [0]), ([7, 9, 19], [0, 5000, 33000])]
+)
+def test_tp_pool_exchange_preserves_rows_tails_and_padding(query_lens, cached):
+    """Every TP owner, including empty owners, behind decode and before padding."""
+    q, w, ape, cache, bt, req, vis, max_pools = _synth(query_lens, cached, seed=4511)
+    rows, leading, trailing = q.shape[0], 3, 5
+    q_full = torch.zeros(rows + leading + trailing, H, D, dtype=q.dtype, device=DEV)
+    w_full = torch.zeros(rows + leading + trailing, H, dtype=w.dtype, device=DEV)
+    q_full[leading : leading + rows] = q
+    w_full[leading : leading + rows] = w
+    # KV starts identify requests, as in production chunk metadata.
+    cumulative = torch.tensor(
+        [
+            0,
+            *torch.tensor([a + b for a, b in zip(query_lens, cached)])
+            .cumsum(0)
+            .tolist(),
+        ],
+        device=DEV,
+        dtype=torch.int32,
+    )
+    ks = cumulative[req.long()]
+    token_to_seq = torch.repeat_interleave(
+        torch.arange(len(query_lens), device=DEV, dtype=torch.int32),
+        torch.tensor(
+            [a + b for a, b in zip(query_lens, cached)], device=DEV
+        ),
+    )
+    chunks = []
+    for start in range(0, rows, 11):
+        end = min(start + 11, rows)
+        # Real query subchunks keep the original request table, even when the
+        # first query belongs to request >0. Renumbering would select wrong KV.
+        chunks.append(
+            SimpleNamespace(
+                token_start=leading + start,
+                token_end=leading + end,
+                cu_seqlen_ks=ks[start:end],
+                cu_seqlen_ke=ks[start:end] + vis[start:end],
+                block_table=bt,
+                cu_seq_lens=cumulative,
+                local_cu_seq_lens=cumulative,
+                token_to_seq=token_to_seq,
+                max_seq_len=max_pools * KP,
+            )
+        )
+    expected = torch.full(
+        (rows + leading + trailing, 2051), -7, device=DEV, dtype=torch.int32
+    )
+    ids = torch.empty((rows, KSEL), device=DEV, dtype=torch.int32)
+    for c in chunks:
+        lo, hi = c.token_start, c.token_end
+        row_req = req[lo - leading : hi - leading]
+        assert torch.equal(gi._prefill_row_req(c, hi - lo), row_req)
+        logits = torch.empty(hi - lo, max_pools, device=DEV)
+        sel = gi._pooled_topk(
+            q_full[lo:hi],
+            w_full[lo:hi],
+            ape,
+            cache,
+            c.block_table,
+            row_req,
+            c.cu_seqlen_ke - c.cu_seqlen_ks,
+            logits,
+            max_pools,
+            BLOCK_SIZE,
+            0.1,
+            KSEL,
+            KP,
+            True,
+        )
+        ids[lo - leading : hi - leading] = sel
+        gi._expand_topk_kernel[(hi - lo,)](
+            sel,
+            c.cu_seqlen_ke - c.cu_seqlen_ks,
+            expected[lo:hi],
+            KSEL,
+            KP=KP,
+            KSEL=KSEL,
+            OUT_W=2051,
+            BLOCK_S=64,
+        )
+    owned = (rows + 3) // 4
+    for rank in range(4):
+        calls = []
+
+        def exchange(local, dim, rank=rank, calls=calls):
+            calls.append(1)
+            assert dim == 0 and local.shape == (owned, KSEL) and local.is_contiguous()
+            start, stop = rank * owned, min((rank + 1) * owned, rows)
+            valid = max(0, stop - start)
+            torch.testing.assert_close(
+                local[:valid].sort(1).values,
+                ids[start:stop].sort(1).values,
+                rtol=0,
+                atol=0,
+            )
+            assert (local[valid:] == -1).all()
+            gathered = torch.full((4 * owned, KSEL), -1, device=DEV, dtype=torch.int32)
+            gathered[:rows] = ids
+            gathered[start : start + owned] = local
+            return gathered
+
+        group = SimpleNamespace(world_size=4, rank_in_group=rank, all_gather=exchange)
+        out = torch.full_like(expected, -7)
+        gi._pooled_prefill_tp_select(
+            q_full, w_full, ape, cache, chunks, out, BLOCK_SIZE, 0.1, KSEL, KP, group
+        )
+        assert len(calls) == 1
+        torch.testing.assert_close(
+            out.sort(1).values, expected.sort(1).values, rtol=0, atol=0
+        )
+        assert (out[:leading] == -7).all() and (out[-trailing:] == -7).all()
+
+
+def test_sm120_tile_changed_input_graphs_match_original_selection(monkeypatch):
+    data = _synth([17, 5, 33], [0, 7000, 33000], seed=921)
+    q, weights, ape, cache, _, _, visible, max_pools = data
+    graphs, outputs = [], []
+    for rt, pt in ((8, 64), (2, 128)):
+        monkeypatch.setattr(gi, "_ROW_TILE", rt)
+        monkeypatch.setattr(gi, "_POOL_TILE", pt)
+        _select(True, *data)
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            output = _select(True, *data)
+        graphs.append(graph)
+        outputs.append(output)
+    valid = torch.arange(max_pools, device=DEV)[None, :] < (visible // KP)[:, None]
+    for replay in range(3):
+        generator = torch.Generator(device=DEV).manual_seed(1251 + replay)
+        q.normal_(generator=generator)
+        cache.normal_(generator=generator)
+        ape.normal_(generator=generator)
+        weights.uniform_(0, H**-0.5, generator=generator)
+        for graph in graphs:
+            graph.replay()
+        torch.cuda.synchronize()
+        reference, candidate = outputs
+        torch.testing.assert_close(
+            reference[0][valid], candidate[0][valid], atol=1e-5, rtol=1e-5
+        )
+        assert torch.equal(reference[1].sort(1).values, candidate[1].sort(1).values)

--- a/tests/kernels/test_quixicore_glm_route_align.py
+++ b/tests/kernels/test_quixicore_glm_route_align.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fused small-M routing (quixicore glm_route_align): sigmoid scores, bias-only
+top-k, renormalize + scaling, Marlin block alignment in one launch, against
+the router's grouped_topk and moe_align_block_size, for GLM-5.3-Flash's
+routing (E=288, top-8, one expert group) at M = 1..16."""
+
+import pytest
+import torch
+import triton
+
+pytest.importorskip("vllm._quixicore_C")
+from vllm.quixicore.ops import quixicore_ops as qc  # noqa: E402
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+if not qc.has_glm_route_align():
+    pytest.skip("QuixiCore build without glm_route_align", allow_module_level=True)
+
+from vllm.model_executor.layers.fused_moe.moe_align_block_size import (  # noqa: E402
+    moe_align_block_size,
+)
+from vllm.model_executor.layers.fused_moe.router import glm_route_align  # noqa: E402
+from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import (  # noqa: E402
+    grouped_topk,
+)
+
+DEV = "cuda"
+E, K, H = 288, 8, 4096
+SCALE = 2.5
+
+
+def _blocks(sorted_ids, expert_ids, post_pad, block_size, numel):
+    n = int(post_pad.item())
+    layout: dict[int, list[int]] = {}
+    for b in range(n // block_size):
+        e = int(expert_ids[b].item())
+        toks = [
+            int(t) for t in sorted_ids[b * block_size : (b + 1) * block_size].tolist()
+        ]
+        layout.setdefault(e, []).extend(t for t in toks if t < numel)
+    return {e: sorted(v) for e, v in layout.items()}, n
+
+
+@pytest.mark.parametrize("tokens", [1, 2, 3, 4, 8, 13, 16])
+def test_glm_route_align_matches_router_and_alignment(tokens):
+    torch.manual_seed(0)
+    logits = (torch.randn(tokens, E, device=DEV) * 2).float()
+    bias = (torch.randn(E, device=DEV) * 0.5).float()
+    hidden = torch.randn(tokens, H, device=DEV, dtype=torch.bfloat16)
+    block_size = glm_route_align.marlin_block_size_m(tokens, K, E)
+    max_padded, max_blocks = glm_route_align.alignment_geometry(
+        tokens, K, E, block_size
+    )
+
+    w, ids, sorted_ids, expert_ids, post_pad = torch.ops.vllm.glm_route_align(
+        logits,
+        bias,
+        K,
+        glm_route_align.SCORING["sigmoid"],
+        True,
+        SCALE,
+        block_size,
+        max_padded,
+        max_blocks,
+    )
+    ref_w, ref_ids = grouped_topk(
+        hidden_states=hidden,
+        gating_output=logits,
+        topk=K,
+        renormalize=True,
+        num_expert_group=1,
+        topk_group=1,
+        scoring_func="sigmoid",
+        routed_scaling_factor=SCALE,
+        e_score_correction_bias=bias,
+    )
+    assert torch.equal(
+        ids.sort(dim=1).values, ref_ids.to(torch.int32).sort(dim=1).values
+    )
+    torch.testing.assert_close(
+        w.sort(dim=1).values, ref_w.sort(dim=1).values, atol=1e-6, rtol=1e-6
+    )
+
+    ref_sorted, ref_experts, ref_pad = moe_align_block_size(
+        ref_ids.to(torch.int32), block_size, E, None, ignore_invalid_experts=True
+    )
+    assert int(post_pad.item()) == int(ref_pad.item())
+    assert _blocks(sorted_ids, expert_ids, post_pad, block_size, tokens * K) == _blocks(
+        ref_sorted, ref_experts, ref_pad, block_size, tokens * K
+    )
+    assert max_blocks == triton.cdiv(max_padded, block_size)
+
+
+def _non_finite_cases(tokens):
+    torch.manual_seed(1)
+    base = (torch.randn(tokens, E, device=DEV) * 2).float()
+    cases = {"all_nan": torch.full_like(base, float("nan"))}
+    half = base.clone()
+    half[tokens // 2 :] = float("nan")
+    cases["half_nan"] = half
+    row = base.clone()
+    row[0] = float("inf")
+    cases["inf_row"] = row
+    row = base.clone()
+    row[-1] = float("-inf")
+    cases["neg_inf_row"] = row
+    mixed = base.clone()
+    mixed[:, ::3] = float("nan")
+    cases["nan_columns"] = mixed
+    return cases
+
+
+@pytest.mark.parametrize("tokens", [1, 8, 16])
+def test_glm_route_align_is_total_on_non_finite_logits(tokens):
+    """vLLM's dummy runs (graph-capture warmups, the sampler warmup) carry NaN
+    activations. Whatever the logits, every expert id must stay in [0, E) and
+    the alignment must be one Marlin can consume: post_pad a multiple of the
+    block size within the buffer, every block its valid entries first and then
+    padding, the tails filled, every assignment placed exactly once in a block
+    of its own expert. The ids of a NaN token are meaningless but bounded."""
+    bias = (torch.randn(E, device=DEV) * 0.5).float()
+    block_size = glm_route_align.marlin_block_size_m(tokens, K, E)
+    max_padded, max_blocks = glm_route_align.alignment_geometry(
+        tokens, K, E, block_size
+    )
+    numel = tokens * K
+    for name, logits in _non_finite_cases(tokens).items():
+        w, ids, sorted_ids, expert_ids, post_pad = torch.ops.vllm.glm_route_align(
+            logits,
+            bias,
+            K,
+            glm_route_align.SCORING["sigmoid"],
+            True,
+            SCALE,
+            block_size,
+            max_padded,
+            max_blocks,
+        )
+        n = int(post_pad.item())
+        assert 0 < n <= max_padded and n % block_size == 0, name
+        assert int(ids.min()) >= 0 and int(ids.max()) < E, name
+        assert ids.shape == (tokens, K) and w.shape == (tokens, K), name
+        blocks = sorted_ids[:n].view(-1, block_size)
+        valid = blocks < numel
+        padded_before = (~valid).int().cumsum(dim=1) > 0
+        assert not bool((padded_before & valid).any()), f"{name}: pad before valid"
+        assert bool((sorted_ids[n:] == numel).all()), f"{name}: sorted tail"
+        used = expert_ids[: n // block_size]
+        assert int(used.min()) >= 0 and int(used.max()) < E, name
+        assert bool((expert_ids[n // block_size :] == -1).all()), f"{name}: expert tail"
+        assignments = blocks[valid]
+        assert torch.equal(
+            assignments.sort().values,
+            torch.arange(numel, device=DEV, dtype=assignments.dtype),
+        ), f"{name}: every assignment once"
+        owner = ids.view(-1)[blocks.clamp(max=numel - 1)]
+        assert not bool(((owner != used[:, None]) & valid).any()), (
+            f"{name}: assignment outside its expert's block"
+        )
+
+
+def test_glm_route_align_rejects_unsupported_shapes():
+    logits = torch.zeros(17, E, device=DEV)
+    bias = torch.zeros(E, device=DEV)
+    with pytest.raises(RuntimeError):
+        torch.ops.vllm.glm_route_align(logits, bias, K, 0, True, SCALE, 8, 64, 8)

--- a/tests/kernels/test_quixicore_glm_route_align.py
+++ b/tests/kernels/test_quixicore_glm_route_align.py
@@ -164,7 +164,7 @@ def test_glm_route_align_rejects_unsupported_shapes():
     logits = torch.zeros(17, E, device=DEV)
     bias = torch.zeros(E, device=DEV)
     max_padded, max_blocks = glm_route_align.alignment_geometry(17, K, E, 8)
-    with pytest.raises(RuntimeError, match="M must be"):
+    with pytest.raises(RuntimeError, match=r"handles 1\.\.16 tokens"):
         torch.ops.vllm.glm_route_align(
             logits, bias, K, 0, True, SCALE, 8, max_padded, max_blocks
         )

--- a/tests/kernels/test_quixicore_glm_route_align.py
+++ b/tests/kernels/test_quixicore_glm_route_align.py
@@ -75,11 +75,11 @@ def test_glm_route_align_matches_router_and_alignment(tokens):
         routed_scaling_factor=SCALE,
         e_score_correction_bias=bias,
     )
-    assert torch.equal(
-        ids.sort(dim=1).values, ref_ids.to(torch.int32).sort(dim=1).values
-    )
+    ordered, permutation = ids.sort(dim=1)
+    ref_ordered, ref_permutation = ref_ids.to(torch.int32).sort(dim=1)
+    assert torch.equal(ordered, ref_ordered)
     torch.testing.assert_close(
-        w.sort(dim=1).values, ref_w.sort(dim=1).values, atol=1e-6, rtol=1e-6
+        w.gather(1, permutation), ref_w.gather(1, ref_permutation), atol=1e-6, rtol=1e-6
     )
 
     ref_sorted, ref_experts, ref_pad = moe_align_block_size(
@@ -163,5 +163,8 @@ def test_glm_route_align_is_total_on_non_finite_logits(tokens):
 def test_glm_route_align_rejects_unsupported_shapes():
     logits = torch.zeros(17, E, device=DEV)
     bias = torch.zeros(E, device=DEV)
-    with pytest.raises(RuntimeError):
-        torch.ops.vllm.glm_route_align(logits, bias, K, 0, True, SCALE, 8, 64, 8)
+    max_padded, max_blocks = glm_route_align.alignment_geometry(17, K, E, 8)
+    with pytest.raises(RuntimeError, match="M must be"):
+        torch.ops.vllm.glm_route_align(
+            logits, bias, K, 0, True, SCALE, 8, max_padded, max_blocks
+        )

--- a/tests/kernels/test_quixicore_topk_sample.py
+++ b/tests/kernels/test_quixicore_topk_sample.py
@@ -1,0 +1,222 @@
+"""Small-k sampling against an explicit stable-order probability oracle.
+
+Top-k retains every kth-value tie; top-p sorts by ascending (logit, token ID).
+Shared noise is indexed by vocabulary ID. No tie case is exempt from equality.
+Use CPU FP64 unnormalized masses for the oracle: FP32 softmax/cumsum can put the
+midpoint of 154880 equal tokens above 0.5 and incorrectly drop one fewer token.
+This defines mathematical sampling semantics, not bitwise PyTorch reductions.
+The CPU oracle is also independent of the GPU reduction kernels being checked.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.quixicore.ops import quixicore_ops
+
+pytestmark = pytest.mark.skipif(
+    not (torch.cuda.is_available() and quixicore_ops.has_topk_sample()),
+    reason="needs CUDA and the QuixiCore topk_sample op",
+)
+DEV = "cuda"
+V = 154880
+K = 32
+
+
+def reference(logits, k, p, noise):
+    values = logits.cpu().numpy().astype(np.float64)
+    ids = np.argsort(values, axis=-1, kind="stable")
+    values = np.take_along_axis(values, ids, axis=-1)
+    threshold = np.take_along_axis(
+        values, (values.shape[1] - k.cpu().numpy())[:, None], axis=-1
+    )
+    values[values < threshold] = -np.inf
+    mass = np.exp(values - values[:, -1:])
+    if p is not None:
+        budget = (1 - p.cpu().numpy().astype(np.float64)[:, None]) * mass.sum(
+            -1, keepdims=True
+        )
+        discard = mass.cumsum(-1) <= budget
+        discard[:, -1] = False
+        mass[discard] = 0
+    masked = np.zeros_like(mass)
+    np.put_along_axis(masked, ids, mass, axis=-1)
+    sampled = (masked / noise.cpu().numpy()).argmax(-1)
+    return torch.from_numpy(sampled).to(logits.device)
+
+
+@pytest.mark.parametrize("batch", [1, 3, 16])
+@pytest.mark.parametrize("trial", [0, 1, 2, 3, 4])
+@pytest.mark.parametrize("noise_dtype", [torch.float32, torch.float64])
+def test_matches_reference_with_shared_vocabulary_noise(batch, trial, noise_dtype):
+    generator = torch.Generator(device=DEV).manual_seed(100 * batch + trial)
+    logits = torch.randn(batch, V, device=DEV, generator=generator) * (1 + trial)
+    if trial % 2:
+        logits[:, :50] = -float("inf")
+    if trial == 2:
+        logits[:, 7] = logits[:, 11] = logits.cpu().amax(dim=-1).to(DEV)
+    if trial == 3:
+        logits = logits.round()  # Cutoff groups can greatly exceed 32.
+    if trial == 4:
+        logits = logits.bfloat16().float()  # Actual output-projection precision.
+    k = torch.randint(
+        1, K + 1, (batch,), device=DEV, dtype=torch.int32, generator=generator
+    )
+    p = (
+        None
+        if trial == 0
+        else torch.rand(batch, device=DEV, generator=generator) * 0.7 + 0.3
+    )
+    noise = torch.empty(batch, V, device=DEV, dtype=noise_dtype).exponential_(
+        generator=generator
+    )
+    got = quixicore_ops.topk_sample(logits, k, p, noise)
+    assert torch.equal(got, reference(logits, k, p, noise))
+
+
+@pytest.mark.parametrize("vocab", [512, 513, V])
+@pytest.mark.parametrize("p_value", [None, 0.0, 0.02, 0.5, 0.95, 1.0])
+def test_unbounded_ties_and_strictly_higher_values(vocab, p_value):
+    generator = torch.Generator(device=DEV).manual_seed(901)
+    logits = torch.zeros(4, vocab, device=DEV)
+    # All ties; small strict prefix; a nucleus boundary above kth;
+    # and one finite token with every other vocabulary entry masked.
+    logits[1, 1:10] = 1
+    logits[2, 1:10] = 3
+    logits[2, 21:31] = 2
+    logits[3] = -float("inf")
+    logits[3, 31] = 0
+    k = torch.tensor([1, 20, 32, 32], dtype=torch.int32, device=DEV)
+    p = None if p_value is None else torch.full((4,), p_value, device=DEV)
+    noise = torch.empty_like(logits).exponential_(generator=generator)
+    got = quixicore_ops.topk_sample(logits, k, p, noise)
+    assert torch.equal(got, reference(logits, k, p, noise))
+
+
+def test_local_overflow_and_noncontiguous_rows():
+    generator = torch.Generator(device=DEV).manual_seed(311)
+    logits = torch.full((6, V), -float("inf"), device=DEV)[::2]
+    # More than 32 ties inside a single candidate partition; other partitions
+    # contain higher values. Discarded ties must still contribute their mass.
+    logits[:, 100:3100] = 0
+    logits[:, 70000:70009] = 1
+    k = torch.tensor([10, 20, 32], dtype=torch.int32, device=DEV)
+    p = torch.tensor([0.5, 0.95, 1.0], device=DEV)
+    noise = torch.empty((3, V), device=DEV).exponential_(generator=generator)
+    assert not logits.is_contiguous()
+    got = quixicore_ops.topk_sample(logits, k, p, noise)
+    assert torch.equal(got, reference(logits, k, p, noise))
+
+
+def test_signed_zero_is_one_tie_group():
+    generator = torch.Generator(device=DEV).manual_seed(991)
+    logits = torch.zeros(3, V, device=DEV)
+    logits[:, ::2] = -0.0
+    k = torch.tensor([1, 20, 32], dtype=torch.int32, device=DEV)
+    p = torch.tensor([0.1, 0.5, 0.95], device=DEV)
+    noise = torch.empty_like(logits).exponential_(generator=generator)
+    got = quixicore_ops.topk_sample(logits, k, p, noise)
+    assert torch.equal(got, reference(logits, k, p, noise))
+
+
+@pytest.mark.parametrize("vocab", [512, 513, V])
+def test_uniform_noise_exposes_exact_nucleus_boundary(vocab):
+    logits = torch.zeros(6, vocab, device=DEV)
+    k = torch.full((6,), 20, dtype=torch.int32, device=DEV)
+    p = torch.tensor([0.0, 0.02, 0.1, 0.5, 0.95, 1.0], device=DEV)
+    noise = torch.ones_like(logits)
+    # All retained scores tie, so argmax must be the lowest retained ID.
+    # Random noise alone rarely catches a one-token cutoff error.
+    got = quixicore_ops.topk_sample(logits, k, p, noise)
+    assert torch.equal(got, reference(logits, k, p, noise))
+    if vocab % 2 == 0:
+        assert got[3].item() == vocab // 2  # Exact half of a uniform mass.
+
+
+def test_every_k_uses_the_entire_uniform_tie_group():
+    vocab = 1000
+    logits = torch.zeros(32, vocab, device=DEV)
+    k = torch.arange(1, 33, dtype=torch.int32, device=DEV)
+    p = torch.linspace(0, 1, 32, device=DEV)
+    expected = ((1 - p.double()) * vocab).floor().long().clamp(max=vocab - 1)
+    got = quixicore_ops.topk_sample(logits, k, p, torch.ones_like(logits))
+    assert torch.equal(got, expected)
+
+
+def test_fp64_noise_is_not_silently_narrowed():
+    logits = torch.full((1, 512), -float("inf"), device=DEV)
+    logits[0, 3] = logits[0, 9] = 0
+    k = torch.tensor([2], dtype=torch.int32, device=DEV)
+    noise = torch.ones((1, 512), device=DEV, dtype=torch.float64)
+    noise[0, 3] = 1 + 1e-9  # Both become 1 if narrowed to float32.
+    got = quixicore_ops.topk_sample(logits, k, None, noise)
+    assert got.item() == 9
+    assert torch.equal(got, reference(logits, k, None, noise))
+
+
+def test_seed_determinism_includes_large_tie_groups():
+    from vllm.v1.sample.ops.topk_topp_sampler import small_topk_sample
+
+    logits = torch.zeros(3, V, device=DEV)
+    k = torch.tensor([1, 4, 20], device=DEV, dtype=torch.int32)
+    p = torch.tensor([1.0, 0.5, 0.95], device=DEV)
+
+    def draw():
+        generators = {
+            i: torch.Generator(device=DEV).manual_seed(11 + i) for i in range(3)
+        }
+        return small_topk_sample(logits, generators, k, p, False)
+
+    expected = draw()
+    for _ in range(5):
+        assert torch.equal(draw(), expected)
+
+
+def test_graph_replay_uses_live_logits_and_noise():
+    generator = torch.Generator(device=DEV).manual_seed(778)
+    logits = torch.randn(3, 512, device=DEV, generator=generator)
+    k = torch.tensor([1, 20, 32], dtype=torch.int32, device=DEV)
+    p = torch.tensor([0.95, 0.5, 1.0], device=DEV)
+    noise = torch.empty_like(logits).exponential_(generator=generator)
+    quixicore_ops.topk_sample(logits, k, p, noise)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        got = quixicore_ops.topk_sample(logits, k, p, noise)
+    for tied in (False, True, False):
+        logits.normal_(generator=generator)
+        if tied:
+            logits.round_()
+        noise.exponential_(generator=generator)
+        graph.replay()
+        assert torch.equal(got, reference(logits, k, p, noise))
+
+
+def test_empty_batch_and_wrong_noise_shape():
+    logits = torch.empty((0, 512), device=DEV)
+    k = torch.empty((0,), dtype=torch.int32, device=DEV)
+    out = quixicore_ops.topk_sample(logits, k, None, logits)
+    assert out.shape == (0,) and out.dtype == torch.int64
+    with pytest.raises(RuntimeError, match="noise"):
+        quixicore_ops.topk_sample(
+            torch.zeros((1, 512), device=DEV),
+            torch.ones((1,), dtype=torch.int32, device=DEV),
+            None,
+            torch.ones((1, K), device=DEV),
+        )
+
+
+@pytest.mark.parametrize("vocab", [513, V])
+def test_nonfinite_dummy_inputs_never_emit_out_of_range_ids(vocab):
+    # Dummy startup inputs need index safety, not meaningful probabilities.
+    logits = torch.zeros(6, vocab, device=DEV)
+    logits[0] = float("nan")
+    logits[1] = float("inf")
+    logits[2] = -float("inf")
+    logits[3, 7] = float("nan")
+    logits[4, 11] = float("inf")
+    logits[5, ::3] = float("nan")
+    k = torch.tensor([1, 20, 32, 20, 32, 1], dtype=torch.int32, device=DEV)
+    for p in (None, torch.full((6,), 0.95, device=DEV)):
+        got = quixicore_ops.topk_sample(logits, k, p, torch.ones_like(logits))
+        assert ((got >= 0) & (got < vocab)).all().item()

--- a/tests/model_executor/test_mamba_copy_warmup.py
+++ b/tests/model_executor/test_mamba_copy_warmup.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+import ctypes
+
+import pytest
+import torch
+
+from vllm.model_executor.warmup.mamba_copy_warmup import warm_mamba_copy_kernel
+from vllm.v1.worker import mamba_utils
+
+
+def test_warmup_uses_production_copy_api_and_metadata_dtypes(monkeypatch):
+    calls = []
+
+    def copy(src, dst, sizes):
+        assert src.dtype == dst.dtype == torch.uint64
+        assert sizes.dtype == torch.int32
+        assert src.shape == dst.shape == sizes.shape == (1,)
+        assert src.item() != dst.item()
+        assert sizes.item() == 1025
+        ctypes.memmove(dst.item(), src.item(), sizes.item())
+        calls.append(sizes.item())
+
+    monkeypatch.setattr(mamba_utils, "batch_memcpy", copy)
+    warm_mamba_copy_kernel(torch.device("cpu"))
+    assert calls == [1025]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_warmed_copy_handles_real_lengths_and_left_overlap(monkeypatch):
+    from triton import knobs
+
+    device = torch.device("cuda")
+    warm_mamba_copy_kernel(device)
+
+    def unexpected_compile(**kwargs):
+        raise AssertionError("state copy recompiled after startup warmup")
+
+    monkeypatch.setattr(knobs.runtime, "jit_post_compile_hook", unexpected_compile)
+    for size in (0, 1, 1023, 1024, 1025, 8192):
+        source = torch.arange(size + 8, device=device, dtype=torch.int32).to(
+            torch.uint8
+        )
+        reference = source.clone()
+        # Left-shift an overlapping state as used by convolution caches.
+        source_ptr = source.data_ptr() + 3
+        destination_ptr = source.data_ptr()
+        mamba_utils.batch_memcpy(
+            torch.tensor([source_ptr], dtype=torch.uint64, device=device),
+            torch.tensor([destination_ptr], dtype=torch.uint64, device=device),
+            torch.tensor([size], dtype=torch.int32, device=device),
+        )
+        assert torch.equal(source[:size], reference[3 : 3 + size])
+        assert torch.equal(source[size:], reference[size:])

--- a/tests/slimserve/test_combine_shared.py
+++ b/tests/slimserve/test_combine_shared.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unsupported native combine inputs must leave the runner's add available."""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.fused_moe import combine_shared
+
+
+class SharedOutput:
+    def __init__(self, value):
+        self.value = value
+        self.consumed = False
+
+    def peek_output(self):
+        return self.value
+
+    @property
+    def output(self):
+        self.consumed = True
+        return self.value
+
+
+@pytest.fixture(autouse=True)
+def clear_publication():
+    combine_shared.retire()
+    yield
+    combine_shared.retire()
+
+
+def test_supported_combine_consumes_shared_output_once():
+    ids = torch.zeros(2, 8, dtype=torch.int32)
+    output = torch.empty(2, 16, dtype=torch.bfloat16)
+    shared = SharedOutput(torch.ones_like(output))
+    combine_shared.publish(ids, shared)
+    assert combine_shared.consume(ids, output) is shared.value
+    assert shared.consumed
+    assert combine_shared.consume(ids, output) is None
+    assert combine_shared.retire()
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "fp16",
+        "fp32",
+        "width",
+        "shared_offset",
+        "output_offset",
+        "strided",
+        "wrong_ids",
+        "shape",
+        "device",
+    ],
+)
+def test_unsupported_combine_keeps_shared_output_for_fallback(case):
+    ids = torch.zeros(2, 8, dtype=torch.int32)
+    output = torch.empty(2, 16, dtype=torch.bfloat16)
+    value = torch.ones_like(output)
+    if case in ("fp16", "fp32"):
+        dtype = torch.float16 if case == "fp16" else torch.float32
+        output, value = output.to(dtype), value.to(dtype)
+    elif case == "width":
+        output = torch.empty(2, 7, dtype=torch.bfloat16)
+        value = torch.ones_like(output)
+    elif case == "shared_offset":
+        value = torch.ones(33, dtype=torch.bfloat16)[1:].view(2, 16)
+    elif case == "output_offset":
+        output = torch.empty(33, dtype=torch.bfloat16)[1:].view(2, 16)
+    elif case == "strided":
+        value = torch.ones(2, 32, dtype=torch.bfloat16)[:, ::2]
+    elif case == "shape":
+        value = torch.ones(1, 16, dtype=torch.bfloat16)
+    elif case == "device":
+        value = torch.empty_like(output, device="meta")
+    shared = SharedOutput(value)
+    combine_shared.publish(ids, shared)
+    assert (
+        combine_shared.consume(ids.clone() if case == "wrong_ids" else ids, output)
+        is None
+    )
+    assert not shared.consumed
+    assert not combine_shared.retire()
+    assert shared.output is value

--- a/tests/slimserve/test_marlin_workspace.py
+++ b/tests/slimserve/test_marlin_workspace.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Marlin lock reuse follows layer/ubatch ownership, never a global device."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.fused_moe.config import int4_w4a16_moe_quant_config
+from vllm.model_executor.layers.fused_moe.experts import marlin_moe as marlin
+
+
+@pytest.fixture
+def owners(monkeypatch):
+    state = SimpleNamespace(ubatch=0, allocations=[])
+    config = SimpleNamespace(
+        additional_config={}, parallel_config=SimpleNamespace(use_ubatching=True)
+    )
+    monkeypatch.setattr(marlin, "get_current_vllm_config_or_none", lambda: config)
+    monkeypatch.setattr(marlin, "get_marlin_input_dtype", lambda: None)
+    monkeypatch.setattr(
+        marlin, "current_platform", SimpleNamespace(is_cuda=lambda: False)
+    )
+    monkeypatch.setattr(marlin, "dbo_current_ubatch_id", lambda: state.ubatch)
+
+    def allocate(device, blocks):
+        assert blocks == 4
+        workspace = torch.zeros(16, dtype=torch.int32)
+        state.allocations.append((device, workspace))
+        return workspace
+
+    monkeypatch.setattr(marlin, "marlin_make_workspace_new", allocate)
+
+    def make(batched=False):
+        quant = int4_w4a16_moe_quant_config(torch.ones(1), torch.ones(1))
+        cls = marlin.BatchedMarlinExperts if batched else marlin.MarlinExperts
+        kwargs = dict(max_num_tokens=8, num_dispatchers=1) if batched else {}
+        return cls(SimpleNamespace(), quant, **kwargs)
+
+    return state, config, make
+
+
+def test_workspace_is_owned_by_layer_device_and_ubatch(owners):
+    state, _, make = owners
+    first, second = make(), make()
+    device = torch.device("cuda:0")
+    workspace = first._marlin_workspace(device)
+    assert first._marlin_workspace(device) is workspace
+    assert second._marlin_workspace(device) is not workspace
+    assert first._marlin_workspace(torch.device("cuda:1")) is not workspace
+    state.ubatch = 1
+    other_ubatch = first._marlin_workspace(device)
+    assert other_ubatch is not workspace
+    assert first._marlin_workspace(device) is other_ubatch
+    state.ubatch = 0
+    assert first._marlin_workspace(device) is workspace
+    assert len(state.allocations) == 4
+
+
+@pytest.mark.parametrize("config_present", [False, True])
+def test_non_ubatched_owner_never_queries_thread_context(
+    owners, monkeypatch, config_present
+):
+    _, config, make = owners
+    config.parallel_config.use_ubatching = False
+    if not config_present:
+        monkeypatch.setattr(marlin, "get_current_vllm_config_or_none", lambda: None)
+
+    def unexpected_context_query():
+        pytest.fail("non-ubatched serving must not consult DBO thread state")
+
+    monkeypatch.setattr(marlin, "dbo_current_ubatch_id", unexpected_context_query)
+    owner = make()
+    device = torch.device("cuda:0")
+    assert owner._marlin_workspace(device) is owner._marlin_workspace(device)
+
+
+@pytest.mark.parametrize("path", ["standard", "lora", "batched"])
+def test_every_expert_path_passes_owned_workspace(owners, monkeypatch, path):
+    state, _, make = owners
+    owner = make(batched=path == "batched")
+    if path == "lora":
+        owner.set_lora_context(object())
+    observed = []
+
+    def run(**kwargs):
+        observed.append(kwargs["workspace"])
+        return kwargs["output"]
+
+    monkeypatch.setattr(marlin, "fused_marlin_moe", run)
+    monkeypatch.setattr(marlin, "batched_fused_marlin_moe", run)
+    tensor = torch.empty(2, 32)
+    for state.ubatch in (0, 1, 0):
+        owner.apply(
+            output=tensor,
+            hidden_states=tensor,
+            w1=tensor,
+            w2=tensor,
+            topk_weights=torch.ones(2, 1),
+            topk_ids=torch.zeros(2, 1, dtype=torch.int32),
+            activation=marlin.MoEActivation.SILU,
+            global_num_experts=1,
+            expert_map=None,
+            a1q_scale=None,
+            a2_scale=None,
+            workspace13=tensor,
+            workspace2=tensor,
+            expert_tokens_meta=SimpleNamespace(expert_num_tokens=torch.tensor([2])),
+            apply_router_weight_on_input=False,
+        )
+    assert observed[0] is observed[2]
+    assert observed[0] is not observed[1]
+    assert len(state.allocations) == 2
+
+
+@pytest.mark.parametrize("explicit", [False, True])
+def test_standalone_call_uses_fresh_or_explicit_workspace(
+    owners, monkeypatch, explicit
+):
+    state, _, _ = owners
+    observed = []
+
+    def gemm(
+        a,
+        output,
+        b,
+        bias,
+        scales,
+        a_scales,
+        global_scale,
+        zeros,
+        g_idx,
+        sort_indices,
+        workspace,
+        *args,
+        **kwargs,
+    ):
+        observed.append(workspace)
+        return output
+
+    monkeypatch.setattr(marlin.ops, "moe_wna16_marlin_gemm", gemm)
+    monkeypatch.setattr(marlin, "marlin_moe_intermediate_size", lambda *_: 16)
+    workspace = torch.zeros(16, dtype=torch.int32) if explicit else None
+    tensor = torch.empty(2, 32)
+    for _ in range(2):
+        marlin._fused_marlin_moe(
+            hidden_states=tensor,
+            w1=tensor,
+            w2=tensor,
+            bias1=None,
+            bias2=None,
+            w1_scale=tensor,
+            w2_scale=tensor,
+            topk_weights=torch.ones(2, 1),
+            num_topk=1,
+            quant_type=marlin.scalar_types.uint4b8,
+            apply_router_weight_on_input=False,
+            expert_map=None,
+            block_size_m=8,
+            sorted_token_ids=torch.arange(2, dtype=torch.int32),
+            expert_ids=torch.zeros(2, dtype=torch.int32),
+            num_tokens_post_padded=torch.tensor([2], dtype=torch.int32),
+            activation_func=lambda *args, **kwargs: None,
+            workspace=workspace,
+        )
+    assert observed[0] is observed[1]
+    assert observed[2] is observed[3]
+    if explicit:
+        assert all(item is workspace for item in observed)
+        assert not state.allocations
+    else:
+        assert observed[0] is not observed[2]
+        assert len(state.allocations) == 2

--- a/tests/slimserve/test_mhc_storage_loader.py
+++ b/tests/slimserve/test_mhc_storage_loader.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+
+from vllm.model_executor.layers.glm5_next_mhc_ops import load_lossless_mhc_fn
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_original_bf16_values_load_without_changing_the_parameter_storage(dtype):
+    weight = torch.tensor([[0.0, -1.0, 0.125, 1e-20]], dtype=torch.bfloat16).to(dtype)
+    param = torch.nn.Parameter(
+        torch.zeros_like(weight, dtype=torch.bfloat16), requires_grad=False
+    )
+    pointer = param.data_ptr()
+    load_lossless_mhc_fn(param, weight)
+    assert param.data_ptr() == pointer
+    assert torch.equal(param.float(), weight.float())
+
+
+@pytest.mark.parametrize("value", [0.1, float("nan"), float("inf")])
+def test_storage_loader_rejects_lossy_or_nonfinite_values_before_copying(value):
+    param = torch.zeros(1, dtype=torch.bfloat16)
+    with pytest.raises(ValueError, match="alter checkpoint"):
+        load_lossless_mhc_fn(param, torch.tensor([value], dtype=torch.float32))
+    assert torch.equal(param, torch.zeros_like(param))
+
+
+def test_storage_loader_rejects_broadcast_shapes_and_wrong_parameter_dtype():
+    param = torch.zeros(2, dtype=torch.bfloat16)
+    with pytest.raises(ValueError, match="shapes differ"):
+        load_lossless_mhc_fn(param, torch.ones(1, dtype=torch.bfloat16))
+    with pytest.raises(ValueError, match="BF16 parameter"):
+        load_lossless_mhc_fn(param.float(), torch.ones_like(param))
+    with pytest.raises(ValueError, match="BF16/FP32 source"):
+        load_lossless_mhc_fn(param, torch.ones(2, dtype=torch.float16))
+
+
+def test_registered_fake_ops_keep_fp32_mixes_with_bf16_fn_storage():
+    residual = torch.empty(2, 4, 4096, device="meta", dtype=torch.bfloat16)
+    fn = torch.empty(24, 16384, device="meta", dtype=torch.bfloat16)
+    scale = torch.empty(3, device="meta", dtype=torch.float32)
+    base = torch.empty(24, device="meta", dtype=torch.float32)
+    constants = (1e-5, 1e-6, 2.0, 20)
+    post, comb, x = torch.ops.vllm.glm5_mhc_pre(residual, fn, scale, base, *constants)
+    assert (post.shape, comb.shape, x.shape) == ((2, 4, 1), (2, 4, 4), (2, 4096))
+    assert post.dtype == comb.dtype == torch.float32
+    assert x.dtype == torch.bfloat16
+    out = torch.ops.vllm.glm5_mhc_fused_post_pre(
+        x, residual, post, comb, fn, scale, base, *constants
+    )
+    assert [t.shape for t in out] == [residual.shape, post.shape, comb.shape, x.shape]
+    assert [t.dtype for t in out] == [
+        torch.bfloat16,
+        torch.float32,
+        torch.float32,
+        torch.bfloat16,
+    ]
+
+
+@pytest.mark.parametrize(
+    "failure", [None, "storage", "settings", "device", "library", "runtime"]
+)
+def test_requested_tensor_core_path_fails_closed(monkeypatch, failure):
+    from types import SimpleNamespace
+
+    from vllm.model_executor.layers import glm5_next_mhc_ops as ops
+
+    config = SimpleNamespace(
+        hidden_size=4096,
+        hc_mult=4,
+        rms_norm_eps=1e-5,
+        hc_eps=1e-6,
+        hc_sinkhorn_iters=20,
+    )
+    if failure == "settings":
+        config.hc_sinkhorn_iters = 3
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_capability",
+        lambda: (8, 0) if failure == "device" else (12, 0),
+    )
+    monkeypatch.setattr(
+        ops,
+        "_qc",
+        lambda: SimpleNamespace(
+            has_glm53_mhc_prefill_tc=lambda: failure != "library",
+            get_glm53_mhc_prefill_tc=lambda: 0 if failure == "runtime" else 1,
+        ),
+    )
+    if failure is None:
+        ops.validate_glm53_mhc_prefill_tc(config, True)
+    else:
+        with pytest.raises((ValueError, RuntimeError), match="mHC tensor-core"):
+            ops.validate_glm53_mhc_prefill_tc(config, failure != "storage")

--- a/tests/slimserve/test_profiles.py
+++ b/tests/slimserve/test_profiles.py
@@ -40,6 +40,82 @@ def test_every_profile_resolves_on_a_platform_it_claims():
             assert plan.engine, "a profile with no engine settings would serve nothing"
 
 
+def test_glm53_spill_free_indexer_geometry_is_rtx6000_scoped():
+    key = "VLLM_GLM5_INDEXER_SM120_TILES"
+    rtx = resolve("glm53-nvfp4-4", "rtx6000", 4, None)
+    assert rtx.env[key] == "1"
+    for profile, count in (("glm53-nvfp4-4", 4), ("glm53-nvfp4-8", 8)):
+        assert key not in resolve(profile, "a100", count, None).env
+
+
+def test_glm53_renamed_profiles_preserve_recorded_commands():
+    for platform, count in (("rtx6000", 4), ("a100", 4), ("a100", 8)):
+        old_id, new_id = f"glm53-nvfp4-{count}", f"glm53f-nvfp4-{count}"
+        old, new = (resolve(p, platform, count, None) for p in (old_id, new_id))
+        assert replace(old, profile_id=new_id) == new
+        assert old_id not in registry.profile_ids()
+        assert new_id in registry.profile_ids()
+    assert compatible_profile_ids(Machine("rtx6000", "RTX PRO 6000", 4)) == [
+        "glm53f-nvfp4-4"
+    ]
+
+
+def test_glm53_merge_keeps_drafters_and_quant_platform_scoped():
+    rtx = resolve("glm53f-nvfp4-4", "rtx6000", 4, None)
+    a100 = resolve("glm53f-nvfp4-8", "a100", 8, None)
+    assert not rtx.speculative
+    assert rtx.speculator["engine"]["method"] == "mtp"
+    assert rtx.weight_recipe["id"] == "glm53-redhatai-nvfp4-fp8-kda-tp4-v1"
+    assert rtx.engine["kv_cache_dtype"] == "auto"
+    assert rtx.env["VLLM_USE_V2_MODEL_RUNNER"] == "0"
+    assert "kv_transfer_config" not in rtx.engine
+    assert a100.speculative
+    assert a100.speculator["engine"]["method"] == "dflash"
+    assert a100.weight_recipe is None
+    assert a100.engine["data_parallel_size"] == 2
+    # A100 inherits main's V2 architecture default; only SM120 pins V1.
+    assert "VLLM_USE_V2_MODEL_RUNNER" not in a100.env
+
+
+def test_glm53_lossless_mhc_storage_is_rtx6000_scoped():
+    key = "VLLM_GLM5_MHC_BF16_FN"
+    rtx = resolve("glm53-nvfp4-4", "rtx6000", 4, None)
+    assert rtx.env[key] == "1"
+    for profile, count in (("glm53-nvfp4-4", 4), ("glm53-nvfp4-8", 8)):
+        assert key not in resolve(profile, "a100", count, None).env
+
+
+def test_glm53_wide_marlin_prefill_is_rtx6000_scoped():
+    key = "VLLM_GLM53_MARLIN_PREFILL_WIDE"
+    rtx = resolve("glm53-nvfp4-4", "rtx6000", 4, None)
+    assert rtx.env[key] == "1"
+    assert rtx.engine["moe_backend"] == "marlin"
+    assert rtx.engine["tensor_parallel_size"] == 4
+    for profile, count in (("glm53-nvfp4-4", 4), ("glm53-nvfp4-8", 8)):
+        assert key not in resolve(profile, "a100", count, None).env
+
+
+def test_glm53_indexer_tp_prefill_is_rtx6000_scoped():
+    key = "VLLM_GLM53_INDEXER_TP_PREFILL"
+    rtx = resolve("glm53-nvfp4-4", "rtx6000", 4, None)
+    assert rtx.env[key] == "1"
+    assert rtx.engine["tensor_parallel_size"] == 4
+    assert not rtx.engine["enable_expert_parallel"]
+    for profile, count in (("glm53-nvfp4-4", 4), ("glm53-nvfp4-8", 8)):
+        assert key not in resolve(profile, "a100", count, None).env
+
+
+def test_glm53_sparse_swapab_is_rtx6000_scoped():
+    key = "VLLM_GLM53_SPARSE_PREFILL_SWAPAB"
+    rtx = resolve("glm53-nvfp4-4", "rtx6000", 4, None)
+    assert rtx.env[key] == "1"
+    assert rtx.engine["tensor_parallel_size"] == 4
+    assert rtx.engine["kv_cache_dtype"] == "auto"
+    assert not rtx.speculative
+    for profile, count in (("glm53-nvfp4-4", 4), ("glm53-nvfp4-8", 8)):
+        assert key not in resolve(profile, "a100", count, None).env
+
+
 def test_every_profile_uses_registered_drafter_with_fp8_dspark():
     for profile_id in registry.profile_ids():
         entry = registry.describe(profile_id)
@@ -88,6 +164,41 @@ def test_no_spec_cli_flag_disables_the_resolved_speculator(monkeypatch):
     assert len(seen) == 1
     assert seen[0].speculative is False
     assert "speculative_config" not in engine_kwargs(seen[0])
+
+
+def test_cuda_profiler_is_explicit_bounded_and_does_not_change_recipe(monkeypatch):
+    original = resolve("glm53-nvfp4-4", "rtx6000", 4, None)
+    machine = Machine("rtx6000", "RTX PRO 6000 Blackwell", 4)
+    monkeypatch.setattr(cli.hardware, "detect", lambda: machine)
+    seen = []
+    monkeypatch.setattr(cli, "_show", seen.append)
+    assert cli.main(["glm53-nvfp4-4", "--cuda-profile", "--dry-run"]) == 0
+    configured = seen[0]
+    expected = {"profiler": "cuda", "ignore_frontend": True, "max_iterations": 32}
+    assert configured.engine["profiler_config"] == expected
+    assert replace(configured, engine=original.engine) == original
+    assert {
+        key: value
+        for key, value in configured.engine.items()
+        if key != "profiler_config"
+    } == original.engine
+    assert "profiler_config" not in original.engine
+    with pytest.raises(SystemExit):
+        cli._parser().parse_args(["--cuda-profile", "--torch-profile-dir", "unused"])
+
+
+def test_verbose_jit_cli_only_changes_observability(monkeypatch):
+    assert not cli._parser().parse_args([]).jit_monitor_verbose
+    original = resolve("glm53-nvfp4-4", "rtx6000", 4, None)
+    machine = Machine("rtx6000", "RTX PRO 6000 Blackwell", 4)
+    monkeypatch.setattr(cli.hardware, "detect", lambda: machine)
+    seen = []
+    monkeypatch.setattr(cli, "_show", seen.append)
+    assert cli.main(["glm53-nvfp4-4", "--jit-monitor-verbose", "--dry-run"]) == 0
+    configured = seen[0]
+    assert configured.engine == {**original.engine, "jit_monitor_verbose": True}
+    assert replace(configured, engine=original.engine) == original
+    assert engine_kwargs(configured)["jit_monitor_verbose"] is True
 
 
 def test_every_profile_source_names_a_blessed_dspark_download():

--- a/tests/slimserve/test_record_speculative.py
+++ b/tests/slimserve/test_record_speculative.py
@@ -1,5 +1,7 @@
 """A platform record may opt into or out of speculation on its own (glm53-nvfp4-4)."""
 
+from dataclasses import replace
+
 from slimserve import registry
 from slimserve.engine import _speculative_config
 
@@ -17,14 +19,25 @@ def test_glm53_records_serve_spec_off_by_default():
         assert _speculative_config(plan) is None
 
 
-def test_rtx6000_opt_in_keeps_the_measured_depth():
-    plan = _plan("rtx6000")
+def test_rtx6000_opt_in_keeps_the_measured_depth(tmp_path, monkeypatch):
+    monkeypatch.setenv("SLIMSERVE_CACHE", str(tmp_path))
+    # The supported --spec CLI applies this exact override to the resolved plan.
+    plan = replace(_plan("rtx6000"), speculative=True)
     assert plan.speculative_overrides == {"num_speculative_tokens": 3}
     spec = plan.speculator
     assert spec["engine"]["method"] == "mtp"
     assert spec["engine"]["moe_backend"] == "triton"
     assert spec["engine"]["attention_backend"] == "QUIXICORE_MLA_SPARSE"
     assert spec["engine"]["index_share_for_mtp_iteration"] is True
+    assert _speculative_config(plan) == {
+        "model": "RedHatAI/GLM-5.3-Flash-NVFP4",
+        "revision": "36c184c6cda000a481711306df5adde42f63321a",
+        "method": "mtp",
+        "num_speculative_tokens": 3,
+        "index_share_for_mtp_iteration": True,
+        "moe_backend": "triton",
+        "attention_backend": "QUIXICORE_MLA_SPARSE",
+    }
 
 
 def test_record_level_speculative_overrides_the_profile_flag():

--- a/tests/slimserve/test_record_speculative.py
+++ b/tests/slimserve/test_record_speculative.py
@@ -1,0 +1,45 @@
+"""A platform record may opt into or out of speculation on its own (glm53-nvfp4-4)."""
+
+from slimserve import registry
+from slimserve.engine import _speculative_config
+
+
+def _plan(platform):
+    return registry.resolve("glm53-nvfp4-4", platform, 4, None, 0)
+
+
+def test_glm53_records_serve_spec_off_by_default():
+    # rtx6000: measured off on the Foundry fan-out (perf entry 2026-09-04);
+    # a100: never validated with the drafter.
+    for platform in ("rtx6000", "a100"):
+        plan = _plan(platform)
+        assert plan.speculative is False
+        assert _speculative_config(plan) is None
+
+
+def test_rtx6000_opt_in_keeps_the_measured_depth():
+    plan = _plan("rtx6000")
+    assert plan.speculative_overrides == {"num_speculative_tokens": 3}
+    spec = plan.speculator
+    assert spec["engine"]["method"] == "mtp"
+    assert spec["engine"]["moe_backend"] == "triton"
+    assert spec["engine"]["attention_backend"] == "QUIXICORE_MLA_SPARSE"
+    assert spec["engine"]["index_share_for_mtp_iteration"] is True
+
+
+def test_record_level_speculative_overrides_the_profile_flag():
+    profile = {
+        "speculative": False,
+        "variants": {
+            "x": {
+                "platform": "x",
+                "engine": {"a": 1},
+                "default_quant": "Q",
+                "speculative": True,
+            }
+        },
+    }
+    merged = registry._merge_platform(profile, "x")
+    assert merged["speculative"] is True
+    profile["variants"]["x"].pop("speculative")
+    assert registry._merge_platform(profile, "x")["speculative"] is None

--- a/tests/slimserve/test_serving_review_regressions.py
+++ b/tests/slimserve/test_serving_review_regressions.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused CPU regressions for serving integration review findings."""
+
+import builtins
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+
+def test_geometry_case_dispatch_does_not_import_benchmarks(monkeypatch):
+    from slimserve import glm53_serving_diagnostic, rmsnorm_geometry
+
+    original_import = builtins.__import__
+
+    def without_benchmarks(name, *args, **kwargs):
+        if name == "benchmarks" or name.startswith("benchmarks."):
+            raise ImportError("benchmarks are not packaged")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", without_benchmarks)
+    assert glm53_serving_diagnostic.cases(
+        {"serving_schema": rmsnorm_geometry.SERVING_SCHEMA}
+    ) == (
+        ("control", "control"),
+        ("geometry", "geometry"),
+        ("return-control", "control"),
+    )
+
+
+@pytest.mark.parametrize("symbol", [False, True])
+def test_router_projection_requires_its_native_symbol(monkeypatch, symbol):
+    from vllm.model_executor.layers.fused_moe.router import gate_linear
+    from vllm.quixicore import ops
+
+    native = (
+        SimpleNamespace(dsv4_projection_gemv=object()) if symbol else SimpleNamespace()
+    )
+    monkeypatch.setattr(ops, "_qc", lambda: native)
+    assert gate_linear._quixicore_projection_available() is symbol
+
+
+@pytest.mark.parametrize("generators,fp64", [(True, False), (False, True)])
+def test_cuda_sampler_fallback_preserves_small_k_metadata(generators, fp64):
+    from vllm.v1.sample.ops.topk_topp_sampler import TopKTopPSampler
+
+    expected = object()
+    native = Mock(return_value=expected)
+    owner = SimpleNamespace(forward_native=native, use_fp64_gumbel=fp64)
+    logits, k = torch.empty(1, 16), torch.tensor([4])
+    per_request = {0: object()} if generators else {}
+    assert (
+        TopKTopPSampler.forward_cuda(owner, logits, per_request, k, None, max_top_k=4)
+        is expected
+    )
+    native.assert_called_once_with(logits, per_request, k, None, max_top_k=4)
+
+
+@pytest.mark.parametrize("aborted", [False, True])
+def test_routing_journal_drops_complete_aborted_frame(aborted):
+    from vllm.v1.core.sched.scheduler import Scheduler
+
+    journal = Mock()
+    requests = {
+        "second": SimpleNamespace(num_computed_tokens=1002, num_prompt_tokens=1000),
+        "first": SimpleNamespace(num_computed_tokens=42, num_prompt_tokens=40),
+    }
+    if aborted:
+        del requests["second"]
+    owner = SimpleNamespace(_slimserve_routing_journal=journal, requests=requests)
+    routed = SimpleNamespace(routing_data=object(), slot_mapping=object())
+    req_ids, scheduled = ["second", "first"], {"first": 1, "second": 1}
+    Scheduler._record_routing_journal(owner, routed, req_ids, scheduled)
+    if aborted:
+        journal.record.assert_not_called()
+    else:
+        journal.record.assert_called_once_with(
+            routed.routing_data,
+            routed.slot_mapping,
+            req_ids,
+            scheduled,
+            {"second": 1002, "first": 42},
+            {"second": 1000, "first": 40},
+        )

--- a/tests/slimserve/test_stream_events.py
+++ b/tests/slimserve/test_stream_events.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+import json
+
+import pytest
+import requests
+
+from slimserve.smoke import _require_match
+from slimserve.stream import chat_completion
+
+
+@pytest.mark.parametrize("final_content", ["red", "blue", "RedRed", None])
+def test_chat_observer_preserves_raw_fields_without_changing_request_or_text(
+    monkeypatch,
+    final_content,
+):
+    chunks = [
+        {"choices": [{"delta": {"role": "assistant"}}]},
+        {"choices": [{"delta": {"reasoning_content": "Red", "reasoning": "Red"}}]},
+        {"choices": [{"delta": {"content": final_content}, "finish_reason": "stop"}]},
+        {"choices": [], "usage": {"completion_tokens": 3}},
+    ]
+    bodies = []
+
+    class Response:
+        status_code = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def iter_lines(self, decode_unicode):
+            assert decode_unicode
+            yield ""
+            yield "data: not-json"
+            for chunk in chunks:
+                yield "data: " + json.dumps(chunk)
+            yield "data: [DONE]"
+
+    def post(url, json, stream, timeout):
+        assert url == "http://localhost/v1/chat/completions"
+        assert stream and timeout == 600
+        bodies.append(json)
+        return Response()
+
+    monkeypatch.setattr(requests, "post", post)
+    events = []
+    kwargs = dict(max_tokens=256, seed=42)
+    messages = [{"role": "user", "content": "test"}]
+    plain = list(chat_completion("http://localhost", "model", messages, **kwargs))
+    observed = list(
+        chat_completion(
+            "http://localhost", "model", messages, on_event=events.append, **kwargs
+        )
+    )
+    expected_content = [final_content] if final_content else []
+    assert plain == observed == ["Red", "Red", *expected_content]
+    assert events == chunks
+    answer_events = []
+    answer = list(
+        chat_completion(
+            "http://localhost",
+            "model",
+            messages,
+            include_reasoning=False,
+            on_event=answer_events.append,
+            **kwargs,
+        )
+    )
+    assert answer == expected_content
+    assert answer_events == chunks
+    if final_content == "red":
+        _require_match({"answer": "".join(answer)}, r"\bred\b", "image")
+    else:
+        with pytest.raises(RuntimeError, match="image check failed"):
+            _require_match({"answer": "".join(answer)}, r"\bred\b", "image")
+    assert (
+        bodies[0]
+        == bodies[1]
+        == bodies[2]
+        == {
+            "model": "model",
+            "messages": messages,
+            "max_tokens": 256,
+            "stream": True,
+            "seed": 42,
+        }
+    )

--- a/tests/slimserve/test_weight_recipe.py
+++ b/tests/slimserve/test_weight_recipe.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+import json
+from dataclasses import replace
+from unittest.mock import Mock
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from slimserve import fetch, registry, weight_recipe
+from slimserve.f32_overrides import _headers
+
+
+def _plan(tmp_path, monkeypatch):
+    monkeypatch.setenv("SLIMSERVE_CACHE", str(tmp_path))
+    monkeypatch.delenv("SLIMSERVE_F32_OVERRIDES", raising=False)
+    monkeypatch.delenv("SLIMSERVE_FP8_SWAPSET", raising=False)
+    plan = registry.resolve("glm53-nvfp4-4", "rtx6000", 4, None)
+    plan.model_dir.mkdir()
+    (plan.model_dir / "config.json").write_text("{}")
+    for name in weight_recipe.SIDECARS[:2]:
+        save_file(
+            {"w": torch.ones(2)}, str(plan.model_dir / name), metadata={"source": "old"}
+        )
+    (plan.model_dir / "fp8-swapset.json").write_text(
+        json.dumps({"source": "old", "tp_size": 4})
+    )
+    recipe = {
+        **plan.weight_recipe,
+        "artifact_digests": {
+            name: weight_recipe.artifact_digest(plan.model_dir / name)
+            for name in weight_recipe.SIDECARS
+        },
+    }
+    return replace(
+        plan,
+        weight_recipe=recipe,
+        quant=replace(
+            plan.quant,
+            files=[{"path": "config.json", "bytes": 2}],
+        ),
+    )
+
+
+def test_recipe_belongs_to_the_rtx6000_record():
+    plan = registry.resolve("glm53-nvfp4-4", "rtx6000", 4, None)
+    assert plan.weight_recipe["target_revision"] == plan.source["revision"]
+    assert plan.weight_recipe["tp_size"] == plan.engine["tensor_parallel_size"] == 4
+    assert plan.entry_file != plan.model_dir
+    assert set(plan.weight_recipe["artifact_digests"]) == set(weight_recipe.SIDECARS)
+    assert all(len(d) == 64 for d in plan.weight_recipe["artifact_digests"].values())
+    a100 = registry.resolve("glm53-nvfp4-4", "a100", 4, None)
+    assert a100.weight_recipe is None
+    assert a100.entry_file == a100.model_dir
+
+
+def test_fetch_prepares_verified_recipe_and_preserves_originals(tmp_path, monkeypatch):
+    plan = _plan(tmp_path, monkeypatch)
+    build = Mock(side_effect=AssertionError("qualified local artifacts need no build"))
+    monkeypatch.setattr(weight_recipe, "_build", build)
+    fetch.ensure(plan, assume_yes=True)
+    assert plan.entry_file.is_dir()
+    assert (plan.entry_file / "config.json").resolve() == plan.model_dir / "config.json"
+    assert (plan.entry_file / "fp8-swapset.safetensors").stat().st_ino != (
+        plan.model_dir / "fp8-swapset.safetensors"
+    ).stat().st_ino
+    fetch.ensure(plan, assume_yes=True)
+    build.assert_not_called()
+
+
+def test_missing_sidecars_are_built_before_publication(tmp_path, monkeypatch):
+    plan = _plan(tmp_path, monkeypatch)
+    original = plan.model_dir / "fp8-swapset.safetensors"
+    data = original.read_bytes()
+    original.unlink()
+
+    def build(_plan, staging):
+        assert not plan.entry_file.exists()
+        for name in weight_recipe.SIDECARS:
+            content = (
+                data if name == original.name else (plan.model_dir / name).read_bytes()
+            )
+            (staging / name).write_bytes(content)
+
+    monkeypatch.setattr(weight_recipe, "_build", build)
+    fetch.ensure(plan, assume_yes=True)
+    weight_recipe.validate(plan.entry_file, plan.weight_recipe)
+    assert not original.exists()
+
+
+def test_changed_tensor_bytes_are_rejected_on_next_start(tmp_path, monkeypatch):
+    plan = _plan(tmp_path, monkeypatch)
+    fetch.ensure(plan, assume_yes=True)
+    path = plan.entry_file / "fp8-swapset.safetensors"
+    save_file({"w": torch.zeros(2)}, str(path), metadata={"source": "old"})
+    with pytest.raises(ValueError, match="artifact digest mismatch"):
+        fetch.ensure(plan, assume_yes=True)
+
+
+@pytest.mark.parametrize("key", ["SLIMSERVE_F32_OVERRIDES", "SLIMSERVE_FP8_SWAPSET"])
+def test_recipe_cannot_silently_disable_its_weights(tmp_path, monkeypatch, key):
+    plan = _plan(tmp_path, monkeypatch)
+    monkeypatch.setenv(key, "0")
+    with pytest.raises(ValueError, match="requires"):
+        fetch.ensure(plan, assume_yes=True)
+    assert not plan.entry_file.exists()
+
+
+def test_artifact_identity_ignores_only_local_provenance(tmp_path):
+    a, b = tmp_path / "a.safetensors", tmp_path / "b.safetensors"
+    for path, source in ((a, "host-a"), (b, "host-b")):
+        save_file({"w": torch.ones(2)}, str(path), metadata={"source": source})
+    assert weight_recipe.artifact_digest(a) == weight_recipe.artifact_digest(b)
+    save_file({"other": torch.ones(2)}, str(b))
+    assert weight_recipe.artifact_digest(a) != weight_recipe.artifact_digest(b)
+
+
+@pytest.mark.parametrize("indexed", [False, True])
+def test_builders_read_original_shards_not_their_previous_output(tmp_path, indexed):
+    save_file(
+        {"w": torch.ones(2, dtype=torch.bfloat16)}, str(tmp_path / "model.safetensors")
+    )
+    save_file({"w": torch.zeros(2)}, str(tmp_path / "f32-overrides.safetensors"))
+    save_file({"w": torch.zeros(2)}, str(tmp_path / "fp8-swapset.safetensors"))
+    if indexed:
+        (tmp_path / "model.safetensors.index.json").write_text(
+            json.dumps(
+                {
+                    "weight_map": {"w": "model.safetensors"},
+                }
+            )
+        )
+    header, shard, _ = _headers(str(tmp_path))["w"]
+    assert header["dtype"] == "BF16"
+    assert shard == str(tmp_path / "model.safetensors")

--- a/tests/slimserve/test_weight_recipe.py
+++ b/tests/slimserve/test_weight_recipe.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import json
+import shutil
 from dataclasses import replace
 from unittest.mock import Mock
 
@@ -18,13 +19,14 @@ def _plan(tmp_path, monkeypatch):
     plan = registry.resolve("glm53-nvfp4-4", "rtx6000", 4, None)
     plan.model_dir.mkdir()
     (plan.model_dir / "config.json").write_text("{}")
-    for name in weight_recipe.SIDECARS[:2]:
-        save_file(
-            {"w": torch.ones(2)}, str(plan.model_dir / name), metadata={"source": "old"}
-        )
-    (plan.model_dir / "fp8-swapset.json").write_text(
-        json.dumps({"source": "old", "tp_size": 4})
-    )
+    for name in weight_recipe.SIDECARS:
+        path = plan.model_dir / name
+        if path.suffix == ".safetensors":
+            save_file({"w": torch.ones(2)}, str(path), metadata={"source": "old"})
+        elif path.suffix == ".json":
+            path.write_text(json.dumps({"source": "old", "tp_size": 4}))
+        else:
+            raise AssertionError(f"unhandled sidecar format: {name}")
     recipe = {
         **plan.weight_recipe,
         "artifact_digests": {
@@ -113,6 +115,33 @@ def test_artifact_identity_ignores_only_local_provenance(tmp_path):
     assert weight_recipe.artifact_digest(a) == weight_recipe.artifact_digest(b)
     save_file({"other": torch.ones(2)}, str(b))
     assert weight_recipe.artifact_digest(a) != weight_recipe.artifact_digest(b)
+
+
+@pytest.mark.parametrize("prefix", [b"", b"1234567"])
+def test_truncated_original_sidecar_uses_the_rebuild_path(
+    tmp_path, monkeypatch, prefix
+):
+    plan = _plan(tmp_path, monkeypatch)
+    original = plan.model_dir / weight_recipe.SIDECARS[0]
+    intact = original.read_bytes()
+    original.write_bytes(prefix)
+    with pytest.raises(ValueError, match="truncated safetensors"):
+        weight_recipe.artifact_digest(original)
+
+    def rebuild(selected, staging):
+        assert selected is plan
+        for name in weight_recipe.SIDECARS:
+            if name == original.name:
+                (staging / name).write_bytes(intact)
+            else:
+                shutil.copyfile(plan.model_dir / name, staging / name)
+
+    build = Mock(side_effect=rebuild)
+    monkeypatch.setattr(weight_recipe, "_build", build)
+    weight_recipe.ensure(plan)
+    build.assert_called_once()
+    weight_recipe.validate(plan.entry_file, plan.weight_recipe)
+    assert original.read_bytes() == prefix  # never mutate the source checkpoint
 
 
 @pytest.mark.parametrize("indexed", [False, True])

--- a/tests/v1/spec_decode/test_glm5_next_mtp.py
+++ b/tests/v1/spec_decode/test_glm5_next_mtp.py
@@ -8,6 +8,7 @@ import torch
 
 import vllm.v1.spec_decode.glm5_next_mtp as glm_proposer
 from vllm.v1.kv_cache_interface import MLAAttentionSpec, UniformTypeKVCacheSpecs
+from vllm.v1.spec_decode.eagle import EagleProposer
 from vllm.v1.spec_decode.glm5_next_mtp import Glm5NextMTPProposer
 
 MLA_LAYER = "draft.model.layers.45.self_attn.attn"
@@ -161,7 +162,7 @@ def test_next_step_recomputes_the_indexer_slots_with_its_own_block_size(monkeypa
     )  # old positions, one per request
     common = SimpleNamespace(slot_mapping=torch.tensor([100, 200]), max_seq_len=10)
     monkeypatch.setattr(
-        Glm5NextMTPProposer.__mro__[2],
+        EagleProposer,
         "_update_positions_dependent_metadata",
         lambda self, pos, cm, b, ib, bs: pos + 1,
     )

--- a/tests/v1/spec_decode/test_glm5_next_mtp.py
+++ b/tests/v1/spec_decode/test_glm5_next_mtp.py
@@ -1,0 +1,183 @@
+"""Cache topology of the GLM-5.3-Flash MTP proposer: sparse MLA + indexer owners,
+each with its own block table and slot mapping."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm.v1.spec_decode.glm5_next_mtp as glm_proposer
+from vllm.v1.kv_cache_interface import MLAAttentionSpec, UniformTypeKVCacheSpecs
+from vllm.v1.spec_decode.glm5_next_mtp import Glm5NextMTPProposer
+
+MLA_LAYER = "draft.model.layers.45.self_attn.attn"
+INDEXER_LAYER = "draft.model.layers.45.self_attn.indexer.k_cache"
+BLOCK = 64
+
+
+class _FakeBackend:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def full_cls_name(self) -> tuple[str, str]:
+        return (__name__, self.name)
+
+
+class _FakeAttentionGroup:
+    def __init__(self, backend, layer_names, kv_cache_spec, kv_cache_group_id):
+        self.backend = backend
+        self.layer_names = list(layer_names)
+        self.kv_cache_spec = kv_cache_spec
+        self.kv_cache_group_id = kv_cache_group_id
+        self.kernel_block_size = None
+
+    def create_metadata_builders(self, vllm_config, device, kernel_block_size=None):
+        self.kernel_block_size = kernel_block_size
+
+    def get_metadata_builder(self):
+        # Report what the builder was handed: the group's block-table rows
+        # and the slot mapping the cache insert would use.
+        return SimpleNamespace(
+            build_for_drafting=lambda common_attn_metadata, draft_index: (
+                self.layer_names[0],
+                common_attn_metadata.block_table_tensor.shape[0],
+                common_attn_metadata.slot_mapping.tolist(),
+            )
+        )
+
+
+def _specs():
+    mla = MLAAttentionSpec(
+        block_size=BLOCK, num_kv_heads=1, head_size=512, dtype=torch.bfloat16
+    )
+    indexer = MLAAttentionSpec(
+        block_size=BLOCK, num_kv_heads=1, head_size=256, dtype=torch.bfloat16
+    )
+    return mla, indexer
+
+
+def _proposer(monkeypatch: pytest.MonkeyPatch, uniform_groups: bool = True):
+    mla, indexer = _specs()
+    backends = {
+        MLA_LAYER: _FakeBackend("QuixiCore"),
+        INDEXER_LAYER: _FakeBackend("Idx"),
+    }
+    fake_layers = {
+        name: SimpleNamespace(get_attn_backend=lambda b=b: b)
+        for name, b in backends.items()
+    }
+    monkeypatch.setattr(
+        glm_proposer, "get_layers_from_vllm_config", lambda *a, **k: fake_layers
+    )
+    monkeypatch.setattr(glm_proposer, "AttentionGroup", _FakeAttentionGroup)
+    p = Glm5NextMTPProposer.__new__(Glm5NextMTPProposer)
+    p.vllm_config = None
+    p.draft_model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(num_nextn_predict_layers=1)
+    )
+    p.device = torch.device("cpu")
+    p._draft_attn_layer_names = {MLA_LAYER, INDEXER_LAYER}
+    p.kv_cache_gid = -1
+    p.draft_attn_groups = []
+    p.block_size = -1
+    p._per_group_block_tables = {}
+    p._per_group_slot_mappings = {}
+    p._per_group_slot_mapping_buffers = {}
+    p.max_positions = 64
+    p._slot_mapping_buffer = torch.zeros(64, dtype=torch.int64)
+    if uniform_groups:
+        g0 = UniformTypeKVCacheSpecs(block_size=BLOCK, kv_cache_specs={MLA_LAYER: mla})
+        g1 = UniformTypeKVCacheSpecs(
+            block_size=BLOCK, kv_cache_specs={INDEXER_LAYER: indexer}
+        )
+    else:
+        g0, g1 = mla, indexer
+    # Indexer group listed first on purpose: the primary owner is found by
+    # name, not by group order.
+    config = SimpleNamespace(
+        kv_cache_groups=[
+            SimpleNamespace(
+                layer_names=["t.layers.3.self_attn.indexer.k_cache", INDEXER_LAYER],
+                kv_cache_spec=g1,
+            ),
+            SimpleNamespace(
+                layer_names=["t.layers.3.self_attn.attn", MLA_LAYER], kv_cache_spec=g0
+            ),
+        ]
+    )
+    return p, config
+
+
+@pytest.mark.parametrize("uniform_groups", [True, False])
+def test_primary_owner_is_the_sparse_mla_layer(monkeypatch, uniform_groups):
+    p, config = _proposer(monkeypatch, uniform_groups)
+    p.initialize_attn_backend(config, kernel_block_sizes=[BLOCK, BLOCK])
+    assert p.kv_cache_gid == 1
+    assert p.block_size == BLOCK
+    assert [g.layer_names[0] for g in p.draft_attn_groups] == [MLA_LAYER, INDEXER_LAYER]
+    assert [g.kv_cache_group_id for g in p.draft_attn_groups] == [1, 0]
+    assert p.model_returns_tuple()
+
+
+def test_indexer_group_gets_its_own_block_table_and_slot_mapping(monkeypatch):
+    p, config = _proposer(monkeypatch)
+    p.initialize_attn_backend(config, kernel_block_sizes=[BLOCK, BLOCK])
+    idx_slots = torch.tensor([7, 8, 9], dtype=torch.int64)
+    p.set_per_group_attn_metadata(0, torch.zeros(9, 4, dtype=torch.int32), idx_slots)
+    mla_slots = torch.tensor([1, 2, 3], dtype=torch.int64)
+    common = SimpleNamespace(
+        num_reqs=3,
+        num_actual_tokens=3,
+        block_table_tensor=torch.zeros(3, 8, dtype=torch.int32),
+        slot_mapping=mla_slots,
+    )
+    per_group, per_layer = p.build_per_group_and_layer_attn_metadata(common)
+    assert len(per_group) == 2
+    assert per_layer[MLA_LAYER] == (MLA_LAYER, 3, [1, 2, 3])
+    assert per_layer[INDEXER_LAYER] == (INDEXER_LAYER, 3, [7, 8, 9])
+    sm = p._get_slot_mapping(3, mla_slots)
+    assert sm[MLA_LAYER].tolist() == [1, 2, 3]
+    assert sm[INDEXER_LAYER].tolist() == [7, 8, 9]
+
+
+def test_next_step_recomputes_the_indexer_slots_with_its_own_block_size(monkeypatch):
+    p, config = _proposer(monkeypatch)
+    # Indexer group (gid 0) uses a block twice the MLA group's, as on rtx6000.
+    p.initialize_attn_backend(config, kernel_block_sizes=[2 * BLOCK, BLOCK])
+    assert p.block_size == BLOCK and p._per_group_block_sizes == {
+        0: 2 * BLOCK,
+        1: BLOCK,
+    }
+    p.uses_mrope = False
+    p.max_model_len = 4096
+    # Indexer group block table: request 0 -> blocks [10, 11], request 1 -> [20, 21].
+    p.set_per_group_attn_metadata(
+        0,
+        torch.tensor([[10, 11], [20, 21]], dtype=torch.int32),
+        torch.zeros(2, dtype=torch.int64),
+    )
+    positions = torch.tensor(
+        [2 * BLOCK - 1, BLOCK + 5]
+    )  # old positions, one per request
+    common = SimpleNamespace(slot_mapping=torch.tensor([100, 200]), max_seq_len=10)
+    monkeypatch.setattr(
+        Glm5NextMTPProposer.__mro__[2],
+        "_update_positions_dependent_metadata",
+        lambda self, pos, cm, b, ib, bs: pos + 1,
+    )
+    new_pos = p._update_positions_dependent_metadata(positions, common, 2, 2, BLOCK)
+    assert new_pos.tolist() == [2 * BLOCK, BLOCK + 6]
+    # Indexer slots use the 2*BLOCK geometry: request 0 crosses into its
+    # second indexer block; request 1 stays in its first.
+    assert p._per_group_slot_mappings[0].tolist() == [
+        11 * 2 * BLOCK,
+        20 * 2 * BLOCK + BLOCK + 6,
+    ]
+    assert p._per_group_slot_mappings[1].tolist() == [100, 200]
+
+
+def test_group_block_sizes_may_differ(monkeypatch):
+    p, config = _proposer(monkeypatch)
+    p.initialize_attn_backend(config, kernel_block_sizes=[128, BLOCK])
+    assert p.block_size == BLOCK
+    assert p._per_group_block_sizes == {0: 128, 1: BLOCK}

--- a/vllm/compilation/passes/utility/fix_functionalization.py
+++ b/vllm/compilation/passes/utility/fix_functionalization.py
@@ -236,6 +236,12 @@ class FixFunctionalizationPass(VllmInductorPass):
                 self.insert_defunctionalized(graph, node)
                 self._remove(node)
 
+            elif at_target == torch.ops.vllm.moe_forward.default:
+                # The single-output MoE op: returns the layer output and
+                # declares hidden_states mutated (getitem[1]).
+                mutated_args = {1: "hidden_states"}
+                self.defunctionalize(graph, node, mutated_args=mutated_args)
+
             # only used for test_functionalization::TestFunctionWithMutatedArgsAndReturn
             elif (
                 hasattr(torch.ops.vllm, "function_with_mutated_args_and_return")

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -57,6 +57,7 @@ MTPModelTypes = Literal[
     "hy_v3_mtp",
     "gemma4_mtp",
     "inkling_mtp",
+    "glm5_next_mtp",
 ]
 NgramGPUTypes = Literal["ngram_gpu"]
 DFlashModelTypes = Literal["dflash"]
@@ -1369,6 +1370,15 @@ class SpeculativeConfig:
             == "step3p5_mtp"
         )
 
+    def use_glm5_next_mtp(self) -> bool:
+        """GLM-5.3-Flash MTP: two draft cache owners (sparse MLA + indexer)."""
+        return (
+            self.method == "mtp"
+            and self.draft_model_config is not None
+            and getattr(self.draft_model_config.hf_config, "model_type", None)
+            == "glm5_next_mtp"
+        )
+
     def use_qwen4_exp_mtp(self) -> bool:
         """Return whether Qwen4Exp needs its dedicated proposer."""
         return (
@@ -1376,14 +1386,6 @@ class SpeculativeConfig:
             and self.draft_model_config is not None
             and getattr(self.draft_model_config.hf_config, "model_type", None)
             == "qwen4_exp_mtp"
-        )
-
-    def use_glm5_next_mtp(self) -> bool:
-        return (
-            self.method == "mtp"
-            and self.draft_model_config is not None
-            and getattr(self.draft_model_config.hf_config, "model_type", None)
-            == "glm5_next_mtp"
         )
 
     def use_eagle(self) -> bool:

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -527,6 +527,14 @@ class VllmConfig:
             vllm_factors.append(self.profiler_config.compute_hash())
         else:
             vllm_factors.append("None")
+        # QuixiCore kernels that change the traced graph (the MoE runner's
+        # custom-op selection depends on which bindings the build provides).
+        from vllm.quixicore.ops import quixicore_ops
+
+        vllm_factors.append(quixicore_ops.graph_factors())
+        from slimserve.fp8_swapset import hash_factor
+
+        vllm_factors.append(hash_factor(getattr(self.model_config, "model", None)))
         vllm_factors.append(self.observability_config.compute_hash())
         if self.quant_config:
             pass  # should be captured by model_config.quantization

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -252,6 +252,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
             self.ca_comm = CustomAllreduce(
                 group=self.cpu_group,
                 device=self.device,
+                max_size=envs.VLLM_CUSTOM_AR_MAX_SIZE_MB << 20,
                 symm_mem_enabled=(
                     self.symm_mem_comm is not None and not self.symm_mem_comm.disabled
                 ),

--- a/vllm/model_executor/layers/fused_moe/combine_shared.py
+++ b/vllm/model_executor/layers/fused_moe/combine_shared.py
@@ -44,9 +44,16 @@ def consume(topk_ids: torch.Tensor, output: torch.Tensor) -> torch.Tensor | None
     shared = pending.shared_experts.peek_output()
     if (
         shared is None
+        or output.dtype != torch.bfloat16
+        or output.ndim != 2
+        or output.shape[1] % 8 != 0
         or shared.shape != output.shape
         or shared.dtype != output.dtype
+        or shared.device != output.device
+        or not output.is_contiguous()
         or not shared.is_contiguous()
+        or output.data_ptr() % 16 != 0
+        or shared.data_ptr() % 16 != 0
     ):
         return None
     pending.consumed = True

--- a/vllm/model_executor/layers/fused_moe/combine_shared.py
+++ b/vllm/model_executor/layers/fused_moe/combine_shared.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Shared-expert combine handoff for the Marlin path (QuixiCore moe_sum_add).
+
+The runner launches the shared experts before the routed experts (on the aux
+stream at decode) and publishes them here keyed on the batch's topk_ids. The
+Marlin experts' final per-assignment sum consumes the publication and folds
+the shared-expert output into the routed sum in the same launch, replacing
+the moe_sum kernel, the finalize copy and the separate add. If nothing
+consumed it (another kernel path, a shape mismatch), the runner adds the
+shared output itself inside the op. Same single-thread, identity-matched
+contract as the routing alignment handoff in router/glm_route_align.py."""
+
+from dataclasses import dataclass
+
+import torch
+
+from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
+    SharedExperts,
+)
+
+
+@dataclass
+class _Pending:
+    topk_ids: torch.Tensor
+    shared_experts: SharedExperts
+    consumed: bool = False
+
+
+_pending: _Pending | None = None
+
+
+def publish(topk_ids: torch.Tensor, shared_experts: SharedExperts) -> None:
+    global _pending
+    _pending = _Pending(topk_ids, shared_experts)
+
+
+def consume(topk_ids: torch.Tensor, output: torch.Tensor) -> torch.Tensor | None:
+    """The shared-expert output to fold into `output` for this batch, joined
+    with the current stream, or None when there is nothing compatible."""
+    pending = _pending
+    if pending is None or pending.consumed or pending.topk_ids is not topk_ids:
+        return None
+    shared = pending.shared_experts.peek_output()
+    if (
+        shared is None
+        or shared.shape != output.shape
+        or shared.dtype != output.dtype
+        or not shared.is_contiguous()
+    ):
+        return None
+    pending.consumed = True
+    return pending.shared_experts.output
+
+
+def retire() -> bool:
+    """Runner side, after the routed experts: drop the publication and report
+    whether the kernel folded the shared output in."""
+    global _pending
+    pending, _pending = _pending, None
+    return pending is not None and pending.consumed

--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -63,23 +63,11 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.platforms import current_platform
 from vllm.quixicore.ops import quixicore_ops
 from vllm.scalar_type import ScalarType, scalar_types
+from vllm.v1.worker.ubatching import dbo_current_ubatch_id
 
-# Marlin's lock/counter workspace only has to be zero when a kernel starts
-# and the kernel leaves it zero, which is why the dense Marlin methods
-# allocate it once per layer. Allocating (and zeroing) one per call put a
-# fill kernel in front of every MoE layer at decode; keep one per device.
-_MARLIN_MOE_WORKSPACE: dict[torch.device, torch.Tensor] = {}
 _CANONICAL_MOE_DIAGNOSTIC = canonical_moe_enabled()
 _STABLE_ALIGN_DIAGNOSTIC = stable_align_enabled()
 _NATIVE_ORDER = native_order_enabled()
-
-
-def _marlin_moe_workspace(device: torch.device) -> torch.Tensor:
-    workspace = _MARLIN_MOE_WORKSPACE.get(device)
-    if workspace is None:
-        workspace = marlin_make_workspace_new(device, 4)
-        _MARLIN_MOE_WORKSPACE[device] = workspace
-    return workspace
 
 
 def _fused_marlin_moe(
@@ -127,7 +115,9 @@ def _fused_marlin_moe(
     N = marlin_moe_intermediate_size(w1, w2)
     w13_num_shards = 2 if activation.is_gated else 1
     if workspace is None:
-        workspace = _marlin_moe_workspace(hidden_states.device)
+        # Standalone calls have no serialized layer/ubatch owner. Their locks
+        # must not alias another invocation, including independent CUDA graphs.
+        workspace = marlin_make_workspace_new(hidden_states.device, 4)
 
     if intermediate_cache13 is None:
         intermediate_cache13 = torch.empty(
@@ -697,6 +687,10 @@ class MarlinExpertsBase(mk.FusedMoEExpertsModular):
             num_dispatchers=num_dispatchers,
         )
         vllm_config = get_current_vllm_config_or_none()
+        self._use_ubatching = (
+            vllm_config is not None and vllm_config.parallel_config.use_ubatching
+        )
+        self._marlin_workspaces: dict[tuple[torch.device, int], torch.Tensor] = {}
         extra = vllm_config.additional_config if vllm_config is not None else {}
         self._singleton_alignment = make_singleton_alignment(
             moe_config,
@@ -706,6 +700,18 @@ class MarlinExpertsBase(mk.FusedMoEExpertsModular):
             current_platform.is_cuda()
             and current_platform.is_device_capability((8, 0)),
         )
+
+    def _marlin_workspace(self, device: torch.device) -> torch.Tensor:
+        # Marlin leaves its locks zero. Reuse removes the per-call fill, but
+        # ownership must follow the runner's serialized layer/ubatch lifecycle,
+        # not the device or capture stream shared by otherwise independent work.
+        ubatch_id = dbo_current_ubatch_id() if self._use_ubatching else 0
+        key = (device, ubatch_id)
+        workspace = self._marlin_workspaces.get(key)
+        if workspace is None:
+            workspace = marlin_make_workspace_new(device, 4)
+            self._marlin_workspaces[key] = workspace
+        return workspace
 
     @staticmethod
     def _supports_current_device() -> bool:
@@ -897,6 +903,7 @@ class MarlinExperts(LoRAExpertsMixin, MarlinExpertsBase):
                 moe_sum=self.moe_sum,
                 expert_map=expert_map,
                 output=output,
+                workspace=self._marlin_workspace(hidden_states.device),
                 # Workspaces are swapped in workspace_shapes() to account for proper
                 # output buffer allocation. Please refer to workspace_shapes().
                 intermediate_cache13=workspace2,
@@ -1023,6 +1030,7 @@ class MarlinExperts(LoRAExpertsMixin, MarlinExpertsBase):
             moe_sum=moe_sum_with_lora,
             expert_map=expert_map,
             output=output,
+            workspace=self._marlin_workspace(hidden_states.device),
             intermediate_cache13=workspace2,
             intermediate_cache2=workspace13,
             g_idx1=self.w13_g_idx,
@@ -1157,6 +1165,7 @@ class BatchedMarlinExperts(MarlinExpertsBase):
             input_global_scale1=self.a1_gscale,
             input_global_scale2=self.a2_gscale,
             output=output,
+            workspace=self._marlin_workspace(hidden_states.device),
             intermediate_cache13=workspace13,
             intermediate_cache2=workspace2,
             g_idx1=self.w13_g_idx,

--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -1048,7 +1048,13 @@ class MarlinExperts(LoRAExpertsMixin, MarlinExpertsBase):
             return
         shared = (
             combine_shared.consume(topk_ids, output)
-            if input.is_contiguous() and output.is_contiguous()
+            if (
+                input.is_cuda
+                and input.dtype == torch.bfloat16
+                and input.device == output.device
+                and input.is_contiguous()
+                and input.data_ptr() % 16 == 0
+            )
             else None
         )
         if shared is not None:

--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -9,6 +9,10 @@ import torch
 
 import vllm._custom_ops as ops
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from slimserve.canonical_moe import enabled as canonical_moe_enabled
+from slimserve.canonical_moe import stable_align_enabled
+from slimserve.glm53_ordering import enabled as native_order_enabled
+from vllm.model_executor.layers.fused_moe import combine_shared
 from vllm.config import get_current_vllm_config_or_none
 from vllm.model_executor.layers.fused_moe.activation import (
     MoEActivation,
@@ -26,6 +30,7 @@ from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
     batched_moe_align_block_size,
     moe_align_block_size,
 )
+from vllm.model_executor.layers.fused_moe.router import glm_route_align
 from vllm.model_executor.layers.fused_moe.singleton_alignment import (
     SingletonAlignment,
     make_singleton_alignment,
@@ -56,7 +61,25 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kNvfp4Static,
 )
 from vllm.platforms import current_platform
+from vllm.quixicore.ops import quixicore_ops
 from vllm.scalar_type import ScalarType, scalar_types
+
+# Marlin's lock/counter workspace only has to be zero when a kernel starts
+# and the kernel leaves it zero, which is why the dense Marlin methods
+# allocate it once per layer. Allocating (and zeroing) one per call put a
+# fill kernel in front of every MoE layer at decode; keep one per device.
+_MARLIN_MOE_WORKSPACE: dict[torch.device, torch.Tensor] = {}
+_CANONICAL_MOE_DIAGNOSTIC = canonical_moe_enabled()
+_STABLE_ALIGN_DIAGNOSTIC = stable_align_enabled()
+_NATIVE_ORDER = native_order_enabled()
+
+
+def _marlin_moe_workspace(device: torch.device) -> torch.Tensor:
+    workspace = _MARLIN_MOE_WORKSPACE.get(device)
+    if workspace is None:
+        workspace = marlin_make_workspace_new(device, 4)
+        _MARLIN_MOE_WORKSPACE[device] = workspace
+    return workspace
 
 
 def _fused_marlin_moe(
@@ -104,7 +127,7 @@ def _fused_marlin_moe(
     N = marlin_moe_intermediate_size(w1, w2)
     w13_num_shards = 2 if activation.is_gated else 1
     if workspace is None:
-        workspace = marlin_make_workspace_new(hidden_states.device, 4)
+        workspace = _marlin_moe_workspace(hidden_states.device)
 
     if intermediate_cache13 is None:
         intermediate_cache13 = torch.empty(
@@ -334,8 +357,41 @@ def fused_marlin_moe(
     if input_dtype is not None and input_dtype.itemsize == 1:
         block_size_m = max(block_size_m, 16)
 
+    if _CANONICAL_MOE_DIAGNOSTIC and (
+        hidden_states.dtype != torch.bfloat16
+        or K != 4096
+        or E != 288
+        or topk != 8
+        or quant_type != scalar_types.float4_e2m1f
+        or expert_map is not None
+        or global_num_experts != E
+    ):
+        raise ValueError("canonical alignment diagnostic requires GLM53 NVFP4 TP")
+
+    alignment = glm_route_align.consume(topk_ids)
+    canonical_alignment = False
     if (
-        hidden_states.shape[0] == 1
+        alignment is not None
+        and alignment.block_size == block_size_m
+        and expert_map is None
+    ):
+        # The fused router already aligned this very batch for this block
+        # size; skip the align / count_and_sort / fill launches.
+        sorted_token_ids = alignment.sorted_token_ids
+        expert_ids = alignment.expert_ids
+        num_tokens_post_padded = alignment.num_tokens_post_padded
+        canonical_alignment = alignment.canonical_assignment_order
+    elif _STABLE_ALIGN_DIAGNOSTIC and 17 <= hidden_states.shape[0] <= 8192:
+        from vllm.model_executor.layers.fused_moe.router.glm_stable_align import align
+
+        sorted_token_ids, expert_ids, num_tokens_post_padded = align(
+            topk_ids, block_size_m
+        )
+        canonical_alignment = True
+    elif (
+        not _NATIVE_ORDER
+        and not _STABLE_ALIGN_DIAGNOSTIC
+        and hidden_states.shape[0] == 1
         and expert_map is None
         and global_num_experts == E
         and singleton_alignment is not None
@@ -345,6 +401,10 @@ def fused_marlin_moe(
             topk_ids
         )
     else:
+        if _NATIVE_ORDER:
+            raise ValueError(
+                "native ordering requires scoped native alignment; no sorting fallback"
+            )
         sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
             topk_ids,
             block_size_m,
@@ -352,6 +412,20 @@ def fused_marlin_moe(
             expert_map,
             ignore_invalid_experts=True,
         )
+
+    if _CANONICAL_MOE_DIAGNOSTIC:
+        from slimserve.canonical_moe import canonicalize
+
+        if not canonical_alignment:
+            if _NATIVE_ORDER:
+                raise ValueError("native ordering received noncanonical alignment")
+            canonicalize(
+                sorted_token_ids,
+                expert_ids,
+                num_tokens_post_padded,
+                tokens=hidden_states.shape[0],
+                block_size=block_size_m,
+            )
 
     assert activation is not None
     moe_output = _fused_marlin_moe(
@@ -971,6 +1045,17 @@ class MarlinExperts(LoRAExpertsMixin, MarlinExpertsBase):
     ) -> None:
         if expert_map is not None:
             ops.moe_sum(input, output, topk_ids, expert_map)
+            return
+        shared = (
+            combine_shared.consume(topk_ids, output)
+            if input.is_contiguous() and output.is_contiguous()
+            else None
+        )
+        if shared is not None:
+            # The runner published this batch's shared-expert output: fold it
+            # into the sum, one launch instead of moe_sum, the finalize copy
+            # and the add.
+            quixicore_ops.moe_sum_add(input, shared, output)
         else:
             ops.moe_sum(input, output)
 

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -1275,6 +1275,23 @@ class FusedMoEKernelModularImpl:
 
         return a1q, a1q_scale, expert_tokens_meta, topk_ids, topk_weights
 
+    def _fused_out_is_final_output(self) -> bool:
+        """Whether the experts write their finished (weighted, reduced) result
+        into the buffer they are given, so it can be the kernel's output and
+        the finalize step's copy is skipped."""
+        if current_platform.is_rocm():
+            from vllm._aiter_ops import rocm_aiter_ops
+
+            return rocm_aiter_ops.is_fused_moe_enabled()
+        from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+            TopKWeightAndReduceNoOP,
+        )
+
+        return isinstance(
+            self.fused_experts.finalize_weight_and_reduce_impl(),
+            TopKWeightAndReduceNoOP,
+        )
+
     def _fused_experts(
         self,
         in_dtype: torch.dtype,
@@ -1322,19 +1339,17 @@ class FusedMoEKernelModularImpl:
         # If caller's output buffer already matches fused_out shape/dtype, alias
         # to skip the redundant copy in TopKWeightAndReduceNoOP.apply downstream.
         # This eliminates ~94% of __amd_rocclr_copyBuffer events (Copy 2 of the
-        # double-copy MoE write-back path).
-        if current_platform.is_rocm():
-            from vllm._aiter_ops import rocm_aiter_ops
-
-            if (
-                rocm_aiter_ops.is_fused_moe_enabled()
-                and output_alias is not None
-                and output_alias.shape == fused_out.shape
-                and output_alias.dtype == fused_out.dtype
-                and output_alias.device == fused_out.device
-                and output_alias.is_contiguous()
-            ):
-                fused_out = output_alias
+        # double-copy MoE write-back path) on ROCm and the memcpy after every
+        # Marlin MoE layer on CUDA.
+        if (
+            output_alias is not None
+            and self._fused_out_is_final_output()
+            and output_alias.shape == fused_out.shape
+            and output_alias.dtype == fused_out.dtype
+            and output_alias.device == fused_out.device
+            and output_alias.is_contiguous()
+        ):
+            fused_out = output_alias
 
         self.fused_experts.apply(
             output=fused_out,

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -1338,9 +1338,10 @@ class FusedMoEKernelModularImpl:
 
         # If caller's output buffer already matches fused_out shape/dtype, alias
         # to skip the redundant copy in TopKWeightAndReduceNoOP.apply downstream.
-        # This eliminates ~94% of __amd_rocclr_copyBuffer events (Copy 2 of the
-        # double-copy MoE write-back path) on ROCm and the memcpy after every
-        # Marlin MoE layer on CUDA.
+        # ROCm's existing AITER predicate is preserved. CUDA alias/combine
+        # measurements: perf/optimization_status.md, 2026-09-07 "Phase 1 item 2
+        # remainder"; linked in docs/glm53-flash-sm120-review.md's qualification
+        # map. The profile's later fixed-start results supersede best-boot rates.
         if (
             output_alias is not None
             and self._fused_out_is_final_output()

--- a/vllm/model_executor/layers/fused_moe/router/fused_moe_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_moe_router.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 
 import torch
 
+from slimserve.moe_journal import instrument_router
 from vllm.distributed.eplb.eplb_state import EplbLayerState
 from vllm.model_executor.layers.fused_moe.config import RoutingMethodType
 
@@ -42,6 +43,7 @@ class FusedMoERouter(ABC):
     ) -> tuple[torch.Tensor, torch.Tensor]:
         raise NotImplementedError
 
+    @instrument_router
     def select_experts(
         self,
         hidden_states: torch.Tensor,

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -99,7 +99,7 @@ class GateLinear(ReplicatedLinear):
             and current_platform.is_device_capability((12, 0))
             and self.weight.dtype == torch.bfloat16
             and input_size == 4096
-            and _quixicore_available()
+            and _quixicore_projection_available()
         )
         self.allow_projection_gemv = (
             self._projection_gemv_shape and out_dtype == torch.float32
@@ -306,11 +306,11 @@ direct_register_custom_op(
 )
 
 
-def _quixicore_available() -> bool:
+def _quixicore_projection_available() -> bool:
     try:
         from vllm.quixicore.ops import quixicore_ops
 
-        return bool(quixicore_ops.is_available())
+        return quixicore_ops.has("dsv4_projection_gemv")
     except Exception:  # noqa: BLE001 - any import failure means no extension
         return False
 

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -19,6 +19,10 @@ class GateLinear(ReplicatedLinear):
     """MoE gate linear layer with multi-tier GEMM dispatch:
 
     1. DSV4 Ampere GEMV (SM80, M<=8, H=4096, E=256, bf16 in, fp32 out)
+    1b. QuixiCore decode projection GEMV (CUDA, M<=8, H=4096, any E,
+       bf16 in, fp32 out): one row-per-block launch that writes the fp32
+       logits directly, where the cuBLAS/F.linear tiers below either need
+       SM90+ or round through bf16 and cast.
     2. cuteDSL ll_bf16_gemm (SM90+, M<=16, bf16 in, fp32 out,
        K divisible by 8)
     3. DSV3 specialized kernel (SM90+, M<=16, H=7168 E=256/384, H=6144 E=256)
@@ -88,6 +92,17 @@ class GateLinear(ReplicatedLinear):
         )
         self.allow_dsv4_ampere_router_gemm = (
             self._dsv4_ampere_router_shape and out_dtype == torch.float32
+        )
+        self._projection_gemv_shape = (
+            not bias
+            and current_platform.is_cuda()
+            and current_platform.is_device_capability((12, 0))
+            and self.weight.dtype == torch.bfloat16
+            and input_size == 4096
+            and _quixicore_available()
+        )
+        self.allow_projection_gemv = (
+            self._projection_gemv_shape and out_dtype == torch.float32
         )
         # GLM-5.3-Flash requires FP32 router logits. Ampere supports cuBLAS
         # BF16 inputs with FP32 output; rounding to BF16 and then casting
@@ -171,6 +186,9 @@ class GateLinear(ReplicatedLinear):
         self.allow_dsv4_ampere_router_gemm = (
             self._dsv4_ampere_router_shape and out_dtype == torch.float32
         )
+        self.allow_projection_gemv = (
+            self._projection_gemv_shape and out_dtype == torch.float32
+        )
 
         if (
             not self.allow_cublas_router_gemm
@@ -204,6 +222,11 @@ class GateLinear(ReplicatedLinear):
             and x.dtype == torch.bfloat16
         ):
             output = torch.ops.vllm.dsv4_ampere_router_gemm(x, self.weight)
+            return output, None
+
+        # Tier 1b: QuixiCore decode projection GEMV (CUDA, H=4096, M<=8).
+        if self.allow_projection_gemv and x.shape[0] <= 8 and x.dtype == torch.bfloat16:
+            output = torch.ops.vllm.router_projection_gemv(x, self.weight)
             return output, None
 
         # Tier 2: cuteDSL ll_bf16_gemm (SM90+, any dims)
@@ -280,6 +303,32 @@ direct_register_custom_op(
     op_name="dsv4_ampere_router_gemm",
     op_func=dsv4_ampere_router_gemm_impl,
     fake_impl=dsv4_ampere_router_gemm_fake,
+)
+
+
+def _quixicore_available() -> bool:
+    try:
+        from vllm.quixicore.ops import quixicore_ops
+
+        return bool(quixicore_ops.is_available())
+    except Exception:  # noqa: BLE001 - any import failure means no extension
+        return False
+
+
+def router_projection_gemv_impl(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    from vllm.quixicore.ops import quixicore_ops
+
+    return quixicore_ops.dsv4_projection_gemv(x, weight, False)
+
+
+def router_projection_gemv_fake(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    return x.new_empty((x.shape[0], weight.shape[0]), dtype=torch.float32)
+
+
+direct_register_custom_op(
+    op_name="router_projection_gemv",
+    op_func=router_projection_gemv_impl,
+    fake_impl=router_projection_gemv_fake,
 )
 
 

--- a/vllm/model_executor/layers/fused_moe/router/glm_route_align.py
+++ b/vllm/model_executor/layers/fused_moe/router/glm_route_align.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fused small-M routing for the Marlin MoE path (QuixiCore glm_route_align).
+
+One launch does the scored top-k with bias-only selection (DeepSeek-style
+noaux_tc with a single expert group), renormalisation and scaling, and the
+Marlin block alignment that fused_marlin_moe would otherwise recompute with
+moe_align_block_size (two blocks) plus count_and_sort plus a fill. The router
+returns the usual (topk_weights, topk_ids) and publishes the alignment for
+fused_marlin_moe, which consumes it (matched on the topk_ids tensor) when its
+own block size matches. Decode only: M <= 16 tokens."""
+
+import os
+from dataclasses import dataclass
+
+import torch
+
+from slimserve.canonical_moe import stable_route_enabled
+from vllm.platforms import current_platform
+from vllm.quixicore.ops import quixicore_ops
+from vllm.utils.torch_utils import direct_register_custom_op
+
+MAX_TOKENS = 16
+# (num_experts, topk) instantiated in the kernel.
+SUPPORTED_SHAPES = {(288, 8)}
+SCORING = {"sigmoid": 0, "sqrtsoftplus": 1}
+
+
+@dataclass
+class RoutingAlignment:
+    topk_ids: torch.Tensor
+    sorted_token_ids: torch.Tensor
+    expert_ids: torch.Tensor
+    num_tokens_post_padded: torch.Tensor
+    block_size: int
+    canonical_assignment_order: bool = False
+
+
+# The router and the Marlin wrapper run back to back inside the moe_forward
+# custom op on one thread; the router publishes the alignment here and
+# fused_marlin_moe consumes it, matched on the identity of the topk_ids
+# tensor so a stale alignment can never be applied to another batch.
+_published: RoutingAlignment | None = None
+
+
+def publish(alignment: RoutingAlignment) -> None:
+    global _published
+    _published = alignment
+
+
+def consume(topk_ids: torch.Tensor) -> RoutingAlignment | None:
+    global _published
+    alignment, _published = _published, None
+    if alignment is not None and alignment.topk_ids is topk_ids:
+        return alignment
+    return None
+
+
+def marlin_block_size_m(num_tokens: int, topk: int, num_experts: int) -> int:
+    """Mirror of fused_marlin_moe's block size selection for bf16 inputs."""
+    for block_size_m in [8, 16, 32, 48, 64]:
+        if num_tokens * topk / num_experts / block_size_m < 0.9:
+            break
+    return block_size_m
+
+
+def alignment_geometry(
+    num_tokens: int, topk: int, num_experts: int, block_size: int
+) -> tuple[int, int]:
+    """Mirror of moe_align_block_size's buffer sizes (pad_sorted_ids=False)."""
+    numel = num_tokens * topk
+    max_padded = numel + num_experts * (block_size - 1)
+    if numel < num_experts:
+        max_padded = min(numel * block_size, max_padded)
+    return max_padded, (max_padded + block_size - 1) // block_size
+
+
+# Kill-switch for performance diagnosis: SLIMSERVE_GLM_ROUTE_ALIGN=0 keeps the
+# reference routing (grouped_topk + moe_align_block_size) on every batch.
+_ENABLED = os.getenv("SLIMSERVE_GLM_ROUTE_ALIGN", "1") != "0"
+_STABLE_ALIGNMENT_DIAGNOSTIC = stable_route_enabled()
+
+
+def eligible(router, router_logits: torch.Tensor, indices_type) -> bool:
+    bias = router.e_score_correction_bias
+    return (
+        _ENABLED
+        and current_platform.is_cuda()
+        and quixicore_ops.has_glm_route_align()
+        and router_logits.dim() == 2
+        and router_logits.dtype == torch.float32
+        and router_logits.is_contiguous()
+        and router_logits.shape[0] <= MAX_TOKENS
+        and (router_logits.shape[1], router.top_k) in SUPPORTED_SHAPES
+        and router.num_expert_group == 1
+        and router.topk_group == 1
+        and router.scoring_func in SCORING
+        and bias is not None
+        and bias.dtype == torch.float32
+        and bias.is_contiguous()
+        and bias.shape == (router_logits.shape[1],)
+        and getattr(router, "num_fused_shared_experts", 0) == 0
+        and indices_type in (None, torch.int32)
+    )
+
+
+def route(router, router_logits: torch.Tensor):
+    num_tokens, num_experts = router_logits.shape
+    block_size = marlin_block_size_m(num_tokens, router.top_k, num_experts)
+    max_padded, max_blocks = alignment_geometry(
+        num_tokens, router.top_k, num_experts, block_size
+    )
+    weights, ids, sorted_ids, expert_ids, post_pad = torch.ops.vllm.glm_route_align(
+        router_logits,
+        router.e_score_correction_bias.data,
+        router.top_k,
+        SCORING[router.scoring_func],
+        router.renormalize,
+        float(router.routed_scaling_factor),
+        block_size,
+        max_padded,
+        max_blocks,
+    )
+    publish(
+        RoutingAlignment(
+            ids,
+            sorted_ids,
+            expert_ids,
+            post_pad,
+            block_size,
+            canonical_assignment_order=_STABLE_ALIGNMENT_DIAGNOSTIC,
+        )
+    )
+    return weights, ids
+
+
+def _glm_route_align_impl(
+    logits: torch.Tensor,
+    bias: torch.Tensor,
+    topk: int,
+    scoring: int,
+    renormalize: bool,
+    scaling: float,
+    block_size: int,
+    max_padded: int,
+    max_blocks: int,
+) -> list[torch.Tensor]:
+    if _STABLE_ALIGNMENT_DIAGNOSTIC:
+        return quixicore_ops.glm_route_align(
+            logits,
+            bias,
+            topk,
+            scoring,
+            renormalize,
+            scaling,
+            block_size,
+            max_padded,
+            max_blocks,
+            stable=True,
+        )
+    return quixicore_ops.glm_route_align(
+        logits,
+        bias,
+        topk,
+        scoring,
+        renormalize,
+        scaling,
+        block_size,
+        max_padded,
+        max_blocks,
+    )
+
+
+def _glm_route_align_fake(
+    logits: torch.Tensor,
+    bias: torch.Tensor,
+    topk: int,
+    scoring: int,
+    renormalize: bool,
+    scaling: float,
+    block_size: int,
+    max_padded: int,
+    max_blocks: int,
+) -> list[torch.Tensor]:
+    i32 = logits.new_empty(0, dtype=torch.int32)
+    return [
+        logits.new_empty((logits.shape[0], topk)),
+        i32.new_empty((logits.shape[0], topk)),
+        i32.new_empty((max_padded,)),
+        i32.new_empty((max_blocks,)),
+        i32.new_empty((1,)),
+    ]
+
+
+direct_register_custom_op(
+    op_name="glm_route_align",
+    op_func=_glm_route_align_impl,
+    fake_impl=_glm_route_align_fake,
+)

--- a/vllm/model_executor/layers/fused_moe/router/glm_stable_align.py
+++ b/vllm/model_executor/layers/fused_moe/router/glm_stable_align.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opaque large-M stable alignment, used only by the opt-in GLM53 diagnostic.
+
+Native dispatch retains count256/scatter256 for M17..32 and uses direct1024/
+scatter512 for M33..8192. No route scores, IDs or weights are changed.
+"""
+
+import torch
+
+from vllm.model_executor.layers.fused_moe.router.glm_route_align import (
+    alignment_geometry,
+)
+from vllm.quixicore.ops import quixicore_ops
+from vllm.utils.torch_utils import direct_register_custom_op
+
+
+def _outputs(ids: torch.Tensor, block: int) -> list[torch.Tensor]:
+    if not (
+        ids.ndim == 2
+        and 17 <= ids.shape[0] <= 8192
+        and ids.shape[1] == 8
+        and ids.dtype == torch.int32
+        and ids.is_contiguous()
+        and block in (8, 16, 32, 48, 64)
+    ):
+        raise ValueError("stable GLM alignment requires contiguous int32 [17..8192,8]")
+    capacity, blocks = alignment_geometry(ids.shape[0], 8, 288, block)
+    return [ids.new_empty((size,)) for size in (capacity, blocks, 1)]
+
+
+def _glm_stable_align_impl(ids: torch.Tensor, block: int) -> list[torch.Tensor]:
+    outputs = _outputs(ids, block)
+    offsets = ids.new_empty((289,))
+    quixicore_ops.glm_stable_align(ids, *outputs, offsets, block)
+    return outputs
+
+
+def _glm_stable_align_fake(ids: torch.Tensor, block: int) -> list[torch.Tensor]:
+    return _outputs(ids, block)
+
+
+direct_register_custom_op(
+    op_name="glm_stable_align",
+    op_func=_glm_stable_align_impl,
+    fake_impl=_glm_stable_align_fake,
+)
+
+
+def align(ids: torch.Tensor, block: int) -> list[torch.Tensor]:
+    return torch.ops.vllm.glm_stable_align(ids, block)

--- a/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
@@ -16,6 +16,7 @@ from vllm.model_executor.layers.fused_moe.config import (
 from vllm.model_executor.layers.fused_moe.experts.rocm_aiter_moe import (
     rocm_aiter_grouped_topk,
 )
+from vllm.model_executor.layers.fused_moe.router import glm_route_align
 from vllm.model_executor.layers.fused_moe.router.base_router import BaseRouter
 from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
     fused_topk_bias,
@@ -322,6 +323,12 @@ class GroupedTopKRouter(BaseRouter):
                     indices_type=indices_type,
                 )
             return topk_weights, topk_ids
+
+        # Decode-sized batches with one expert group: one QuixiCore launch does
+        # the scored top-k and the Marlin block alignment, which it publishes
+        # for fused_marlin_moe (glm_route_align.consume).
+        if glm_route_align.eligible(self, router_logits, indices_type):
+            return glm_route_align.route(self, router_logits)
 
         # Select grouped_topk implementation
         if rocm_aiter_ops.is_fused_moe_enabled():

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -22,6 +22,7 @@ from vllm.forward_context import (
     is_forward_context_available,
 )
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe import combine_shared
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEConfig,
@@ -49,6 +50,7 @@ from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
     SharedExpertsOrder,
 )
 from vllm.platforms import current_platform
+from vllm.quixicore.ops import quixicore_ops
 from vllm.utils.torch_utils import (
     _USE_LAYERNAME,
     LayerName,
@@ -274,7 +276,7 @@ class MoERunner(MoERunnerInterface):
         self.enable_dbo = enable_dbo
         # DSV4 Ampere can carry shared/routed TP partials separately into its
         # custom all-reduce+mHC transition, avoiding a materialized local add.
-        self.defer_shared_expert_add = False
+        self._defer_shared_expert_add = False
 
         # When both gates are present and FSE is enabled, fuse their
         # weight matrices into [num_experts + num_shared, hidden] so one
@@ -294,6 +296,27 @@ class MoERunner(MoERunnerInterface):
                 mk_can_overlap_shared_experts=can_overlap,
             )
 
+        # Fold the shared-expert add into the routed experts' final sum
+        # (QuixiCore moe_sum_add through combine_shared): the op then returns
+        # the combined tensor and the separate add launch disappears. Only for
+        # the plain layer shape: no routed transforms or padding, no DP / EP /
+        # PCP / sequence parallel, no DBO, and the routed scale already applied
+        # by the router (the runner's factor is 1.0).
+        self._combine_shared_in_op = (
+            self._shared_experts is not None
+            and current_platform.is_cuda()
+            and quixicore_ops.has_moe_sum_add()
+            and routed_scaling_factor == 1.0
+            and routed_input_transform is None
+            and routed_output_transform is None
+            and not enable_dbo
+            and moe_config.dp_size == 1
+            and moe_config.pcp_size == 1
+            and not moe_config.use_ep
+            and not moe_config.is_sequence_parallel
+            and moe_config.hidden_dim == moe_config.hidden_dim_unpadded
+        )
+
         # Needed for string -> MoERunner layer lookup in custom ops.
         self.layer_name = layer_name
 
@@ -308,17 +331,31 @@ class MoERunner(MoERunnerInterface):
         return self.routed_experts.load_weights(weights)
 
     def _select_forward(self) -> Callable:
+        # One combined output unless the shared-expert output comes back
+        # separately for the Python-level add.
+        single = self._shared_experts is None or self._combine_shared_in_op
         if current_platform.is_tpu() or current_platform.is_cpu():
             # TODO: Once the OOM issue for the TPU backend is resolved, we
             # will switch to using the moe_forward custom op.
             # Note: CPU doesn't require wrapped _forward_impl.
-            return _moe_forward if self._shared_experts is None else _moe_forward_shared
+            return _moe_forward if single else _moe_forward_shared
 
         return (
-            torch.ops.vllm.moe_forward
-            if self._shared_experts is None
-            else torch.ops.vllm.moe_forward_shared
+            torch.ops.vllm.moe_forward if single else torch.ops.vllm.moe_forward_shared
         )
+
+    @property
+    def defer_shared_expert_add(self) -> bool:
+        return self._defer_shared_expert_add
+
+    @defer_shared_expert_add.setter
+    def defer_shared_expert_add(self, value: bool) -> None:
+        self._defer_shared_expert_add = value
+        # The model wants the shared and routed partials separately, which
+        # the in-kernel combine cannot provide.
+        if value and self._combine_shared_in_op:
+            self._combine_shared_in_op = False
+            self._forward_entry = self._select_forward()
 
     @property
     def shared_experts(self) -> SharedExperts | None:
@@ -609,6 +646,14 @@ class MoERunner(MoERunnerInterface):
         self._maybe_apply_shared_experts(
             shared_experts_input, SharedExpertsOrder.NO_OVERLAP, prequant_input
         )
+        if self._combine_shared_in_op:
+            # Launch the aux-stream shared experts ahead of the routed experts;
+            # SharedExperts.output joins the streams when the sum consumes it.
+            self._maybe_apply_shared_experts(
+                shared_experts_input,
+                SharedExpertsOrder.MULTI_STREAM_OVERLAPPED,
+                prequant_input,
+            )
 
         if self.routed_experts.quant_method.is_monolithic:
             # Monolithic kernels: pass router_logits to routed_experts
@@ -629,6 +674,11 @@ class MoERunner(MoERunnerInterface):
             else:
                 topk_weights, topk_ids = preselected
 
+            if (
+                self._combine_shared_in_op
+                and self._shared_experts.peek_output() is not None
+            ):
+                combine_shared.publish(topk_ids, self._shared_experts)
             fused_out = self.routed_experts.forward_modular(
                 x=hidden_states,
                 topk_weights=topk_weights,
@@ -637,6 +687,15 @@ class MoERunner(MoERunnerInterface):
                 shared_experts_input=shared_experts_input,
                 prequant_input=prequant_input,
             )
+
+        if self._combine_shared_in_op:
+            assert self._shared_experts is not None
+            if not combine_shared.retire():
+                # No kernel folded the shared output in (another experts
+                # implementation or an incompatible shape): add it here,
+                # still inside the op.
+                fused_out = fused_out + self._shared_experts.output
+            return None, fused_out
 
         self._maybe_apply_shared_experts(
             shared_experts_input,
@@ -746,6 +805,9 @@ class MoERunner(MoERunnerInterface):
             )
         )
 
+        # The in-op combine adds shared and routed outputs of one width.
+        assert not (self._combine_shared_in_op and og_hidden_dim_pre_xform is not None)
+
         result = self._forward_entry(
             hidden_states,
             router_logits,
@@ -854,7 +916,7 @@ class MoERunner(MoERunnerInterface):
         ):
             hidden_states = get_pcp_group().reduce_scatter(hidden_states, dim=0)
 
-        if self.shared_experts is not None:
+        if self.shared_experts is not None and not self._combine_shared_in_op:
             assert shared_output is not None
             return shared_output, hidden_states
         else:

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -52,6 +52,10 @@ class SharedExperts(torch.nn.Module):
         # index is always 0 and the second output list element is ignored.
         self.enable_dbo = enable_dbo
         self._output: list[torch.Tensor | None] = [None, None]
+        # Aux-stream outputs are joined (main stream waits on the aux stream)
+        # when they are consumed through `output`, not when they are launched,
+        # so the routed experts enqueued in between can overlap them.
+        self._join_pending: list[bool] = [False, False]
         self._layer = layer
         self._moe_config = moe_config
 
@@ -146,7 +150,7 @@ class SharedExperts(torch.nn.Module):
                 output = self._layer(
                     shared_experts_input, prequant_input=prequant_input
                 )
-        current_stream().wait_stream(self._stream)
+        self._join_pending[self._output_idx] = True
 
         return output
 
@@ -154,11 +158,22 @@ class SharedExperts(torch.nn.Module):
     def _output_idx(self) -> int:
         return dbo_current_ubatch_id() if self.enable_dbo else 0
 
+    def peek_output(self) -> torch.Tensor | None:
+        """The stored output, if any, without consuming or joining it."""
+        return self._output[self._output_idx]
+
     @property
     def output(self) -> torch.Tensor:
-        assert self._output[self._output_idx] is not None
-        output = self._output[self._output_idx]
-        self._output[self._output_idx] = None
+        """Consume the stored output; joins the aux stream first if it was
+        computed there."""
+        idx = self._output_idx
+        assert self._output[idx] is not None
+        if self._join_pending[idx]:
+            assert self._stream is not None
+            current_stream().wait_stream(self._stream)
+            self._join_pending[idx] = False
+        output = self._output[idx]
+        self._output[idx] = None
         return output
 
     def forward(

--- a/vllm/model_executor/layers/glm5_next_indexer.py
+++ b/vllm/model_executor/layers/glm5_next_indexer.py
@@ -28,11 +28,18 @@ opaque to torch.compile and captures into decode CUDA graphs.
 
 from __future__ import annotations
 
+import os
+from functools import cache as cache_once
+
 import torch
 from torch import nn
 
+from slimserve.canonical_indexer import maybe_ordered_topk
+from slimserve.index_journal import instrument_pooled_indexer, instrument_topk
+
 from vllm import _custom_ops as ops
-from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
+from vllm.config import CacheConfig, VllmConfig
+from vllm.distributed import get_dcp_group, get_pcp_group, get_tp_group
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.glm5_next_indexer_workspace import (
@@ -60,10 +67,60 @@ from vllm.v1.kv_cache_interface import KVCacheSpec, MLAAttentionSpec
 
 logger = init_logger(__name__)
 
+# Keep the observer outside the intervention: record the actual selection order
+# passed to pool expansion. Both factories are identity functions when disabled.
+top_k_per_row_prefill = instrument_topk(maybe_ordered_topk(ops.top_k_per_row_prefill))
+
 # Row layout of the cached indexer state.
 _K_DIM = 128
 _ROW_DIM = 2 * _K_DIM  # [k | gate]
 _POOL_PROGRAMS = 128  # programs per row on the pool axis (stride loop inside)
+# Prefill path: pooled keys once per (request, pool), then a tensor-core
+# matmul of [_ROW_TILE * H, D] query rows against [_POOL_TILE, D] pooled keys.
+# Kill switch for A/B runs only (read here, so it is not a compile factor):
+# VLLM_GLM5_INDEXER_PREFILL_MATMUL=0 scores prefill rows with the decode-shaped
+# per-row kernel instead.
+def _prefill_matmul_enabled() -> bool:
+    # Keep A100's raw-cache fallback on its original per-row implementation.
+    # Its compact-cache path has an independent prefill scorer.
+    sm120 = current_platform.is_cuda() and current_platform.is_device_capability(
+        (12, 0)
+    )
+    return os.getenv("VLLM_GLM5_INDEXER_PREFILL_MATMUL", "1" if sm120 else "0") != "0"
+
+
+_PREFILL_MATMUL = _prefill_matmul_enabled()
+# Profile-selected SM120 geometry: fewer query rows and more pooled keys avoid the
+# original tile's register spills. Arithmetic and selection are unchanged.
+# Keep other profiles on their measured geometry; set before worker import.
+_SM120_TILES = os.getenv("VLLM_GLM5_INDEXER_SM120_TILES", "0") == "1"
+_ROW_TILE = 2 if _SM120_TILES else 8
+_POOL_TILE = 128 if _SM120_TILES else 64
+_TP_PREFILL_SHARD = os.getenv("VLLM_GLM53_INDEXER_TP_PREFILL", "0") == "1"
+
+
+def _prefill_row_sharding_enabled(chunks) -> bool:
+    # This fork stores host-side context lengths on each chunk, not on the
+    # enclosing prefill metadata (unlike the newer upstream implementation).
+    return bool(
+        _TP_PREFILL_SHARD and _PREFILL_MATMUL and chunks
+        and chunks[-1].token_end - chunks[0].token_start >= 2048
+        and max(c.max_seq_len for c in chunks) >= 32768
+    )
+
+
+@cache_once
+def _prefill_shard_group():
+    # Explicit SM120/TP4 opt-in. Decode, short prefills and other platforms
+    # retain the existing zero-communication path.
+    if (not _TP_PREFILL_SHARD or not torch.cuda.is_available()
+            or torch.cuda.get_device_capability() != (12, 0)):
+        return None
+    group = get_tp_group()
+    if (group.world_size != 4 or get_dcp_group().world_size != 1
+            or get_pcp_group().world_size != 1):
+        return None
+    return group
 
 
 def _compact_decode_options(vllm_config, heads):
@@ -298,9 +355,15 @@ def _expand_topk_kernel(
     tail_count = vis - n_pools * KP
     tail_start = n_pools * KP
     n_sel = tl.minimum(n_pools, KSEL)  # top-k writes valid pools first
+    # Only the selected slots are written here; the tail store and the
+    # padding loop below own the columns from n_sel * KP on. Threads of one
+    # program are not ordered against each other, so a slot written by two
+    # stores keeps whichever lands last: writing -1 over [0, KSEL * KP) here
+    # raced the tail store and dropped the tail (often the query's own
+    # token) from a fraction of rows.
     for s0 in range(0, KSEL, BLOCK_S):
         s = s0 + tl.arange(0, BLOCK_S)
-        smask = s < KSEL
+        smask = s < n_sel
         pool = tl.load(sel_ptr + r.to(tl.int64) * sel_stride + s, mask=smask, other=-1)
         ok = smask & (pool >= 0) & (pool < n_pools)
         m = tl.arange(0, KP)
@@ -322,7 +385,214 @@ def _expand_topk_kernel(
         tl.store(out_ptr + r.to(tl.int64) * OUT_W + c, tl.full((256,), -1, tl.int32), mask=cm)
 
 
+@triton.jit(do_not_specialize=["max_pools"])
+def _pool_keys_kernel(
+    ape_ptr,        # [KP, D] fp32
+    cache_ptr,      # [num_slots, ROW] bf16
+    bt_ptr,         # [num_bt_rows, bt_stride] int32
+    req_pools_ptr,  # [num_bt_rows] int32: pools to build per block-table row
+    pk_ptr,         # [num_bt_rows, max_pools, D] bf16
+    max_pools,
+    bt_stride,
+    page_stride,
+    BLOCK_SIZE: tl.constexpr,
+    D: tl.constexpr,
+    KP: tl.constexpr,
+    ROW: tl.constexpr,
+    BLOCK_P: tl.constexpr,
+):
+    """pk[req, p, :] = sum_m softmax_m(gate(t_m) + ape[m]) * k(t_m) over the
+    KP members of pool p of the request in block-table row req. The pooled
+    key depends only on the cache and APE, never on the query, so the
+    prefill path builds it once per request instead of once per query row
+    (`_pooled_logits_kernel` re-pools it for every row: rows x visible
+    softmaxes gathered through the block table). Same arithmetic and the
+    same bf16 rounding as that kernel's pool_key."""
+    req = tl.program_id(0)
+    pt = tl.program_id(1)
+    n_pools = tl.load(req_pools_ptr + req)
+    p = pt * BLOCK_P + tl.arange(0, BLOCK_P)
+    pmask = p < n_pools
+    m = tl.arange(0, KP)
+    d = tl.arange(0, D)
+    ape = tl.load(ape_ptr + m[:, None] * D + d[None, :])  # [KP, D]
+    tok = p[:, None] * KP + m[None, :]  # [P, KP]
+    blk = tl.load(
+        bt_ptr + req.to(tl.int64) * bt_stride + tok // BLOCK_SIZE,
+        mask=pmask[:, None],
+        other=0,
+    )
+    base = cache_ptr + (
+        blk.to(tl.int64) * page_stride + (tok % BLOCK_SIZE) * ROW
+    )[:, :, None]  # [P, KP, 1]
+    k = tl.load(base + d[None, None, :], mask=pmask[:, None, None], other=0.0)
+    g = tl.load(base + D + d[None, None, :], mask=pmask[:, None, None], other=0.0)
+    logits_g = g.to(tl.float32) + ape[None, :, :]  # [P, KP, D]
+    mx = tl.max(logits_g, axis=1)  # [P, D]
+    e = tl.exp(logits_g - mx[:, None, :])
+    probs = e / tl.sum(e, axis=1)[:, None, :]
+    pool_key = tl.sum(probs * k.to(tl.float32), axis=1)  # [P, D]
+    tl.store(
+        pk_ptr + (req.to(tl.int64) * max_pools + p)[:, None] * D + d[None, :],
+        pool_key.to(tl.bfloat16),
+        mask=pmask[:, None],
+    )
+
+
+@triton.jit
+def _row_tiles_kernel(
+    start_ptr,      # [num_req] int32: first query row of the request
+    count_ptr,      # [num_req] int32: query rows of the request
+    first_ptr,      # [num_req] int32: first tile slot of the request
+    row0_ptr,       # [max_tiles] int32 out
+    end_ptr,        # [max_tiles] int32 out
+    req_ptr,        # [max_tiles] int32 out
+    RT: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+):
+    """Tiles of RT consecutive query rows of one request (the last tile of a
+    request is short), written at the request's slots of the tile table.
+    Sized on the host from an upper bound, so no sync: unused slots keep
+    their (0, 0) fill and the matmul programs that draw them exit."""
+    req = tl.program_id(0)
+    start = tl.load(start_ptr + req)
+    count = tl.load(count_ptr + req)
+    first = tl.load(first_ptr + req)
+    n_tiles = (count + RT - 1) // RT
+    for t0 in range(0, n_tiles, BLOCK_T):
+        t = t0 + tl.arange(0, BLOCK_T)
+        tmask = t < n_tiles
+        row0 = start + t * RT
+        tl.store(row0_ptr + first + t, row0, mask=tmask)
+        tl.store(end_ptr + first + t, tl.minimum(row0 + RT, start + count), mask=tmask)
+        req_v = tl.full((BLOCK_T,), 0, tl.int32) + req
+        tl.store(req_ptr + first + t, req_v, mask=tmask)
+
+
+@triton.jit(do_not_specialize=["max_pools"])
+def _pooled_logits_matmul_kernel(
+    q_ptr,          # [R, H, D] bf16
+    w_ptr,          # [R, H] fp32 (already * n_heads^-0.5)
+    pk_ptr,         # [num_bt_rows, max_pools, D] bf16 pooled keys
+    row0_ptr,       # [max_tiles] int32
+    end_ptr,        # [max_tiles] int32
+    req_ptr,        # [max_tiles] int32
+    vis_ptr,        # [R] int32
+    out_ptr,        # [R, max_pools] fp32
+    max_pools,
+    softmax_scale,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    KP: tl.constexpr,
+    RT: tl.constexpr,
+    PT: tl.constexpr,
+):
+    """logits[r, p] = sum_h w[r, h] * relu(scale * <pk[req(r), p], q[r, h]>)
+    for p < vis(r) // KP. One program scores a row tile (rows [row0, end)
+    of one request) against PT pools as a [RT * H, D] x [D, PT] tensor-core
+    product; pool tiles past every row's visibility exit at once."""
+    rt = tl.program_id(0)
+    pt = tl.program_id(1)
+    r0 = tl.load(row0_ptr + rt)
+    r_end = tl.load(end_ptr + rt)
+    rows = r0 + tl.arange(0, RT)
+    rmask = rows < r_end
+    vis = tl.load(vis_ptr + rows, mask=rmask, other=0)
+    n_pools = vis // KP
+    p0 = pt * PT
+    if p0 >= tl.max(n_pools, axis=0):
+        return
+    req = tl.load(req_ptr + rt)
+    p = p0 + tl.arange(0, PT)
+    d = tl.arange(0, D)
+    pk = tl.load(
+        pk_ptr + (req.to(tl.int64) * max_pools + p)[:, None] * D + d[None, :],
+        mask=(p < max_pools)[:, None],
+        other=0.0,
+    )  # [PT, D]
+    qi = tl.arange(0, RT * H)
+    qrow = r0 + qi // H
+    qmask = qrow < r_end
+    q = tl.load(
+        q_ptr + (qrow.to(tl.int64) * H + qi % H)[:, None] * D + d[None, :],
+        mask=qmask[:, None],
+        other=0.0,
+    )  # [RT * H, D]
+    scores = tl.dot(q, tl.trans(pk))  # [RT * H, PT] fp32
+    scores = tl.maximum(scores * softmax_scale, 0.0)
+    w = tl.load(w_ptr + qrow * H + qi % H, mask=qmask, other=0.0)  # [RT * H]
+    scores = tl.reshape(scores * w[:, None], (RT, H, PT))
+    logit = tl.sum(scores, axis=1)  # [RT, PT]
+    valid = (p[None, :] < n_pools[:, None]) & rmask[:, None]
+    logit = tl.where(valid, logit, float("-inf"))
+    tl.store(
+        out_ptr + rows.to(tl.int64)[:, None] * max_pools + p[None, :],
+        logit,
+        mask=rmask[:, None] & (p[None, :] < max_pools),
+    )
+
+
 # --------------------------------------------------------------------- core op
+
+
+def _pooled_logits_by_request(
+    q: torch.Tensor,
+    weights: torch.Tensor,
+    ape: torch.Tensor,
+    cache: torch.Tensor,
+    block_table: torch.Tensor,
+    row_req: torch.Tensor,
+    n_pools: torch.Tensor,     # [R] int32: visible // kp per row
+    visible: torch.Tensor,
+    logits: torch.Tensor,
+    max_pools: int,
+    block_size: int,
+    softmax_scale: float,
+    kp: int,
+) -> None:
+    """Fill `logits` for rows grouped by request (rows of a request are
+    contiguous, requests in block-table order, as in a prefill chunk):
+    pooled keys once per request, then the tiled matmul. Every size that
+    shapes a launch is a host int, so nothing syncs."""
+    R, H, D = q.shape
+    RT, PT = _ROW_TILE, _POOL_TILE
+    n_req = block_table.shape[0]
+    dev = q.device
+    i32 = torch.int32
+    req_ids = torch.arange(n_req, device=dev, dtype=row_req.dtype)
+    start = torch.searchsorted(row_req, req_ids).to(i32)
+    end = torch.searchsorted(row_req, req_ids, right=True).to(i32)
+    count = end - start
+    req_pools = torch.zeros(n_req, dtype=i32, device=dev)
+    req_pools.scatter_reduce_(0, row_req.long(), n_pools, reduce="amax")
+    n_tiles = (count + (RT - 1)) // RT
+    tile_first = torch.cumsum(n_tiles, 0, dtype=i32) - n_tiles
+    # sum over requests of ceil(count / RT) <= ceil(R / RT) + n_req; padded
+    # to 16 slots so the three table rows stay 16-byte aligned (Triton
+    # specialises pointer args on alignment: one compile per boot, not one
+    # per tile count).
+    max_tiles = -(-(triton.cdiv(R, RT) + n_req) // 16) * 16
+    tiles = torch.zeros((3, max_tiles), dtype=i32, device=dev)
+    _row_tiles_kernel[(n_req,)](
+        start, count, tile_first, tiles[0], tiles[1], tiles[2],
+        RT=RT, BLOCK_T=256,
+    )
+    pk = torch.empty((n_req, max_pools, D), dtype=torch.bfloat16, device=dev)
+    BLOCK_P = 16
+    _pool_keys_kernel[(n_req, triton.cdiv(max_pools, BLOCK_P))](
+        ape, cache, block_table, req_pools, pk, max_pools,
+        block_table.stride(0), cache.stride(0),
+        BLOCK_SIZE=block_size, D=D, KP=kp, ROW=_ROW_DIM, BLOCK_P=BLOCK_P,
+    )
+    _pooled_logits_matmul_kernel[(max_tiles, triton.cdiv(max_pools, PT))](
+        q, weights, pk, tiles[0], tiles[1], tiles[2], visible, logits,
+        max_pools, softmax_scale, H=H, D=D, KP=kp, RT=RT, PT=PT,
+    )
+
+
+def _prefill_row_req(chunk, R: int) -> torch.Tensor:
+    """Compatibility entry point; retain actual table IDs for sliced queries."""
+    return _prefill_query_requests(chunk)[:R]
 
 
 def _prefill_query_requests(chunk) -> torch.Tensor:
@@ -352,14 +622,13 @@ def _pooled_topk(
     softmax_scale: float,
     ksel: int,
     kp: int,
+    by_request: bool = False,  # rows grouped by request: prefill chunks
     adaptive_score: bool = False,
 ) -> torch.Tensor:
     R, H, D = q.shape
-    assert R > 0
-    BLOCK_P = 16
-    # Fixed program count per row; each program strides over the row's
-    # actual pool tiles (see the kernel docstring).
-    grid = (R, min(triton.cdiv(max_pools, BLOCK_P), _POOL_PROGRAMS))
+    if R == 0:
+        return torch.empty((0, ksel), dtype=torch.int32, device=q.device)
+    n_pools = torch.div(visible, kp, rounding_mode="floor").to(torch.int32)
     if cache.shape[-1] == POOL_CACHE_HEAD_DIM:
         assert kp == 4 and D == 128 and softmax_scale == 128**-0.5
         if adaptive_score and R <= 64:
@@ -368,17 +637,27 @@ def _pooled_topk(
             adaptive_pool_logits(q, weights, cache, block_table, row_req, visible, logits)
         else:
             cached_pool_logits(q, weights, cache, block_table, row_req, visible, logits)
+    elif by_request:
+        _pooled_logits_by_request(
+            q, weights, ape, cache, block_table, row_req, n_pools, visible,
+            logits, max_pools, block_size, softmax_scale, kp,
+        )
     else:
+        BLOCK_P = 16
+        # Fixed program count per row; each program strides over the row's
+        # actual pool tiles (see the kernel docstring).
+        grid = (R, min(triton.cdiv(max_pools, BLOCK_P), _POOL_PROGRAMS))
         _pooled_logits_kernel[grid](
             q, weights, ape, cache, block_table, row_req, visible,
-            logits, max_pools, block_table.stride(0), cache.stride(0), softmax_scale,
-            BLOCK_SIZE=block_size, H=H, D=D, KP=kp, ROW=_ROW_DIM, BLOCK_P=BLOCK_P,
+            logits, max_pools, block_table.stride(0), cache.stride(0),
+            softmax_scale,
+            BLOCK_SIZE=block_size, H=H, D=D, KP=kp, ROW=_ROW_DIM,
+            BLOCK_P=BLOCK_P,
         )
     # top-k over pools: prefill-style ranges [0, n_pools) per row.
-    n_pools = torch.div(visible, kp, rounding_mode="floor").to(torch.int32)
     zeros = torch.zeros_like(n_pools)
     sel = torch.empty((R, ksel), dtype=torch.int32, device=q.device)
-    ops.top_k_per_row_prefill(
+    top_k_per_row_prefill(
         logits[:R], zeros, n_pools, sel, R, logits.stride(0), logits.stride(1),
         ksel,
     )
@@ -388,6 +667,7 @@ def _pooled_topk(
 def _pooled_select(
     q, weights, ape, cache, block_table, row_req, visible, logits,
     max_pools, block_size, softmax_scale, ksel, topk_out, kp,
+    by_request=False,
     adaptive_score=False, row_shard=False,
 ) -> None:
     R = q.shape[0]
@@ -400,7 +680,7 @@ def _pooled_select(
         assert group.world_size in (4, 8) and 0 <= group.rank_in_group < group.world_size
         assert R in (16, 32) and q.shape[1:] == (32, 128)
         assert cache.shape[-1] == POOL_CACHE_HEAD_DIM and kp == 4 and ksel == 512
-        assert not adaptive_score
+        assert not adaptive_score and not by_request
         communicator = group.device_communicator
         assert communicator is not None
         communicator.wait_for_comm_init()
@@ -422,7 +702,8 @@ def _pooled_select(
     else:
         sel = _pooled_topk(
             q, weights, ape, cache, block_table, row_req, visible, logits,
-            max_pools, block_size, softmax_scale, ksel, kp, adaptive_score,
+            max_pools, block_size, softmax_scale, ksel, kp,
+            by_request=by_request, adaptive_score=adaptive_score,
         )
     _expand_topk_kernel[(R,)](
         sel, visible, topk_out, sel.stride(0),
@@ -430,6 +711,52 @@ def _pooled_select(
     )
 
 
+def _pooled_prefill_tp_select(
+    q, weights, ape, cache, chunks, topk_out, block_size,
+    softmax_scale, ksel, kp, group,
+) -> None:
+    """Disjoint query rows; one pool-ID exchange before token expansion.
+
+    Adapted from vLLM #54951's row-ownership design. Pool IDs are 4x smaller
+    than expanded indices for GLM53. No score reduction/quantization change.
+    Chunk offsets exclude leading decode rows and trailing graph padding.
+    """
+    first, last = chunks[0].token_start, chunks[-1].token_end
+    owned = triton.cdiv(last - first, group.world_size)
+    start = first + group.rank_in_group * owned
+    stop = min(start + owned, last)
+    local = torch.full((owned, ksel), -1, dtype=torch.int32, device=q.device)
+    for chunk in chunks:
+        lo, hi = max(start, chunk.token_start), min(stop, chunk.token_end)
+        if lo >= hi:
+            continue
+        R = chunk.token_end - chunk.token_start
+        offset = slice(lo - chunk.token_start, hi - chunk.token_start)
+        visible = (chunk.cu_seqlen_ke - chunk.cu_seqlen_ks).to(torch.int32)
+        row_req = _prefill_row_req(chunk, R)
+        max_pools = max(1, chunk.max_seq_len // kp)
+        logits = torch.empty((hi - lo, max_pools), dtype=torch.float32, device=q.device)
+        local[lo - start:hi - start] = _pooled_topk(
+            q[lo:hi], weights[lo:hi], ape, cache, chunk.block_table,
+            row_req[offset], visible[offset], logits, max_pools, block_size,
+            softmax_scale, ksel, kp, by_request=True,
+        )
+    # Keep local alive until all dependent work is enqueued. Empty owners still
+    # participate with padding; every rank issues exactly one collective.
+    gathered = group.all_gather(local, dim=0)
+    for chunk in chunks:
+        R = chunk.token_end - chunk.token_start
+        if R <= 0:
+            continue
+        selected = gathered[chunk.token_start - first:chunk.token_end - first]
+        visible = (chunk.cu_seqlen_ke - chunk.cu_seqlen_ks).to(torch.int32)
+        _expand_topk_kernel[(R,)](
+            selected, visible, topk_out[chunk.token_start:chunk.token_end],
+            selected.stride(0), KP=kp, KSEL=ksel, OUT_W=topk_out.shape[1], BLOCK_S=64,
+        )
+
+
+@instrument_pooled_indexer
 def glm5_next_pooled_indexer(
     q: torch.Tensor,
     packed: torch.Tensor,
@@ -479,7 +806,19 @@ def glm5_next_pooled_indexer(
     # 2) prefill chunks.
     if md.num_prefills > 0:
         assert md.prefill is not None
-        for chunk in md.prefill.chunks:
+        chunks = md.prefill.chunks
+        group = None
+        if _prefill_row_sharding_enabled(chunks):
+            group = _prefill_shard_group()
+        if group is not None:
+            logger.info_once(
+                "GLM53 TP4 prefill indexer row sharding active (pool-ID exchange)."
+            )
+            _pooled_prefill_tp_select(
+                q, weights, ape, cache, chunks, topk_indices_buffer,
+                block_size, softmax_scale, ksel, kp, group,
+            )
+        for chunk in (() if group is not None else chunks):
             R = chunk.token_end - chunk.token_start
             if R <= 0:
                 continue
@@ -495,6 +834,7 @@ def glm5_next_pooled_indexer(
                 ape, cache, chunk.block_table, row_req, visible, logits,
                 max_pools, block_size, softmax_scale, ksel,
                 topk_indices_buffer[chunk.token_start:chunk.token_end], kp,
+                by_request=_PREFILL_MATMUL,
             )
 
     # 3) decode rows (fixed-size workspace: CUDA-graph safe).
@@ -553,9 +893,14 @@ class Glm5NextPooledIndexer(nn.Module):
         cache_config: CacheConfig | None,
         topk_indices_buffer: torch.Tensor,
         prefix: str = "",
+        fold_input_projections: bool = False,
         workspace: Glm5NextIndexerWorkspace | None = None,
     ) -> None:
         super().__init__()
+        # When the owning attention layer folds wk, the kpool compress gate
+        # and weights_proj into its fused_qkv_a_proj, forward() receives their
+        # outputs as ``precomputed`` and this module holds no such weights.
+        self.fold_input_projections = fold_input_projections
         self.n_heads = config.index_n_heads
         self.adaptive_score, self.singleton_fused_update = _compact_decode_options(
             vllm_config, self.n_heads
@@ -579,20 +924,21 @@ class Glm5NextPooledIndexer(nn.Module):
             config.q_lora_rank, self.n_heads * self.head_dim, bias=False,
             quant_config=quant_config, prefix=f"{prefix}.wq_b",
         )
-        self.wk = ReplicatedLinear(
-            config.hidden_size, self.head_dim, bias=False,
-            quant_config=quant_config, prefix=f"{prefix}.wk",
-        )
+        if not fold_input_projections:
+            self.wk = ReplicatedLinear(
+                config.hidden_size, self.head_dim, bias=False,
+                quant_config=quant_config, prefix=f"{prefix}.wk",
+            )
+            self.weights_proj = ReplicatedLinear(
+                config.hidden_size, self.n_heads, bias=False,
+                quant_config=quant_config, prefix=f"{prefix}.weights_proj",
+            )
+            self.index_kpool_compress_gate = nn.Parameter(
+                torch.zeros(self.head_dim, config.hidden_size), requires_grad=False
+            )
         self.k_norm = nn.LayerNorm(self.head_dim, eps=1e-6)
-        self.weights_proj = ReplicatedLinear(
-            config.hidden_size, self.n_heads, bias=False,
-            quant_config=quant_config, prefix=f"{prefix}.weights_proj",
-        )
         self.index_kpool_compress_ape = nn.Parameter(
             torch.zeros(self.kp, self.head_dim), requires_grad=False
-        )
-        self.index_kpool_compress_gate = nn.Parameter(
-            torch.zeros(self.head_dim, config.hidden_size), requires_grad=False
         )
         self.k_cache = Glm5NextIndexerCache(
             head_dim=_cache_row_dim(vllm_config, self.kp),
@@ -626,10 +972,19 @@ class Glm5NextPooledIndexer(nn.Module):
         qr: torch.Tensor,
         positions: torch.Tensor,
         rotary_emb=None,
+        precomputed: tuple[torch.Tensor, ...] | None = None,
     ) -> torch.Tensor:
         q, _ = self.wq_b(qr)
         q = q.view(-1, self.n_heads, self.head_dim).to(torch.bfloat16)
-        k, _ = self.wk(hidden_states)
+        if precomputed is not None:
+            k, gate, weights = precomputed
+        else:
+            k, _ = self.wk(hidden_states)
+            gate = torch.nn.functional.linear(
+                hidden_states,
+                self.index_kpool_compress_gate.to(hidden_states.dtype),
+            )
+            weights, _ = self.weights_proj(hidden_states)
         k = torch.nn.functional.layer_norm(
             k.float(),
             (self.head_dim,),
@@ -637,11 +992,7 @@ class Glm5NextPooledIndexer(nn.Module):
             self.k_norm.bias.float(),
             self.k_norm.eps,
         ).to(torch.bfloat16)
-        gate = torch.nn.functional.linear(
-            hidden_states, self.index_kpool_compress_gate.to(hidden_states.dtype)
-        ).to(torch.bfloat16)
-        packed = torch.cat([k, gate], dim=-1).contiguous()
-        weights, _ = self.weights_proj(hidden_states)
+        packed = torch.cat([k, gate.to(torch.bfloat16)], dim=-1).contiguous()
         weights = (weights.float() * self.n_head_scale).contiguous()
         if self._ape_f32 is None or self._ape_f32.device != q.device:
             self._ape_f32 = self.index_kpool_compress_ape.float().contiguous()

--- a/vllm/model_executor/layers/glm5_next_mhc_ops.py
+++ b/vllm/model_executor/layers/glm5_next_mhc_ops.py
@@ -6,14 +6,17 @@ The MHCPreOp/MHCPostOp/MHCFusedPostPreOp CustomOps call the quixicore
 pybind entry points directly, which Dynamo cannot trace (DSV4's A100 model
 is not compiled, so it never needed to). glm5_next runs under
 support_torch_compile, so the same kernels are exposed here as registered
-custom ops with fake implementations. Small batches use the split SIMT
-Triton transition; larger prefill uses the QuixiCore CUDA implementation.
-Both can fuse the following RMSNorm. Streams are [T, 4, D] bf16; fn is
-float32 [(2+4)*4, 4*D]; scale float32 [3]; base float32 [(2+4)*4].
+custom ops with fake implementations. Streams are [T, 4, D] bf16; fn is
+float32 (or opt-in lossless BF16 storage) [(2+4)*4, 4*D]; scale float32 [3];
+base float32 [(2+4)*4]. All fn operands are converted to FP32 inside the
+kernels; accumulation and reduction precision do not change.
+On A100, small batches use the split SIMT Triton transition; larger prefill
+uses the QuixiCore CUDA implementation. Both can fuse the following RMSNorm.
 """
 
 import torch
 
+from slimserve.model_journal import instrument_mhc
 from vllm.model_executor.layers.glm5_next_mhc_triton import mhc_transition
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
@@ -26,10 +29,54 @@ _USE_SM80_SIMT = current_platform.is_cuda() and current_platform.is_device_capab
 )
 
 
+def load_lossless_mhc_fn(param: torch.Tensor, weight: torch.Tensor) -> None:
+    """Keep original BF16 fn values without accepting a new quantization.
+
+    Check before copying so a non-representable source cannot partially replace
+    the parameter. Native FP32 base/scale tensors do not use this loader.
+    """
+    if param.dtype != torch.bfloat16:
+        raise ValueError("BF16 mHC fn storage requires a BF16 parameter")
+    if weight.dtype not in (torch.bfloat16, torch.float32):
+        raise ValueError("BF16 mHC fn storage requires BF16/FP32 source weights")
+    if param.shape != weight.shape:
+        raise ValueError("mHC fn checkpoint and parameter shapes differ")
+    narrow = weight.to(torch.bfloat16)
+    if not torch.isfinite(weight).all() or not torch.equal(
+        weight, narrow.to(weight.dtype)
+    ):
+        raise ValueError("BF16 mHC fn storage would alter checkpoint values")
+    param.data.copy_(narrow)
+
+
 def _qc():
     from vllm.quixicore import quixicore_ops
 
     return quixicore_ops
+
+
+def validate_glm53_mhc_prefill_tc(config, bf16_fn: bool) -> None:
+    """Fail before serving if an explicitly requested native path cannot run."""
+    if not bf16_fn:
+        raise ValueError("mHC tensor-core prefill requires lossless BF16 fn storage")
+    expected = {
+        "hidden_size": 4096, "hc_mult": 4, "rms_norm_eps": 1e-5,
+        "hc_eps": 1e-6, "hc_sinkhorn_iters": 20,
+    }
+    if any(getattr(config, key, None) != value for key, value in expected.items()):
+        raise ValueError(
+            "mHC tensor-core prefill requires the qualified GLM53 settings"
+        )
+    if torch.cuda.get_device_capability() != (12, 0):
+        raise ValueError("mHC tensor-core prefill is qualified only on SM120")
+    native = _qc()
+    if not native.has_glm53_mhc_prefill_tc():
+        raise RuntimeError("rebuild the native library for mHC tensor-core prefill")
+    if native.get_glm53_mhc_prefill_tc() != 1:
+        raise RuntimeError(
+            "mHC tensor-core prefill is not enabled in the native runtime; "
+            "restart the process"
+        )
 
 
 def glm5_mhc_pre(
@@ -212,20 +259,14 @@ def _glm5_mhc_post_fake(x, residual, post_mix, comb_mix):
 
 
 direct_register_custom_op(
-    op_name="glm5_mhc_pre",
-    op_func=glm5_mhc_pre,
-    mutates_args=[],
+    op_name="glm5_mhc_pre", op_func=instrument_mhc(glm5_mhc_pre), mutates_args=[],
     fake_impl=_glm5_mhc_pre_fake,
 )
 direct_register_custom_op(
-    op_name="glm5_mhc_fused_post_pre",
-    op_func=glm5_mhc_fused_post_pre,
-    mutates_args=[],
-    fake_impl=_glm5_mhc_fused_post_pre_fake,
+    op_name="glm5_mhc_fused_post_pre", op_func=instrument_mhc(glm5_mhc_fused_post_pre),
+    mutates_args=[], fake_impl=_glm5_mhc_fused_post_pre_fake,
 )
 direct_register_custom_op(
-    op_name="glm5_mhc_post",
-    op_func=glm5_mhc_post,
-    mutates_args=[],
+    op_name="glm5_mhc_post", op_func=instrument_mhc(glm5_mhc_post), mutates_args=[],
     fake_impl=_glm5_mhc_post_fake,
 )

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -58,7 +58,7 @@ def _apply_kda_output_norm(
     # CUDA kernel explicitly instead of launching casts, reductions, sigmoid
     # and multiplies separately at every KDA layer. Its output aliases a
     # contiguous input; copy_ is then a no-op (and handles noncontiguous input).
-    if current_platform.is_cuda():
+    if current_platform.is_cuda_alike():
         output.copy_(norm.forward_cuda(output, gate))
     else:
         output.copy_(norm(output, gate))
@@ -174,7 +174,7 @@ def _make_fused_conv1d_weight_loader(
 class _KimiGDNMergedColumnParallelLinear(MergedColumnParallelLinear):
     """Merged projection with selected outputs replicated across TP ranks.
 
-    The replicated shard is represented as ``size * tp_size`` so the merged
+    Each replicated shard is represented as ``size * tp_size`` so the merged
     parameter reserves ``size`` local rows on every rank. Loading that shard
     from rank zero then gives every rank the complete checkpoint weight.
     """
@@ -263,8 +263,15 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         config: KimiLinearConfig,
         vllm_config: VllmConfig,
         prefix: str = "",
+        beta_shard_rows: int | None = None,
         fuse_gate_a: bool = False,
     ) -> None:
+        """``beta_shard_rows``: rows per rank to reserve for the beta shard of
+        the merged input projection instead of ``num_heads / tp``. A
+        block-quantized projection needs every shard's local rows to be a
+        multiple of the block size, so the FP8 swap-set (slimserve.fp8_swapset)
+        stores beta per rank padded to 128 rows and asks for 128 here; the
+        padding rows are zero weights whose outputs the forward drops."""
         super().__init__(config, vllm_config, prefix)
 
         kda_config = config.linear_attn_config  # type: ignore[attr-defined]
@@ -285,6 +292,9 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         self.fuse_gate_a = fuse_gate_a and not self.use_full_rank_gate
 
         if self.use_full_rank_gate:
+            if beta_shard_rows is not None:
+                raise ValueError("beta_shard_rows applies to the low-rank gate only")
+            self.beta_shard_rows = self.local_num_heads
             # Keep f_a before the narrow beta shard, then pad each TP-local row
             # to select the aligned BF16 GEMM path. The padding also avoids an
             # Inductor correctness issue seen with the row-strided G view.
@@ -293,6 +303,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 self.head_dim,
                 self.num_heads,
             ]
+            replicated_shard_ids: tuple[int, ...] = (4,)
             local_output_size = (
                 4 * self.local_projection_size + self.head_dim + self.local_num_heads
             )
@@ -300,17 +311,28 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
             if self.in_proj_padding:
                 in_proj_output_sizes.append(self.in_proj_padding * self.tp_size)
         else:
+            # The low-rank output gate's first stage (g_a_proj, head_dim rows
+            # of hidden_size) reads the same input as the projection, so it
+            # rides in the merged GEMM as a second replicated shard instead
+            # of a separate launch per layer at decode.
+            if beta_shard_rows is not None and beta_shard_rows < self.local_num_heads:
+                raise ValueError(
+                    f"beta_shard_rows={beta_shard_rows} < {self.local_num_heads} "
+                    "local heads"
+                )
+            self.beta_shard_rows = beta_shard_rows or self.local_num_heads
             in_proj_output_sizes = [self.projection_size] * 3 + [
-                self.num_heads,
+                self.beta_shard_rows * self.tp_size,
                 self.head_dim,
             ]
+            replicated_shard_ids = (4, 5) if self.fuse_gate_a else (4,)
             self.in_proj_padding = 0
             if self.fuse_gate_a:
                 in_proj_output_sizes.append(self.head_dim)
         self.in_proj_qkvgfab = _KimiGDNMergedColumnParallelLinear(
             self.hidden_size,
             in_proj_output_sizes,
-            replicated_shard_id=(4, 5) if self.fuse_gate_a else 4,
+            replicated_shard_id=replicated_shard_ids,
             tp_size=self.tp_size,
             bias=False,
             quant_config=self.quant_config,
@@ -394,8 +416,31 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 quant_config=self.quant_config,
                 prefix=f"{prefix}.g_b_proj",
             )
+        self.use_batched_gate_projection = (
+            self.fuse_gate_a
+            and current_platform.is_cuda()
+            and current_platform.is_device_capability((12, 0))
+            and isinstance(self.f_b_proj.quant_method, UnquantizedLinearMethod)
+            and isinstance(self.g_b_proj.quant_method, UnquantizedLinearMethod)
+        )
+        if self.use_batched_gate_projection:
+            # f_b_proj and g_b_proj share a shape (local projection rows of
+            # head_dim) and read adjacent columns of the merged projection
+            # output, so at decode they run as one strided-batched GEMV on
+            # this buffer. The two Parameters stay as views into it, which
+            # keeps the checkpoint loaders untouched.
+            self.fg_b_weight = torch.empty(
+                2,
+                self.local_projection_size,
+                self.head_dim,
+                dtype=self.f_b_proj.weight.dtype,
+                device=self.f_b_proj.weight.device,
+            )
+            self.f_b_proj.weight.data = self.fg_b_weight[0]
+            self.g_b_proj.weight.data = self.fg_b_weight[1]
         self.use_paired_gate_projection = (
             self.fuse_gate_a
+            and not self.use_batched_gate_projection
             and current_platform.is_cuda()
             and not envs.VLLM_BATCH_INVARIANT
             and self.head_dim == 128
@@ -455,22 +500,30 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         else:
             split_sizes = [
                 3 * self.local_projection_size,
-                self.local_num_heads,
+                self.beta_shard_rows,
                 self.head_dim,
             ]
             if self.fuse_gate_a:
                 split_sizes.append(self.head_dim)
             projected = projected_qkvgfab.split(split_sizes, dim=-1)
             mixed_qkv, beta, f_a = projected[:3]
+            if self.beta_shard_rows != self.local_num_heads:
+                beta = beta[:, : self.local_num_heads]
             g_a = projected[3] if self.fuse_gate_a else self.g_a_proj(hidden_states)[0]
-            if self.use_paired_gate_projection:
+            if self.use_batched_gate_projection:
+                # Preserve the qualified SM120 strided BMM and storage layout.
+                fg_a = projected_qkvgfab[:, -2 * self.head_dim :]
+                fg_a = fg_a.view(num_tokens, 2, self.head_dim).transpose(0, 1)
+                fg_b = torch.bmm(fg_a, self.fg_b_weight.transpose(1, 2))
+                g1, g_proj_states = fg_b.unbind(0)
+            elif self.use_paired_gate_projection:
                 g1, g_proj_states = torch.ops.vllm.kda_gate_pair(
                     f_a, g_a, self.f_b_proj.weight, self.g_b_proj.weight
                 )
             else:
                 g_proj_states = self.g_b_proj(g_a)[0]
 
-        if not self.use_paired_gate_projection:
+        if not (self.use_paired_gate_projection or self.use_batched_gate_projection):
             g1 = self.f_b_proj(f_a)[0]
         beta = beta.unsqueeze(0)
         g1 = rearrange(g1, "n (h d) -> 1 n h d", d=self.head_dim)

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -30,6 +30,10 @@ class MLAModules:
     # Output gate (Kimi K3's mla_use_output_gate). Applied to the attention
     # output before o_proj; None for models without one.
     g_proj: torch.nn.Module | None = None
+    # Output widths appended to fused_qkv_a_proj for a sparse indexer's own
+    # hidden_states projections; they are split off and handed to the
+    # indexer as ``precomputed``. None keeps the indexer computing them.
+    indexer_a_sizes: tuple[int, ...] | None = None
 
 
 # --8<-- [start:multi_head_latent_attention]
@@ -88,6 +92,7 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
         self.rotary_emb = mla_modules.rotary_emb
         self.o_proj = mla_modules.o_proj
         self.indexer = mla_modules.indexer
+        self.indexer_a_sizes = mla_modules.indexer_a_sizes
         self.indexer_rope_emb = mla_modules.indexer_rotary_emb
         self.is_sparse = mla_modules.is_sparse
         self.g_proj = mla_modules.g_proj
@@ -134,6 +139,7 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
     ) -> torch.Tensor:
         q_c = None
         kv_lora = None
+        indexer_inputs: tuple[torch.Tensor, ...] | None = None
 
         if self.q_lora_rank is not None:
             assert self.fused_qkv_a_proj is not None, (
@@ -147,10 +153,14 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
             )
 
             qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
-            q_c, kv_lora = qkv_lora.split(
-                [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
-                dim=-1,
-            )
+            a_sizes = [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim]
+            if self.indexer_a_sizes:
+                q_c, kv_lora, *indexer_parts = qkv_lora.split(
+                    a_sizes + list(self.indexer_a_sizes), dim=-1
+                )
+                indexer_inputs = tuple(indexer_parts)
+            else:
+                q_c, kv_lora = qkv_lora.split(a_sizes, dim=-1)
             q_c = self.q_a_layernorm(q_c)
             q_proj_layer = self.q_b_proj
             q_proj_input = q_c
@@ -182,7 +192,16 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
             )
 
         if self.indexer and self.is_sparse and not self.skip_topk:
-            self.indexer(hidden_states, q_c, positions, self.indexer_rope_emb)
+            if indexer_inputs is not None:
+                self.indexer(
+                    hidden_states,
+                    q_c,
+                    positions,
+                    self.indexer_rope_emb,
+                    precomputed=indexer_inputs,
+                )
+            else:
+                self.indexer(hidden_states, q_c, positions, self.indexer_rope_emb)
 
         if llama_4_scaling is not None:
             q *= llama_4_scaling

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -13,6 +13,9 @@ from vllm.logger import init_logger
 from vllm.model_executor.kernels.linear import (
     init_fp8_linear_kernel,
 )
+from vllm.model_executor.kernels.linear.scaled_mm.cutlass import (
+    CutlassFp8BlockScaledMMKernel,
+)
 from vllm.model_executor.layers.fusion.quant_activation import (
     QuantizedActivation,
     expose_input_quant_key,
@@ -40,6 +43,10 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 )
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
     cutlass_block_fp8_supported,
+)
+from vllm.model_executor.layers.utils import (
+    decode_gemm_fp8_enabled,
+    maybe_quixicore_fp8_block_linear,
 )
 
 __all__ = ["CompressedTensorsW8A8Fp8"]
@@ -148,6 +155,13 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
         )
 
         expose_input_quant_key(layer, self.fp8_linear)
+        # The QuixiCore M <= 16 kernel only stands in for the CUTLASS block path
+        # (its M > 16 branch reproduces that path exactly).
+        self._quixicore_decode = (
+            self.strategy == QuantizationStrategy.BLOCK
+            and isinstance(self.fp8_linear, CutlassFp8BlockScaledMMKernel)
+            and decode_gemm_fp8_enabled()
+        )
 
     def process_weights_after_loading(self, layer) -> None:
         if self.strategy == QuantizationStrategy.TENSOR:
@@ -204,4 +218,10 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
         x: torch.Tensor | QuantizedActivation,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        if self._quixicore_decode and isinstance(x, torch.Tensor):
+            out = maybe_quixicore_fp8_block_linear(
+                x, layer.weight, layer.weight_scale, bias
+            )
+            if out is not None:
+                return out
         return self.fp8_linear.apply_weights(layer, x, bias)

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
@@ -349,11 +349,10 @@ def prepare_nvfp4_moe_layer_for_marlin(
 ) -> tuple[
     torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
 ]:
-    logger.warning_once(
-        "Your GPU does not have native support for FP4 computation but "
-        "FP4 quantization is being used. Weight-only FP4 compression will "
-        "be used leveraging the Marlin kernel. This may degrade "
-        "performance for compute-heavy workloads."
+    logger.info_once(
+        "Using Marlin weight-only NVFP4 MoE with 16-bit activations. "
+        "This backend selection does not imply that the GPU lacks "
+        "native FP4 support."
     )
 
     input_dtype = get_marlin_input_dtype(prefix="")
@@ -673,7 +672,6 @@ def prepare_moe_mxfp4_layer_for_marlin(
     w2_bias = permute_bias(w2_bias)
 
     return w13, w2, w13_scale, w2_scale, w13_bias, w2_bias
-
 
 
 

--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -214,7 +214,14 @@ class DefaultModelLoader(BaseModelLoader):
                     use_safetensors = True
                 break
 
-        if use_safetensors:
+        # A model that names its files explicitly (no glob) owns that choice:
+        # GLM-5.3-Flash NVFP4 conversions keep the MTP head in
+        # model_mtp.safetensors outside model.safetensors.index.json, and the
+        # index filter below would drop it.
+        explicit_files = allow_patterns_overrides is not None and not any(
+            any(ch in pattern for ch in "*?[") for pattern in allow_patterns_overrides
+        )
+        if use_safetensors and not explicit_files:
             # For models like Mistral-7B-Instruct-v0.3
             # there are both sharded safetensors files and a consolidated
             # safetensors file. Using both breaks.

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -283,6 +283,14 @@ def get_quant_config(
         )
 
     if hf_quant_config is not None:
+        from slimserve.fp8_swapset import apply_config_group
+
+        if apply_config_group(model_config.model, hf_quant_config):
+            logger.info(
+                "FP8 swap-set: quantization config group added from %s",
+                model_config.model,
+            )
+
         # `model_config.quantization_config` may be set alongside a checkpoint
         # quant config: the checkpoint determines `quant_cls`, and the user's
         # QuantizationConfigArgs is consulted by individual quant methods

--- a/vllm/model_executor/models/glm5_next.py
+++ b/vllm/model_executor/models/glm5_next.py
@@ -23,6 +23,7 @@ sparse MLA kernel. The MTP head (layer 45) and video inputs are later
 phases.
 """
 
+import os
 from collections.abc import Iterable
 
 from typing import ClassVar, Literal
@@ -54,7 +55,14 @@ from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateDtypeCalculator,
     MambaStateShapeCalculator,
 )
-import vllm.model_executor.layers.glm5_next_mhc_ops  # noqa: F401  (registers torch.ops.vllm.glm5_mhc_*)
+from vllm.model_executor.layers.glm5_next_indexer import (
+    Glm5NextPooledIndexer,
+)
+# Import also registers the compile-opaque torch.ops.vllm.glm5_mhc_* operators.
+from vllm.model_executor.layers.glm5_next_mhc_ops import (
+    load_lossless_mhc_fn,
+    validate_glm53_mhc_prefill_tc,
+)
 from vllm.model_executor.layers.glm5_next_mhc_project import (
     plain_bf16_projection,
     prepare_router_projection,
@@ -62,18 +70,12 @@ from vllm.model_executor.layers.glm5_next_mhc_project import (
     register_projection_stream,
     router_projection_enabled,
 )
-from vllm.model_executor.layers.glm5_next_indexer import (
-    Glm5NextPooledIndexer,
-)
 from vllm.model_executor.layers.glm5_next_indexer_workspace import (
     Glm5NextIndexerWorkspace,
 )
 from vllm.model_executor.layers.mla import (
     MLAModules,
     MultiHeadLatentAttentionWrapper,
-)
-from vllm.model_executor.layers.quantization.base_config import (
-    QuantizationConfig,
 )
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -87,16 +89,140 @@ from vllm.model_executor.models.interfaces import (
     SupportsPP,
 )
 from vllm.model_executor.models.utils import (
-    AutoWeightsLoader,
-    PPMissingLayer,
     is_pp_missing_parameter,
     make_empty_intermediate_tensors_factory,
     make_layers,
     maybe_prefix,
 )
+from vllm.model_executor.utils import set_weight_attrs
 from vllm.sequence import IntermediateTensors
 
 logger = init_logger(__name__)
+
+F32_OVERRIDES_FILE = "f32-overrides.safetensors"
+F32_OVERRIDES_ENV = "SLIMSERVE_F32_OVERRIDES"
+
+
+def _load_f32_overrides(model_path: str | None) -> dict[str, torch.Tensor]:
+    """Tensors to substitute for the checkpoint's copies, keyed by HF name.
+
+    Some NVFP4 conversions of GLM-5.3-Flash (RedHatAI's, 2026-08) saved the
+    router bias (``mlp.gate.e_score_correction_bias``), the KDA decay
+    tensors (``A_log``, ``dt_bias``) and the mHC base/scale vectors in BF16
+    although the native checkpoint keeps them in F32 and this model holds
+    them as F32 parameters. ``slimserve.f32_overrides`` rebuilds them from
+    the native checkpoint into ``<model>/f32-overrides.safetensors``; when
+    that file is present it wins over the shard copies. Set
+    ``SLIMSERVE_F32_OVERRIDES=0`` to serve the shard copies for an A/B.
+    """
+    import os
+
+    if not model_path or os.environ.get(F32_OVERRIDES_ENV, "1") == "0":
+        return {}
+    path = os.path.join(model_path, F32_OVERRIDES_FILE)
+    if not os.path.isfile(path):
+        return {}
+    from safetensors.torch import load_file
+
+    overrides = load_file(path)
+    bad = [k for k, v in overrides.items() if v.dtype != torch.float32]
+    if bad:
+        raise ValueError(
+            f"{path}: {len(bad)} override tensors are not float32, e.g. {bad[0]}"
+        )
+    logger.info("glm5_next: %d F32 override tensors from %s", len(overrides), path)
+    return overrides
+
+
+def iter_with_overrides(
+    weights: Iterable[tuple[str, torch.Tensor]],
+    overrides: dict[str, torch.Tensor],
+    extras: dict[str, torch.Tensor] | None = None,
+    strict: bool = False,
+) -> Iterable[tuple[str, torch.Tensor]]:
+    """Yield ``weights`` with any name present in ``overrides`` replaced, then
+    the ``extras`` (tensors the checkpoint stream does not carry, such as the
+    block scales of a swapped FP8 weight). ``strict`` turns an override that
+    never appeared into an error: for the FP8 swap-set a missing substitution
+    would let the loader copy a BF16 shard into an FP8 parameter."""
+    if not overrides and not extras:
+        yield from weights
+        return
+    pending = set(overrides)
+    for name, weight in weights:
+        if name in overrides:
+            pending.discard(name)
+            yield name, overrides[name]
+        else:
+            yield name, weight
+    if pending:
+        msg = (
+            f"glm5_next: {len(pending)} override tensors never appeared in the "
+            f"checkpoint stream, e.g. {sorted(pending)[0]}"
+        )
+        if strict:
+            raise ValueError(msg)
+        logger.warning(msg)
+    if extras:
+        yield from extras.items()
+
+
+def iter_with_f32_overrides(
+    weights: Iterable[tuple[str, torch.Tensor]],
+    overrides: dict[str, torch.Tensor],
+) -> Iterable[tuple[str, torch.Tensor]]:
+    """Yield ``weights`` with any name present in ``overrides`` replaced."""
+    return iter_with_overrides(weights, overrides)
+
+
+def _load_fp8_swapset(
+    model_path: str | None,
+) -> tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]:
+    """(weights to substitute, block scales to inject) from the FP8 swap-set
+    ``slimserve.fp8_swapset`` wrote next to the checkpoint; empty when the
+    files are absent or ``SLIMSERVE_FP8_SWAPSET=0``. The quantization config
+    group that makes those modules block-FP8 is added by the model loader
+    from the same manifest, so the two cannot disagree."""
+    import json
+    import os
+
+    from slimserve.fp8_swapset import manifest_path
+
+    path = manifest_path(model_path)
+    if path is None:
+        return {}, {}
+    with open(path) as fh:
+        manifest = json.load(fh)
+    from safetensors.torch import load_file
+
+    file = os.path.join(model_path, manifest["file"])
+    tensors = load_file(file)
+    if sorted(tensors) != sorted(manifest["tensors"]):
+        raise ValueError(f"{file}: tensor names do not match the manifest {path}")
+    if manifest.get("self_quantized"):
+        tp_size = get_tensor_model_parallel_world_size()
+        if manifest.get("tp_size") != tp_size:
+            raise ValueError(
+                f"{path}: the self-quantized KDA beta layout is for tp_size="
+                f"{manifest.get('tp_size')}, serving with {tp_size}; rebuild the "
+                "swap-set with --self-quant-kda --tp-size"
+            )
+    subs = {k: v for k, v in tensors.items() if k.endswith(".weight")}
+    extras = {k: v for k, v in tensors.items() if k.endswith(".weight_scale")}
+    bad = [k for k, v in subs.items() if v.dtype != torch.float8_e4m3fn]
+    bad += [k for k, v in extras.items() if v.dtype != torch.float32]
+    if bad or len(subs) + len(extras) != len(tensors):
+        raise ValueError(
+            f"{file}: expected float8_e4m3fn weights and float32 weight_scale "
+            f"tensors only, e.g. {(bad or sorted(tensors))[0]}"
+        )
+    logger.info(
+        "glm5_next: FP8 swap-set from %s: %d weights, %d block scales",
+        file,
+        len(subs),
+        len(extras),
+    )
+    return subs, extras
 
 
 class Glm5NextMLAAttention(nn.Module):
@@ -127,9 +253,20 @@ class Glm5NextMLAAttention(nn.Module):
         self.num_local_heads = self.num_heads // tp_size
         self.scaling = self.qk_head_dim**-0.5
 
+        # The pooled indexer's three hidden_states projections (wk, the kpool
+        # compress gate, weights_proj) ride in the same replicated GEMM as
+        # extra output shards instead of three launches per DSA layer.
+        fold_indexer = current_platform.is_cuda() and current_platform.is_device_capability(
+            (12, 0)
+        )
+        self.indexer_a_sizes = (
+            (config.index_head_dim, config.index_head_dim, config.index_n_heads)
+            if fold_indexer else None
+        )
         self.fused_qkv_a_proj = MergedColumnParallelLinear(
             self.hidden_size,
-            [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
+            [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim]
+            + list(self.indexer_a_sizes or ()),
             bias=False,
             quant_config=quant_config,
             prefix=f"{prefix}.fused_qkv_a_proj",
@@ -169,6 +306,7 @@ class Glm5NextMLAAttention(nn.Module):
             cache_config=cache_config,
             topk_indices_buffer=topk_indices_buffer,
             prefix=f"{prefix}.indexer",
+            fold_input_projections=fold_indexer,
             workspace=indexer_workspace,
         )
         mla_modules = MLAModules(
@@ -184,6 +322,7 @@ class Glm5NextMLAAttention(nn.Module):
             indexer=self.indexer,
             is_sparse=True,
             topk_indices_buffer=topk_indices_buffer,
+            indexer_a_sizes=self.indexer_a_sizes,
         )
         self.mla_attn = MultiHeadLatentAttentionWrapper(
             self.hidden_size,
@@ -243,8 +382,17 @@ class Glm5NextDecoderLayer(nn.Module):
         )
 
         if self.is_linear:
+            from slimserve.fp8_swapset import beta_shard_rows
+
             self.self_attn = KimiGatedDeltaNetAttention(
-                config, vllm_config, prefix=f"{prefix}.self_attn", fuse_gate_a=True
+                config,
+                vllm_config,
+                prefix=f"{prefix}.self_attn",
+                beta_shard_rows=beta_shard_rows(
+                    vllm_config.model_config.model,
+                    f"{prefix}.self_attn.in_proj_qkvgfab",
+                ),
+                fuse_gate_a=True,
             )
         else:
             self.self_attn = Glm5NextMLAAttention(
@@ -281,13 +429,25 @@ class Glm5NextDecoderLayer(nn.Module):
         mix_hc = (2 + self.hc_mult) * self.hc_mult
         hc_dim = self.hc_mult * self.hidden_size
 
-        def _p(*shape):
+        def _p(*shape, dtype=torch.float32):
             return nn.Parameter(
-                torch.empty(*shape, dtype=torch.float32), requires_grad=False
+                torch.empty(*shape, dtype=dtype), requires_grad=False
             )
 
-        self.hc_attn_fn = _p(mix_hc, hc_dim)
-        self.hc_ffn_fn = _p(mix_hc, hc_dim)
+        # Profile-selected lossless storage; native FP32 base/scale stay FP32.
+        bf16_fn = os.getenv("VLLM_GLM5_MHC_BF16_FN", "0") == "1"
+        if os.getenv("VLLM_GLM5_MHC_PREFILL_TC", "0") == "1":
+            validate_glm53_mhc_prefill_tc(config, bf16_fn)
+            logger.info_once(
+                "GLM53 mHC tensor-core prefill enabled: SM120, lossless BF16 fn, "
+                "64..7616 rows; registered decode batches retain their existing path"
+            )
+        fn_dtype = torch.bfloat16 if bf16_fn else torch.float32
+        self.hc_attn_fn = _p(mix_hc, hc_dim, dtype=fn_dtype)
+        self.hc_ffn_fn = _p(mix_hc, hc_dim, dtype=fn_dtype)
+        if bf16_fn:
+            for param in (self.hc_attn_fn, self.hc_ffn_fn):
+                set_weight_attrs(param, {"weight_loader": load_lossless_mhc_fn})
         self.hc_attn_base = _p(mix_hc)
         self.hc_ffn_base = _p(mix_hc)
         self.hc_attn_scale = _p(3)
@@ -390,6 +550,64 @@ class Glm5NextDecoderLayer(nn.Module):
         else:
             x = self.mlp(x, router_logits=router_logits)
         return x, residual, post_mix, res_mix
+
+
+class Glm5NextMTPBlock(nn.Module):
+    """The MTP (NextN) layer's decoder block: a plain-residual DSA layer.
+
+    Layer ``num_hidden_layers`` of GLM-5.3-Flash carries no mHC and no KDA:
+    input RMSNorm -> sparse NoPE MLA -> residual add -> post RMSNorm -> MoE
+    -> residual add. ``config.layer_types`` / ``mlp_layer_types`` stop at
+    the last target layer, so the block is built explicitly. The module
+    prefix stays ``...layers.<idx>`` so the checkpoint's compressed-tensors
+    targets for that layer (FP8 block experts) resolve; the draft loader
+    (``glm5_next_mtp.py``) rewrites checkpoint names onto the ``mtp_block``
+    attribute path.
+    """
+
+    def __init__(
+        self,
+        config,
+        vllm_config: VllmConfig,
+        prefix: str,
+        topk_indices_buffer: torch.Tensor,
+    ) -> None:
+        super().__init__()
+        quant_config = vllm_config.quant_config
+        self.hidden_size = config.hidden_size
+        self.self_attn = Glm5NextMLAAttention(
+            config, vllm_config, prefix=f"{prefix}.self_attn",
+            topk_indices_buffer=topk_indices_buffer,
+        )
+        self.mlp = DeepseekV2MoE(
+            config=config,
+            parallel_config=vllm_config.parallel_config,
+            quant_config=quant_config,
+            prefix=f"{prefix}.mlp",
+        )
+        self.input_layernorm = RMSNorm(self.hidden_size, config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(
+            self.hidden_size, config.rms_norm_eps
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+        hidden_states = self.self_attn(positions, hidden_states)
+        hidden_states, residual = self.post_attention_layernorm(
+            hidden_states, residual
+        )
+        hidden_states = self.mlp(hidden_states)
+        # The caller adds the residual (pre-final-norm hidden for the logits).
+        return hidden_states, residual
 
 
 @support_torch_compile
@@ -557,6 +775,9 @@ class Glm5NextForCausalLM(
         # MLA latent projections
         ("fused_qkv_a_proj", "q_a_proj", 0),
         ("fused_qkv_a_proj", "kv_a_proj_with_mqa", 1),
+        ("fused_qkv_a_proj", "indexer.wk", 2),
+        ("fused_qkv_a_proj", "indexer.index_kpool_compress_gate", 3),
+        ("fused_qkv_a_proj", "indexer.weights_proj", 4),
         # KDA merged input projection: [q, k, v, b(beta), f_a, g_a]
         ("in_proj_qkvgfab", "q_proj", 0),
         ("in_proj_qkvgfab", "k_proj", 1),
@@ -577,6 +798,7 @@ class Glm5NextForCausalLM(
         super().__init__()
         config = vllm_config.model_config.hf_config.get_text_config()
         self.config = config
+        self._model_path = vllm_config.model_config.model
         self.model = Glm5NextTextModel(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
@@ -657,6 +879,10 @@ class Glm5NextForCausalLM(
         )
         params_dict = dict(self.named_parameters())
         loaded: set[str] = set()
+        model_path = getattr(self, "_model_path", None)
+        weights = iter_with_f32_overrides(weights, _load_f32_overrides(model_path))
+        fp8_weights, fp8_scales = _load_fp8_swapset(model_path)
+        weights = iter_with_overrides(weights, fp8_weights, fp8_scales, strict=True)
         for name, weight in weights:
             # Vision tower and MTP layer: later phases.
             if name.startswith("model.visual."):
@@ -674,12 +900,20 @@ class Glm5NextForCausalLM(
             mapped = False
             if not is_expert:
                 for target, ckpt_name, shard_id in self.stacked_params_mapping:
+                    if ckpt_name.startswith("indexer.") and name in params_dict:
+                        # Non-SM120 keeps these projections separate. Do not
+                        # load them into the two-shard Q/KV projection.
+                        continue
                     token = f".{ckpt_name}."
                     if token not in name and not name.endswith(
                         f".{ckpt_name}"
                     ):
                         continue
                     tgt = name.replace(ckpt_name, target)
+                    if tgt not in params_dict and f"{tgt}.weight" in params_dict:
+                        # A bare checkpoint parameter folded into a Linear
+                        # (the indexer's kpool compress gate) lands in .weight.
+                        tgt = f"{tgt}.weight"
                     if tgt not in params_dict:
                         continue
                     param = params_dict[tgt]

--- a/vllm/model_executor/models/glm5_next.py
+++ b/vllm/model_executor/models/glm5_next.py
@@ -561,7 +561,7 @@ class Glm5NextDecoderLayer(nn.Module):
         return x, residual, post_mix, res_mix
 
 
-class Glm5NextMTPBlock(nn.Module):
+class Glm5NextSM120MTPBlock(nn.Module):
     """The MTP (NextN) layer's decoder block: a plain-residual DSA layer.
 
     Layer ``num_hidden_layers`` of GLM-5.3-Flash carries no mHC and no KDA:
@@ -570,7 +570,7 @@ class Glm5NextMTPBlock(nn.Module):
     the last target layer, so the block is built explicitly. The module
     prefix stays ``...layers.<idx>`` so the checkpoint's compressed-tensors
     targets for that layer (FP8 block experts) resolve; the draft loader
-    (``glm5_next_mtp.py``) rewrites checkpoint names onto the ``mtp_block``
+    (``glm5_next_sm120_mtp.py``) rewrites checkpoint names onto the ``mtp_block``
     attribute path.
     """
 

--- a/vllm/model_executor/models/glm5_next_mtp.py
+++ b/vllm/model_executor/models/glm5_next_mtp.py
@@ -150,3 +150,14 @@ class Glm5NextMTP(DeepSeekMTP):
 
         loaded = super().load_weights(normalized_weights())
         return loaded | loaded_indexer
+
+
+# The independently qualified SM120 diagnostic adapter owns a different cache
+# grouping/recurrence contract. Keep it paired with its matching proposer;
+# ordinary GLM profiles on other platforms retain the compiled adapter above.
+from vllm.platforms import current_platform
+
+if current_platform.is_cuda() and current_platform.is_device_capability((12, 0)):
+    from .glm5_next_sm120_mtp import Glm5NextMTP as Glm5NextMTPModel
+else:
+    Glm5NextMTPModel = Glm5NextMTP

--- a/vllm/model_executor/models/glm5_next_mtp.py
+++ b/vllm/model_executor/models/glm5_next_mtp.py
@@ -19,6 +19,7 @@ from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.platforms import current_platform
 
 from .deepseek_mtp import (
     DeepSeekMTP,
@@ -155,8 +156,6 @@ class Glm5NextMTP(DeepSeekMTP):
 # The independently qualified SM120 diagnostic adapter owns a different cache
 # grouping/recurrence contract. Keep it paired with its matching proposer;
 # ordinary GLM profiles on other platforms retain the compiled adapter above.
-from vllm.platforms import current_platform
-
 if current_platform.is_cuda() and current_platform.is_device_capability((12, 0)):
     from .glm5_next_sm120_mtp import Glm5NextMTP as Glm5NextMTPModel
 else:

--- a/vllm/model_executor/models/glm5_next_sm120_mtp.py
+++ b/vllm/model_executor/models/glm5_next_sm120_mtp.py
@@ -38,7 +38,7 @@ from vllm.model_executor.models.deepseek_v2 import (
     DeepseekV2MixtureOfExperts,
     DeepseekV2MoE,
 )
-from vllm.model_executor.models.glm5_next import Glm5NextMTPBlock
+from vllm.model_executor.models.glm5_next import Glm5NextSM120MTPBlock
 from vllm.model_executor.models.utils import (
     get_spec_layer_idx_from_weight_name,
     maybe_prefix,
@@ -80,7 +80,7 @@ class Glm5NextMultiTokenPredictorLayer(nn.Module):
         )
         # Prefix stays the layer's so the compressed-tensors targets for this
         # layer match; checkpoint names are rewritten onto ``mtp_block``.
-        self.mtp_block = Glm5NextMTPBlock(
+        self.mtp_block = Glm5NextSM120MTPBlock(
             config,
             vllm_config,
             prefix=prefix,

--- a/vllm/model_executor/models/glm5_next_sm120_mtp.py
+++ b/vllm/model_executor/models/glm5_next_sm120_mtp.py
@@ -314,6 +314,9 @@ class Glm5NextMTP(nn.Module, DeepseekV2MixtureOfExperts):
     stacked_params_mapping = [
         ("fused_qkv_a_proj", "q_a_proj", 0),
         ("fused_qkv_a_proj", "kv_a_proj_with_mqa", 1),
+        ("fused_qkv_a_proj", "indexer.wk", 2),
+        ("fused_qkv_a_proj", "indexer.index_kpool_compress_gate", 3),
+        ("fused_qkv_a_proj", "indexer.weights_proj", 4),
         ("gate_up_proj", "gate_proj", 0),
         ("gate_up_proj", "up_proj", 1),
     ]

--- a/vllm/model_executor/models/glm5_next_sm120_mtp.py
+++ b/vllm/model_executor/models/glm5_next_sm120_mtp.py
@@ -1,0 +1,387 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""GLM-5.3-Flash MTP (NextN) draft model.
+
+The checkpoint's layer ``num_hidden_layers`` is a one-step multi-token
+predictor: ``enorm``/``hnorm`` + ``eh_proj`` fold the token embedding and the
+target's final hidden state into one stream, a plain-residual DSA decoder
+block (its own sparse MLA, pooled indexer and MoE; no mHC, no KDA) refines
+it, and ``shared_head.norm`` feeds the target's LM head. Mirrors
+``deepseek_mtp.py``: forward returns ``(pre_norm_hidden, post_norm_hidden)``,
+``compute_logits`` applies the head to the normalized pre-norm hidden.
+
+NVFP4 conversions such as RedHatAI's keep the head in
+``model_mtp.safetensors`` outside the shard index; the loader reads that
+file alone when it exists (``allow_patterns_overrides``).
+"""
+
+import os
+from collections.abc import Iterable
+
+import torch
+from torch import nn
+
+from vllm.config import VllmConfig
+from vllm.distributed import get_tensor_model_parallel_rank
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe import (
+    fused_moe_make_expert_params_mapping,
+)
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.models.deepseek_mtp import SharedHead
+from vllm.model_executor.models.deepseek_v2 import (
+    DeepseekV2MixtureOfExperts,
+    DeepseekV2MoE,
+)
+from vllm.model_executor.models.glm5_next import Glm5NextMTPBlock
+from vllm.model_executor.models.utils import (
+    get_spec_layer_idx_from_weight_name,
+    maybe_prefix,
+)
+from vllm.sequence import IntermediateTensors
+
+logger = init_logger(__name__)
+
+MTP_SIDECAR_FILE = "model_mtp.safetensors"
+_DEBUG_TEACHER_FORCED = os.environ.get("SLIMSERVE_MTP_DEBUG", "0") == "1"
+
+
+def topk_buffer_width(config) -> int:
+    """Pooled-indexer output width: expanded pools + tail, padded to 32."""
+    width = config.index_topk + config.index_kpool - 1
+    return (width + 31) // 32 * 32
+
+
+class Glm5NextMultiTokenPredictorLayer(nn.Module):
+    def __init__(self, vllm_config: VllmConfig, prefix: str) -> None:
+        super().__init__()
+        assert vllm_config.speculative_config is not None
+        config = vllm_config.speculative_config.draft_model_config.hf_config
+        self.config = config
+        quant_config = vllm_config.quant_config
+
+        self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+
+        topk_indices_buffer = torch.empty(
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            topk_buffer_width(config),
+            dtype=torch.int32,
+            device=torch.cuda.current_device(),
+        )
+        self.shared_head = SharedHead(
+            config=config, prefix=prefix, quant_config=quant_config
+        )
+        # Prefix stays the layer's so the compressed-tensors targets for this
+        # layer match; checkpoint names are rewritten onto ``mtp_block``.
+        self.mtp_block = Glm5NextMTPBlock(
+            config,
+            vllm_config,
+            prefix=prefix,
+            topk_indices_buffer=topk_indices_buffer,
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        previous_hidden_states: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
+        spec_step_index: int = 0,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        assert inputs_embeds is not None
+        # Position 0 has no previous token: zero its embedding (reference MTP).
+        inputs_embeds = torch.where(positions.unsqueeze(-1) == 0, 0, inputs_embeds)
+        inputs_embeds = self.enorm(inputs_embeds)
+        previous_hidden_states = self.hnorm(previous_hidden_states)
+        hidden_states = self.eh_proj(
+            torch.cat([inputs_embeds, previous_hidden_states], dim=-1)
+        )
+        hidden_states, residual = self.mtp_block(
+            positions=positions, hidden_states=hidden_states, residual=None
+        )
+        hidden_states = residual + hidden_states  # pre-final-norm
+        # Recycle the post-norm hidden into the next draft step; the logits
+        # path normalizes the pre-norm element itself (one norm each).
+        return hidden_states, self.shared_head(hidden_states)
+
+
+class Glm5NextMultiTokenPredictor(nn.Module):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        # The loader hands the draft the serving VllmConfig (its model_config
+        # is the target's VL config, no num_hidden_layers); the draft's own
+        # promoted text config lives on speculative_config.
+        assert vllm_config.speculative_config is not None
+        config = vllm_config.speculative_config.draft_model_config.hf_config
+        self.mtp_start_layer_idx = config.num_hidden_layers
+        self.num_mtp_layers = config.num_nextn_predict_layers
+        self.layers = torch.nn.ModuleDict(
+            {
+                str(idx): Glm5NextMultiTokenPredictorLayer(
+                    vllm_config, f"{prefix}.layers.{idx}"
+                )
+                for idx in range(
+                    self.mtp_start_layer_idx,
+                    self.mtp_start_layer_idx + self.num_mtp_layers,
+                )
+            }
+        )
+        self.embed_tokens = VocabParallelEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            prefix=maybe_prefix(prefix, "embed_tokens"),
+        )
+        self._mtp_layers = list(self.layers.values())
+        self._mtp_mla_attns = [
+            layer.mtp_block.self_attn.mla_attn for layer in self._mtp_layers
+        ]
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+
+    def set_skip_topk(self, skip: bool) -> None:
+        """index_share_for_mtp_iteration: step 0 computes top-k, later steps
+        reuse the indices step 0 wrote into the shared buffer."""
+        for mla_attn in self._mtp_mla_attns:
+            mla_attn.skip_topk = skip
+
+    def compact_topk_indices(self, slot_ids: torch.Tensor) -> None:
+        """Gather each request's last-token top-k rows to the buffer front."""
+        num_slots = slot_ids.numel()
+        for mla_attn in self._mtp_mla_attns:
+            buf = mla_attn.topk_indices_buffer
+            assert buf is not None
+            buf[:num_slots] = buf[slot_ids]
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        previous_hidden_states: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
+        spec_step_idx: int = 0,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+        current_step_idx = spec_step_idx % self.num_mtp_layers
+        return self._mtp_layers[current_step_idx](
+            input_ids,
+            positions,
+            previous_hidden_states,
+            inputs_embeds,
+            current_step_idx,
+        )
+
+    def compute_logits(
+        self, hidden_states: torch.Tensor, spec_step_idx: int = 0
+    ) -> torch.Tensor:
+        mtp_layer = self._mtp_layers[spec_step_idx % self.num_mtp_layers]
+        return self.logits_processor(
+            mtp_layer.shared_head.head, mtp_layer.shared_head(hidden_states)
+        )
+
+
+class Glm5NextMTP(nn.Module, DeepseekV2MixtureOfExperts):
+    """Draft model entry (architecture ``Glm5NextMTPModel``)."""
+
+    hf_to_vllm_prefix = {"model.language_model.": "model."}
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        assert vllm_config.speculative_config is not None
+        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        self.quant_config = vllm_config.quant_config
+        self.model = Glm5NextMultiTokenPredictor(
+            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
+        )
+        self.set_moe_parameters()
+        # Conversions that keep the head outside the shard index: read only
+        # that file (the loader would otherwise filter it out and stream the
+        # whole target checkpoint for nothing).
+        model_path = vllm_config.model_config.model
+        sidecar = os.path.join(model_path, MTP_SIDECAR_FILE)
+        self.allow_patterns_overrides: list[str] | None = (
+            [MTP_SIDECAR_FILE] if os.path.isfile(sidecar) else None
+        )
+        if self.allow_patterns_overrides:
+            logger.info("glm5_next_mtp: draft weights from %s", sidecar)
+
+    def set_moe_parameters(self) -> None:
+        self.num_moe_layers = self.config.num_nextn_predict_layers
+        self.num_expert_groups = getattr(self.config, "n_group", 1)
+        self.moe_layers = []
+        self.moe_mlp_layers = []
+        example_moe = None
+        for layer in self.model.layers.values():
+            mlp = layer.mtp_block.mlp
+            if isinstance(mlp, DeepseekV2MoE):
+                example_moe = mlp
+                self.moe_mlp_layers.append(mlp)
+                self.moe_layers.append(mlp.experts)
+        self.extract_moe_parameters(example_moe)
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        spec_step_idx: int = 0,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        out = self.model(
+            input_ids, positions, hidden_states, inputs_embeds, spec_step_idx
+        )
+        if _DEBUG_TEACHER_FORCED and input_ids is not None and input_ids.shape[0] > 8:
+            self._log_teacher_forced(out[0], input_ids, spec_step_idx)
+        return out
+
+    @torch.no_grad()
+    def _log_teacher_forced(
+        self, hidden: torch.Tensor, input_ids: torch.Tensor, spec_step_idx: int
+    ) -> None:
+        """Diagnostic (SLIMSERVE_MTP_DEBUG=1): on a multi-token draft pass the
+        draft's input at row i is the token at position i+1 and its target
+        is the token at i+2, i.e. input_ids[i + 1]; report top-1 agreement."""
+        logits = self.model.compute_logits(hidden, spec_step_idx)
+        if logits is None:
+            return
+        pred = logits.argmax(dim=-1)[:-1]
+        gold = input_ids[1:]
+        acc = (pred == gold).float().mean().item()
+        logger.info(
+            "glm5_next_mtp teacher-forced: %d rows, top-1 next-token agreement %.3f",
+            int(gold.numel()),
+            acc,
+        )
+        dump_dir = os.environ.get("SLIMSERVE_MTP_DEBUG_DIR")
+        if dump_dir and get_tensor_model_parallel_rank() == 0:
+            # Draft argmax per row for the offline draft-vs-target comparison.
+            os.makedirs(dump_dir, exist_ok=True)
+            self._dump_idx = getattr(self, "_dump_idx", 0) + 1
+            torch.save(
+                {
+                    "input_ids": input_ids.cpu(),
+                    "draft_argmax": logits.argmax(dim=-1).cpu(),
+                },
+                os.path.join(dump_dir, f"draft-{self._dump_idx:03d}.pt"),
+            )
+
+    def compute_logits(
+        self, hidden_states: torch.Tensor, spec_step_idx: int = 0
+    ) -> torch.Tensor:
+        return self.model.compute_logits(hidden_states, spec_step_idx)
+
+    # Checkpoint names for the MTP layer, e.g.
+    #   model.language_model.layers.45.self_attn.q_a_proj.weight
+    #   model.language_model.layers.45.mlp.experts.7.gate_proj.weight_scale
+    #   model.language_model.layers.45.shared_head.norm.weight
+    # The block's parameters live under ``mtp_block``; the layer-level
+    # pieces (enorm/hnorm/eh_proj/shared_head) do not.
+    _LAYER_LEVEL = ("enorm", "hnorm", "eh_proj", "shared_head")
+
+    @classmethod
+    def strip_hf_prefix(cls, name: str) -> str:
+        for pref, new in cls.hf_to_vllm_prefix.items():
+            if name.startswith(pref):
+                return new + name[len(pref) :]
+        return name
+
+    @classmethod
+    def rewrite_spec_layer_name(cls, spec_layer: int, name: str) -> str:
+        name = cls.strip_hf_prefix(name)
+        head = f"model.layers.{spec_layer}."
+        if not name.startswith(head):
+            return name
+        rest = name[len(head) :]
+        if rest.startswith("embed_tokens"):
+            return "model." + rest  # shared with the target
+        if rest.split(".", 1)[0] in cls._LAYER_LEVEL:
+            return name
+        return head + "mtp_block." + rest
+
+    stacked_params_mapping = [
+        ("fused_qkv_a_proj", "q_a_proj", 0),
+        ("fused_qkv_a_proj", "kv_a_proj_with_mqa", 1),
+        ("gate_up_proj", "gate_proj", 0),
+        ("gate_up_proj", "up_proj", 1),
+    ]
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        expert_params_mapping = fused_moe_make_expert_params_mapping(
+            self,
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=self.config.n_routed_experts,
+        )
+        params_dict = dict(self.named_parameters())
+        loaded: set[str] = set()
+        for name, weight in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+            # The helper matches "model.layers.<n>." only; strip the VL
+            # checkpoint's "model.language_model." first.
+            name = self.strip_hf_prefix(name)
+            spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
+            if spec_layer is None:
+                continue
+            name = self.rewrite_spec_layer_name(spec_layer, name)
+            if ".mlp.experts." in name:
+                for param_name, ckpt_name, expert_id, shard_id in expert_params_mapping:
+                    if ckpt_name not in name:
+                        continue
+                    tgt = name.replace(ckpt_name, param_name)
+                    if tgt not in params_dict:
+                        continue
+                    param = params_dict[tgt]
+                    param.weight_loader(
+                        param, weight, tgt, shard_id=shard_id, expert_id=expert_id
+                    )
+                    loaded.add(tgt)
+                    break
+                else:
+                    logger.warning_once("glm5_next_mtp: unmatched expert %s", name)
+                continue
+            mapped = False
+            for target, ckpt_name, shard_id in self.stacked_params_mapping:
+                token = f".{ckpt_name}."
+                if token not in name:
+                    continue
+                tgt = name.replace(ckpt_name, target)
+                if tgt not in params_dict:
+                    continue
+                param = params_dict[tgt]
+                param.weight_loader(param, weight, shard_id)
+                loaded.add(tgt)
+                mapped = True
+                break
+            if mapped:
+                continue
+            if name not in params_dict:
+                logger.warning_once("glm5_next_mtp: unmatched weight %s", name)
+                continue
+            param = params_dict[name]
+            loader = getattr(param, "weight_loader", default_weight_loader)
+            loader(param, weight)
+            loaded.add(name)
+
+        start = self.model.mtp_start_layer_idx
+        for layer_idx in range(start, start + self.model.num_mtp_layers):
+            if not any(f"model.layers.{layer_idx}." in n for n in loaded):
+                raise ValueError(
+                    f"MTP layer {layer_idx} has no weights in the checkpoint; "
+                    f"NVFP4 conversions ship it as {MTP_SIDECAR_FILE}"
+                )
+        return loaded

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -425,7 +425,7 @@ _SPECULATIVE_DECODING_MODELS = {
     "Eagle3DeepseekV2ForCausalLM": ("deepseek_eagle3", "Eagle3DeepseekV2ForCausalLM"),
     "Eagle3DeepseekV3ForCausalLM": ("deepseek_eagle3", "Eagle3DeepseekV2ForCausalLM"),
     "DeepSeekMTPModel": ("deepseek_mtp", "DeepSeekMTP"),
-    "Glm5NextMTPModel": ("glm5_next_mtp", "Glm5NextMTP"),
+    "Glm5NextMTPModel": ("glm5_next_mtp", "Glm5NextMTPModel"),
     "DSparkDraftModel": ("vllm.models.deepseek_v4", "DSparkDeepseekV4ForCausalLM"),
     "DeepSeekV4MTPModel": ("vllm.models.deepseek_v4", "DeepSeekV4MTP"),
     # Temporarily disabled.

--- a/vllm/model_executor/warmup/mamba_copy_warmup.py
+++ b/vllm/model_executor/warmup/mamba_copy_warmup.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Warm the align-cache copy path without touching any model/cache storage."""
+
+import torch
+
+
+def warm_mamba_copy_kernel(device: torch.device) -> None:
+    from vllm.v1.worker.mamba_utils import batch_memcpy
+
+    # The copy length and batch count are runtime values, not JIT constants.
+    # Use the production metadata dtypes so this compiles its actual signature.
+    # A non-block-multiple length also exercises the final masked iteration.
+    source = torch.zeros(1025, dtype=torch.uint8, device=device)
+    destination = torch.empty_like(source)
+    src_ptrs = torch.tensor([source.data_ptr()], dtype=torch.uint64, device=device)
+    dst_ptrs = torch.tensor([destination.data_ptr()], dtype=torch.uint64, device=device)
+    sizes = torch.tensor([source.numel()], dtype=torch.int32, device=device)
+    batch_memcpy(src_ptrs, dst_ptrs, sizes)

--- a/vllm/model_executor/warmup/mamba_copy_warmup.py
+++ b/vllm/model_executor/warmup/mamba_copy_warmup.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Warm the align-cache copy path without touching any model/cache storage."""
+"""Warm the align-cache copy path without touching any model/cache storage.
+
+Startup-stall fix, not a steady-state speedup. The fixed-profile workload and
+raw receipts are linked in docs/glm53-flash-sm120-review.md under
+"Qualification record map" (2026-09-08 repro-baseline/ and warmup-boundary/).
+"""
 
 import torch
 

--- a/vllm/v1/attention/backends/mla/quixicore_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/quixicore_mla_sparse.py
@@ -115,6 +115,8 @@ def _bf16_partition(q: torch.Tensor, idx: torch.Tensor) -> int:
     # per-head re-reads of the shared latent dominate and 64 is best (41.4 vs
     # 47.1 us at 1000, 75.0 vs 93.1 at 2048). The reduce is flat in the
     # partition count since the channel reducer.
+    # Full decode/prefill evidence map: docs/glm53-flash-sm120-review.md,
+    # "Qualification record map". Historical best-start rates are superseded.
     size = 32 if B <= 8 else 64
     P = (idx.shape[1] + size - 1) // size
     if B * H * P * 512 * 4 > _BF16_PARTITION_SCRATCH_CAP:

--- a/vllm/v1/attention/backends/mla/quixicore_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/quixicore_mla_sparse.py
@@ -41,6 +41,7 @@ from vllm.v1.attention.backend import (
     MLAAttentionImpl,
     MultipleOf,
 )
+from vllm.v1.attention.backends.mla import quixicore_mla_sparse_prefill
 from vllm.v1.attention.backends.utils import split_decodes_and_prefills
 from vllm.v1.kv_cache_interface import AttentionSpec
 
@@ -58,7 +59,6 @@ def _page_stride_bytes(kv_cache: torch.Tensor) -> int:
     return kv_cache.stride(0) * kv_cache.element_size()
 
 
-_BF16_PARTITION = 128
 _BF16_PARTITION_SCRATCH_CAP = 512 << 20  # bytes of fp32 partials
 
 
@@ -105,10 +105,20 @@ def _bf16_partition(q: torch.Tensor, idx: torch.Tensor) -> int:
     already B x H warps wide, so partition only while the scratch is small.
     """
     B, H = q.shape[0], q.shape[1]
-    P = (idx.shape[1] + _BF16_PARTITION - 1) // _BF16_PARTITION
+    # Decode sizes by batch, measured 2026-09-07 on glm53-nvfp4-4 / rtx6000
+    # with the channel reducer (notebook "Sparse MLA decode: partition and
+    # reduce"): one warp per (head, token, partition) walks its partition
+    # serially, so at small B the 2080-wide list wants 32-token partitions
+    # (B = 1: decode 6.6 us vs 15.8 at 128 for 1000 selected tokens, 10.8 vs
+    # 31.0 at 2048; B = 8: within 2 us of 128 either way); at B >= 16 the
+    # per-head re-reads of the shared latent dominate and 64 is best (41.4 vs
+    # 47.1 us at 1000, 75.0 vs 93.1 at 2048). The reduce is flat in the
+    # partition count since the channel reducer.
+    size = 32 if B <= 8 else 64
+    P = (idx.shape[1] + size - 1) // size
     if B * H * P * 512 * 4 > _BF16_PARTITION_SCRATCH_CAP:
         return 0
-    return _BF16_PARTITION
+    return size
 
 
 class QuixiCoreMLASparseBackend(AttentionBackend):
@@ -435,6 +445,20 @@ class QuixiCoreMLASparseImpl(MLAAttentionImpl[QuixiCoreMLASparseMetadata]):
                         self.softmax_scale, split=tc_split,
                     ), None
                 # NoPE MLA (glm5_next): no rope segment, 512-wide latents.
+                # Steps with prefill tokens take the head-batched
+                # tensor-core kernel (one program per token, the heads as
+                # the M dimension); decode steps keep the graph-captured
+                # walk below.
+                if (
+                    quixicore_mla_sparse_prefill.ENABLED
+                    and attn_metadata.num_prefills > 0
+                    and quixicore_mla_sparse_prefill.supports(q)
+                ):
+                    return quixicore_mla_sparse_prefill.sparse_mla_prefill_nope(
+                        q, kv_c_and_k_pe_cache, bt, idx, tlen,
+                        attn_metadata.block_size, self.softmax_scale,
+                        page_stride_bytes=_page_stride_bytes(kv_c_and_k_pe_cache),
+                    ), None
                 # Partitioned (128 -> 17 partitions at the 2080-wide list):
                 # the one-warp-per-(head, token) walk was 155 ms/token at
                 # TP8 with the 2048 top-k (8 warps per rank). Microbench

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1657,18 +1657,18 @@ class Scheduler(SchedulerInterface):
         return GrammarOutput(structured_output_request_ids, bitmask, apply_rows)
 
     def _record_routing_journal(self, routed, req_ids, scheduled) -> None:
-        requests = [self.requests.get(rid) for rid in req_ids]
+        requests = {rid: self.requests[rid] for rid in req_ids if rid in self.requests}
         # An abort can remove a request while the model is executing. Drop the
         # whole diagnostic frame, never misalign surviving metadata with rows.
-        if any(request is None for request in requests):
+        if len(requests) != len(req_ids):
             return
         self._slimserve_routing_journal.record(
             routed.routing_data,
             routed.slot_mapping,
             req_ids,
             scheduled,
-            {rid: request.num_computed_tokens for rid, request in zip(req_ids, requests)},
-            {rid: request.num_prompt_tokens for rid, request in zip(req_ids, requests)},
+            {rid: request.num_computed_tokens for rid, request in requests.items()},
+            {rid: request.num_prompt_tokens for rid, request in requests.items()},
         )
 
     def update_from_output(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1656,6 +1656,21 @@ class Scheduler(SchedulerInterface):
         bitmask, apply_rows = result
         return GrammarOutput(structured_output_request_ids, bitmask, apply_rows)
 
+    def _record_routing_journal(self, routed, req_ids, scheduled) -> None:
+        requests = [self.requests.get(rid) for rid in req_ids]
+        # An abort can remove a request while the model is executing. Drop the
+        # whole diagnostic frame, never misalign surviving metadata with rows.
+        if any(request is None for request in requests):
+            return
+        self._slimserve_routing_journal.record(
+            routed.routing_data,
+            routed.slot_mapping,
+            req_ids,
+            scheduled,
+            {rid: request.num_computed_tokens for rid, request in zip(req_ids, requests)},
+            {rid: request.num_prompt_tokens for rid, request in zip(req_ids, requests)},
+        )
+
     def update_from_output(
         self,
         scheduler_output: SchedulerOutput,
@@ -1703,14 +1718,8 @@ class Scheduler(SchedulerInterface):
         if model_runner_output.routed_experts is not None:
             re = model_runner_output.routed_experts
             if self._slimserve_routing_journal is not None:
-                req_ids = model_runner_output.req_ids
-                self._slimserve_routing_journal.record(
-                    re.routing_data,
-                    re.slot_mapping,
-                    req_ids,
-                    num_scheduled_tokens,
-                    {rid: self.requests[rid].num_computed_tokens for rid in req_ids},
-                    {rid: self.requests[rid].num_prompt_tokens for rid in req_ids},
+                self._record_routing_journal(
+                    re, model_runner_output.req_ids, num_scheduled_tokens
                 )
             self.routed_experts_mgr.store_batch(re.routing_data, re.slot_mapping)
             routing_data = re.routing_data.astype(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -355,6 +355,27 @@ class Scheduler(SchedulerInterface):
         self.enable_return_routed_experts = (
             vllm_config.model_config.enable_return_routed_experts
         )
+        self._slimserve_routing_journal = None
+        journal_dir = vllm_config.additional_config.get("slimserve_routing_journal")
+        if journal_dir:
+            from slimserve.routing_journal import RoutingJournal
+
+            if (
+                not self.enable_return_routed_experts
+                or self.scheduler_config.async_scheduling
+            ):
+                raise ValueError(
+                    "routing journal requires capture and synchronous scheduling"
+                )
+            config = vllm_config.model_config.hf_text_config
+            self._slimserve_routing_journal = RoutingJournal(
+                journal_dir,
+                model=vllm_config.model_config.model,
+                num_layers=config.num_hidden_layers,
+                first_moe_layer=config.first_k_dense_replace,
+                num_experts=config.n_routed_experts,
+                top_k=config.num_experts_per_tok,
+            )
 
         if self.enable_return_routed_experts:
             assert self.dcp_world_size == 1 and self.pcp_world_size == 1, (
@@ -1681,6 +1702,16 @@ class Scheduler(SchedulerInterface):
         routing_offsets: dict[str, int] = {}
         if model_runner_output.routed_experts is not None:
             re = model_runner_output.routed_experts
+            if self._slimserve_routing_journal is not None:
+                req_ids = model_runner_output.req_ids
+                self._slimserve_routing_journal.record(
+                    re.routing_data,
+                    re.slot_mapping,
+                    req_ids,
+                    num_scheduled_tokens,
+                    {rid: self.requests[rid].num_computed_tokens for rid in req_ids},
+                    {rid: self.requests[rid].num_prompt_tokens for rid in req_ids},
+                )
             self.routed_experts_mgr.store_batch(re.routing_data, re.slot_mapping)
             routing_data = re.routing_data.astype(
                 self.routed_experts_mgr.routed_experts_by_slot.dtype,

--- a/vllm/v1/sample/metadata.py
+++ b/vllm/v1/sample/metadata.py
@@ -53,3 +53,7 @@ class SamplingMetadata:
     # When non-None, use ``holder.has_tracked_requests()`` to see if this batch applies
     # thinking-token-budget logits (holder may exist with an empty tracking set).
     thinking_budget_state_holder: ThinkingBudgetStateHolder | None = None
+    # Largest top_k in the batch (CPU-side, from the input batch); None when
+    # no request uses top-k. Lets the sampler take the small-k kernel path
+    # without a device sync.
+    max_top_k: int | None = None

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -184,9 +184,9 @@ class TopKTopPSampler(nn.Module):
                     "per-request generators. Falling back to "
                     "PyTorch-native implementation."
                 )
-            return self.forward_native(logits, generators, k, p)
+            return self.forward_native(logits, generators, k, p, max_top_k=max_top_k)
         if self.use_fp64_gumbel:
-            return self.forward_native(logits, generators, k, p)
+            return self.forward_native(logits, generators, k, p, max_top_k=max_top_k)
         assert self.logprobs_mode not in PROCESSED_LOGPROBS_MODES, (
             "FlashInfer does not support returning logits/logprobs"
         )

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -142,6 +142,9 @@ class TopKTopPSampler(nn.Module):
         PyTorch-native implementation of top-k and top-p sampling.
 
         The logits tensor may be updated in-place.
+
+        Corrected tie/noise semantics and fixed-profile qualification:
+        docs/glm53-flash-sm120-review.md, "Qualification record map".
         """
         if (
             k is not None

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -136,12 +136,23 @@ class TopKTopPSampler(nn.Module):
         generators: dict[int, torch.Generator],
         k: torch.Tensor | None,
         p: torch.Tensor | None,
+        max_top_k: int | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """
         PyTorch-native implementation of top-k and top-p sampling.
 
         The logits tensor may be updated in-place.
         """
+        if (
+            k is not None
+            and max_top_k is not None
+            and max_top_k <= SMALL_TOPK_WINDOW
+            and self.logprobs_mode not in PROCESSED_LOGPROBS_MODES
+            and small_topk_kernel_available(logits)
+        ):
+            return small_topk_sample(
+                logits, generators, k, p, self.use_fp64_gumbel
+            ), None
         logits = apply_top_k_top_p(logits, k, p)
         logits_to_return = None
         if self.logprobs_mode == "processed_logits":
@@ -160,6 +171,7 @@ class TopKTopPSampler(nn.Module):
         generators: dict[int, torch.Generator],
         k: torch.Tensor | None,
         p: torch.Tensor | None,
+        max_top_k: int | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """More optimized implementation for top-k and top-p sampling."""
         # Fall back to the PyTorch-native path when FlashInfer has nothing
@@ -189,6 +201,7 @@ class TopKTopPSampler(nn.Module):
         generators: dict[int, torch.Generator],
         k: torch.Tensor | None,
         p: torch.Tensor | None,
+        max_top_k: int | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """
         PyTorch-native implementation of top-k and top-p sampling for CPU.
@@ -235,6 +248,7 @@ class TopKTopPSampler(nn.Module):
         generators: dict[int, torch.Generator],
         k: torch.Tensor | None,
         p: torch.Tensor | None,
+        max_top_k: int | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """Optimized ROCm/aiter path (same structure as forward_cuda)."""
         if (k is None and p is None) or generators:
@@ -297,6 +311,7 @@ class TopKTopPSampler(nn.Module):
         generators: dict[int, torch.Generator],
         k: torch.Tensor | None,
         p: torch.Tensor | None,
+        max_top_k: int | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         if generators:
             logger.warning_once(
@@ -403,6 +418,49 @@ def apply_top_k_top_p_pytorch(
 
     # Re-sort the probabilities.
     return logits.scatter_(dim=-1, index=logits_idx, src=logits_sort)
+
+
+# Small-k kernel path: candidate windows find thresholds, but never limit
+# the set of sampled tokens or discard kth-value tie mass. Nucleus ordering
+# is ascending (logit, token ID), deterministic even where torch.sort's
+# default unstable equal-key order is not. Draw one exponential per vocabulary
+# ID, preserving its precision, just as in the full-vocabulary random sampler.
+SMALL_TOPK_WINDOW = 32
+
+
+def small_topk_kernel_available(logits: torch.Tensor) -> bool:
+    if logits.device.type != "cuda" or logits.shape[1] < 16 * SMALL_TOPK_WINDOW:
+        return False
+    from vllm.quixicore.ops import quixicore_ops
+
+    return quixicore_ops.has_topk_sample()
+
+
+def small_topk_sample(
+    logits: torch.Tensor,
+    generators: dict[int, torch.Generator],
+    k: torch.Tensor,
+    p: torch.Tensor | None,
+    use_fp64_gumbel: bool = False,
+) -> torch.Tensor:
+    from vllm.quixicore.ops import quixicore_ops
+
+    batch, vocab = logits.shape
+    q = torch.empty(
+        (batch, vocab),
+        dtype=torch.float64 if use_fp64_gumbel else torch.float32,
+        device=logits.device,
+    )
+    if len(generators) != batch:
+        q.exponential_()
+    for i, generator in generators.items():
+        q[i].exponential_(generator=generator)
+    return quixicore_ops.topk_sample(
+        logits.float() if logits.dtype != torch.float32 else logits,
+        k.to(torch.int32),
+        None if p is None else p.to(torch.float32),
+        q,
+    )
 
 
 def apply_top_k_only(logits: torch.Tensor, k: torch.Tensor) -> torch.Tensor:

--- a/vllm/v1/sample/prompt_logprobs.py
+++ b/vllm/v1/sample/prompt_logprobs.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded row-wise prompt scoring; not installed in the serving path yet.
+
+Keep the full, unchanged lm_head result. Only split the subsequent independent
+row operations, using the existing sampler's log_softmax/top-k/rank functions.
+"""
+
+import torch
+
+from vllm.v1.outputs import LogprobsTensors
+
+CHUNK_ROWS = 1024
+MODES = ("raw_logprobs", "processed_logprobs", "raw_logits", "processed_logits")
+
+
+def gather_prompt_logprobs(
+    logits: torch.Tensor,
+    target_token_ids: torch.Tensor,
+    num_logprobs: int,
+    mode: str,
+    *,
+    sampler,
+    chunk_rows: int = CHUNK_ROWS,
+) -> LogprobsTensors:
+    """Bound score/conversion temporaries, not the requested output size.
+
+    No sampling processors apply to prompt tokens. ``processed_*`` therefore
+    has the same meaning as ``raw_*``, as in GPUModelRunner. The caller still
+    owns the projection, TP gather, journal and asynchronous CPU transfer.
+    """
+    if (
+        logits.ndim != 2
+        or not logits.is_floating_point()
+        or logits.shape[0] <= 0
+        or logits.shape[1] <= 0
+        or target_token_ids.shape != (logits.shape[0],)
+        or target_token_ids.dtype != torch.int64
+        or target_token_ids.device != logits.device
+        or type(num_logprobs) is not int
+        or not 0 <= num_logprobs <= logits.shape[1]
+        or mode not in MODES
+        or type(chunk_rows) is not int
+        or chunk_rows <= 0
+    ):
+        raise ValueError("invalid prompt-score matrix, targets, mode or chunk bound")
+    rows = logits.shape[0]
+    output = None
+    for start in range(0, rows, chunk_rows):
+        end = min(start + chunk_rows, rows)
+        piece = logits[start:end]
+        scores = (
+            piece.to(torch.float32)
+            if mode in ("raw_logits", "processed_logits")
+            else sampler.compute_logprobs(piece)
+        )
+        part = sampler.gather_logprobs(
+            scores, num_logprobs, target_token_ids[start:end]
+        )
+        if part.cu_num_generated_tokens is not None:
+            raise ValueError("prompt scoring requires flat per-row outputs")
+        if rows <= chunk_rows:
+            return part
+        if output is None:
+            output = LogprobsTensors(
+                *(t.new_empty((rows, *t.shape[1:])) for t in part[:3])
+            )
+        for destination, source in zip(output[:3], part[:3]):
+            destination[start:end].copy_(source)
+        # Do not retain the preceding chunk's score matrix while creating the
+        # next one. Outputs own independent, requested-size storage only.
+        del scores, part, piece, source
+    assert output is not None
+    return output

--- a/vllm/v1/sample/prompt_logprobs.py
+++ b/vllm/v1/sample/prompt_logprobs.py
@@ -1,8 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Bounded row-wise prompt scoring; not installed in the serving path yet.
+"""Opt-in bounded row-wise GLM53 prompt scoring; not a profile default.
 
 Keep the full, unchanged lm_head result. Only split the subsequent independent
 row operations, using the existing sampler's log_softmax/top-k/rank functions.
+
+The native-order diagnostic passed exact-score/memory checks; production-order
+rollout stopped on the unchanged control's historical quality gate. Full records:
+docs/glm53-flash-sm120-review.md, "Qualification record map". No speedup claim.
 """
 
 import torch

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -288,6 +288,7 @@ class Sampler(nn.Module):
             sampling_metadata.generators,
             sampling_metadata.top_k,
             sampling_metadata.top_p,
+            max_top_k=sampling_metadata.max_top_k,
         )
 
         if greedy_sampled is None:

--- a/vllm/v1/spec_decode/glm5_next_mtp.py
+++ b/vllm/v1/spec_decode/glm5_next_mtp.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Proposer for the GLM-5.3-Flash MTP head.
+
+The draft layer owns two KV cache layers that land in two scheduler groups:
+the sparse NoPE MLA cache (``...self_attn.attn``, the primary owner whose
+group carries the proposer's block table and slot mapping) and the pooled
+indexer's key cache (``...self_attn.indexer.k_cache``). The base proposer
+assumes one group and hands the drafter one slot mapping; the indexer's
+rows would then be inserted at the MLA group's slot numbers. This builds on
+``Step3p5MTPProposer``, which stages a block table AND a slot mapping per
+group from the runner and recomputes the non-primary groups' slot mappings
+per draft step from their own block tables.
+"""
+
+import torch
+
+from vllm.config import VllmConfig, get_layers_from_vllm_config
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    KVCacheSpec,
+    UniformTypeKVCacheSpecs,
+)
+from vllm.v1.spec_decode.eagle import EagleProposer
+from vllm.v1.spec_decode.step3p5 import Step3p5MTPProposer
+from vllm.v1.spec_decode.utils import PADDING_SLOT_ID
+from vllm.v1.worker.utils import AttentionGroup
+
+MAIN_LAYER_SUFFIX = ".self_attn.attn"
+
+
+class Glm5NextMTPProposer(Step3p5MTPProposer):
+    """Speculative decoding proposer for GLM-5.3-Flash MTP."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        device: torch.device,
+        runner=None,
+    ) -> None:
+        super().__init__(vllm_config, device, runner)
+
+    def model_returns_tuple(self) -> bool:
+        """The draft returns (pre-norm hidden, recycled post-norm hidden)."""
+        return True
+
+    def _maybe_share_lm_head(self, target_language_model: torch.nn.Module) -> None:
+        # Unlike Step3.5, the GLM-5.3 head has no lm_head of its own: the
+        # checkpoint carries shared_head.norm only, the target's lm_head is
+        # shared in (base behaviour).
+        EagleProposer._maybe_share_lm_head(self, target_language_model)
+
+    def initialize_attn_backend(
+        self,
+        kv_cache_config: KVCacheConfig,
+        kernel_block_sizes: list[int] | None = None,
+    ) -> None:
+        num_mtp_layers = getattr(
+            self.draft_model_config.hf_config, "num_nextn_predict_layers", 1
+        )
+        if num_mtp_layers != 1:
+            raise NotImplementedError(
+                "GLM-5.3 MTP proposer only supports one MTP layer"
+            )
+        assert kernel_block_sizes is not None, (
+            "GLM-5.3 MTP requires resolved kernel block sizes"
+        )
+        assert len(kernel_block_sizes) == len(kv_cache_config.kv_cache_groups), (
+            "GLM-5.3 MTP requires one kernel block size per KV cache group"
+        )
+
+        all_attn_layers = get_layers_from_vllm_config(
+            self.vllm_config,
+            AttentionLayerBase,  # type: ignore[type-abstract]
+        )
+        layer_to_gid, layer_to_spec = self._map_draft_layers_to_groups(kv_cache_config)
+        main_layers = [n for n in layer_to_spec if n.endswith(MAIN_LAYER_SUFFIX)]
+        assert len(main_layers) == 1, (
+            "GLM-5.3 MTP requires exactly one sparse MLA cache owner, got "
+            f"{sorted(main_layers)}"
+        )
+        self.kv_cache_gid = layer_to_gid[main_layers[0]]
+
+        attention_groups: list[AttentionGroup] = []
+        for layer_name in sorted(self._draft_attn_layer_names):
+            attn_layer = all_attn_layers[layer_name]
+            gid = layer_to_gid[layer_name]
+            attn_group = AttentionGroup(
+                backend=attn_layer.get_attn_backend(),
+                layer_names=[layer_name],
+                kv_cache_spec=layer_to_spec[layer_name],
+                kv_cache_group_id=gid,
+            )
+            attn_group.create_metadata_builders(
+                self.vllm_config,
+                self.device,
+                kernel_block_size=kernel_block_sizes[gid],
+            )
+            attention_groups.append(attn_group)
+
+        # Primary owner first: the base proposer reads the first group's
+        # block table and slot mapping.
+        self.draft_attn_groups = sorted(
+            attention_groups,
+            key=lambda group: (
+                group.kv_cache_group_id != self.kv_cache_gid,
+                group.kv_cache_group_id,
+                group.layer_names[0],
+            ),
+        )
+        self.block_size = kernel_block_sizes[self.kv_cache_gid]
+        # The indexer group's block is not the MLA group's (2176 vs 1088
+        # tokens on the rtx6000 record: hybrid page-size unification), so
+        # the per-step slot recomputation below uses each group's own size.
+        self._per_group_block_sizes = {
+            g.kv_cache_group_id: kernel_block_sizes[g.kv_cache_group_id]
+            for g in self.draft_attn_groups
+        }
+
+    def _update_positions_dependent_metadata(
+        self,
+        positions: torch.Tensor,
+        common_attn_metadata,
+        batch_size: int,
+        input_batch_size: int,
+        block_size: int,
+    ) -> torch.Tensor:
+        """Step3p5's recompute, with each non-primary group's own block size."""
+        old_positions_1d = positions[0] if self.uses_mrope else positions
+        positions = EagleProposer._update_positions_dependent_metadata(
+            self,
+            positions,
+            common_attn_metadata,
+            batch_size,
+            input_batch_size,
+            block_size,
+        )
+        self._per_group_slot_mappings[self.kv_cache_gid] = (
+            common_attn_metadata.slot_mapping
+        )
+        new_positions_1d = positions[0] if self.uses_mrope else positions
+        exceeds = old_positions_1d + 1 >= self.max_model_len
+        for attn_group in self.draft_attn_groups:
+            gid = attn_group.kv_cache_group_id
+            if gid == self.kv_cache_gid:
+                continue
+            block_table = self._per_group_block_tables.get(gid)
+            if block_table is None:
+                continue
+            gbs = self._per_group_block_sizes[gid]
+            n_blocks = block_table.shape[1]
+            bn = new_positions_1d // gbs
+            bn.clamp_(max=n_blocks - 1)
+            bn = bn.to(torch.long)
+            block_ids = block_table[:batch_size].gather(1, bn.unsqueeze(1)).squeeze(1)
+            sm = block_ids * gbs + (new_positions_1d % gbs)
+            sm.masked_fill_(exceeds, PADDING_SLOT_ID)
+            buf = self._slot_mapping_buffer_for(gid)
+            buf[:batch_size].copy_(sm)
+            if input_batch_size > batch_size:
+                buf[batch_size:input_batch_size].fill_(PADDING_SLOT_ID)
+            self._per_group_slot_mappings[gid] = buf[:batch_size]
+        return positions
+
+    def _map_draft_layers_to_groups(
+        self,
+        kv_cache_config: KVCacheConfig,
+    ) -> tuple[dict[str, int], dict[str, KVCacheSpec]]:
+        layer_to_gid: dict[str, int] = {}
+        layer_to_spec: dict[str, KVCacheSpec] = {}
+        for gid, group in enumerate(kv_cache_config.kv_cache_groups):
+            group_spec = group.kv_cache_spec
+            for layer_name in group.layer_names:
+                if layer_name not in self._draft_attn_layer_names:
+                    continue
+                if isinstance(group_spec, UniformTypeKVCacheSpecs):
+                    spec = group_spec.kv_cache_specs.get(layer_name)
+                    assert spec is not None, (
+                        f"GLM-5.3 draft cache group {gid} has no spec for {layer_name}"
+                    )
+                else:
+                    spec = group_spec
+                layer_to_gid[layer_name] = gid
+                layer_to_spec[layer_name] = spec
+
+        assert layer_to_spec.keys() == self._draft_attn_layer_names, (
+            "GLM-5.3 draft KV cache configuration is missing layers: "
+            f"{sorted(self._draft_attn_layer_names - layer_to_spec.keys())}"
+        )
+        return layer_to_gid, layer_to_spec
+
+
+__all__ = ["Glm5NextMTPProposer"]

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1025,8 +1025,9 @@ class SpecDecodeBaseProposer:
             # DeepSeek-family MTP (deepseek_mtp.py) recycles the post-final-
             # norm hidden, so its forward returns (logit_hidden,
             # recycle_hidden). Other MTP families return a single tensor.
-            return "DeepSeekMTPModel" in (
-                self.draft_model_config.hf_config.architectures or []
+            archs = self.draft_model_config.hf_config.architectures or []
+            return any(
+                arch in archs for arch in ("DeepSeekMTPModel", "Glm5NextMTPModel")
             )
         return self.method not in ("mtp", "draft_model", "dflash")
 

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -960,6 +960,7 @@ class InputBatch:
             bad_words_token_ids=self.bad_words_token_ids,
             logitsprocs=self.logitsprocs,
             thinking_budget_state_holder=self.thinking_budget_state_holder,
+            max_top_k=None if self.no_top_k else int(self.top_k_cpu[:num_reqs].max()),
         )
 
     def get_pooling_params(self) -> list[PoolingParams]:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5957,6 +5957,8 @@ class GPUModelRunner(
                 "glm5_next_text",
             ):
                 raise ValueError("prompt-score chunks are qualified for GLM53 only")
+            # GLM opt-in memory-fix qualification and failed default rollout:
+            # docs/glm53-flash-sm120-review.md, "Qualification record map".
             chunk_rows = CHUNK_ROWS
 
         if not hasattr(self, "_slimserve_score_journal"):

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -212,6 +212,9 @@ from vllm.v1.spec_decode.eagle import EagleProposer
 from vllm.v1.spec_decode.extract_hidden_states import ExtractHiddenStatesProposer
 from vllm.v1.spec_decode.gemma4 import Gemma4Proposer
 from vllm.v1.spec_decode.glm5_next import Glm5NextMTPProposer
+from vllm.v1.spec_decode.glm5_next_mtp import (
+    Glm5NextMTPProposer as Glm5NextSM120MTPProposer,
+)
 from vllm.v1.spec_decode.medusa import MedusaProposer
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.spec_decode.ngram_proposer_gpu import (
@@ -641,6 +644,8 @@ class GPUModelRunner(
                 | Gemma4Proposer
                 | Step3p5MTPProposer
                 | Qwen4ExpMTPProposer
+                | Glm5NextMTPProposer
+                | Glm5NextSM120MTPProposer
             )
             if self.speculative_config.method == "custom_class":
                 self.drafter = create_custom_proposer(  # type: ignore[assignment]
@@ -680,7 +685,12 @@ class GPUModelRunner(
             elif self.speculative_config.use_qwen4_exp_mtp():
                 self.drafter = Qwen4ExpMTPProposer(self.vllm_config, self.device, self)
             elif self.speculative_config.use_glm5_next_mtp():
-                self.drafter = Glm5NextMTPProposer(self.vllm_config, self.device, self)
+                glm_proposer = (
+                    Glm5NextSM120MTPProposer
+                    if current_platform.is_device_capability((12, 0))
+                    else Glm5NextMTPProposer
+                )
+                self.drafter = glm_proposer(self.vllm_config, self.device, self)
             elif self.speculative_config.use_dflash():
                 self.drafter = DFlashProposer(self.vllm_config, self.device, self)
                 self.use_aux_hidden_state_outputs = True
@@ -1015,6 +1025,35 @@ class GPUModelRunner(
                 self.max_num_reqs, dtype=torch.int32
             )
         self.layerwise_nvtx_hooks_registered = False
+
+        from slimserve.model_journal import install_model_journal
+
+        install_model_journal(self)
+        from slimserve.index_journal import install_index_journal
+
+        install_index_journal(self)
+        from slimserve.indexer_correction_diagnostic import (
+            install as install_indexer_correction,
+        )
+
+        install_indexer_correction(self)
+        from slimserve.prompt_score_diagnostic import (
+            install as install_prompt_score_diagnostic,
+        )
+
+        install_prompt_score_diagnostic(self)
+        from slimserve.kv_diagnostic import install as install_kv_diagnostic
+
+        install_kv_diagnostic(self)
+        from slimserve.rmsnorm_geometry import install as install_rmsnorm_geometry
+
+        install_rmsnorm_geometry(self)
+        from slimserve.rmsnorm_diagnostic import install as install_rmsnorm_diagnostic
+
+        install_rmsnorm_diagnostic(self)
+        from slimserve.reduction_receipts import install as install_reduction_receipts
+
+        install_reduction_receipts(self)
 
     def update_max_model_len(self, max_model_len: int) -> None:
         self.max_model_len = max_model_len
@@ -5905,6 +5944,35 @@ class GPUModelRunner(
         if not num_prompt_logprobs_dict:
             return {}
 
+        # Runtime-only scoring policy, outside the compiled model/AOT key.
+        chunk_flag = os.getenv("SLIMSERVE_GLM53_PROMPT_SCORE_CHUNKS", "0")
+        if chunk_flag not in ("0", "1"):
+            raise ValueError("SLIMSERVE_GLM53_PROMPT_SCORE_CHUNKS must be 0 or 1")
+        chunk_rows = 0
+        if chunk_flag == "1":
+            from vllm.v1.sample.prompt_logprobs import CHUNK_ROWS
+
+            if getattr(self.model_config.hf_config, "model_type", None) not in (
+                "glm5_next",
+                "glm5_next_text",
+            ):
+                raise ValueError("prompt-score chunks are qualified for GLM53 only")
+            chunk_rows = CHUNK_ROWS
+
+        if not hasattr(self, "_slimserve_score_journal"):
+            from slimserve.score_journal import ScoreJournal
+
+            self._slimserve_score_journal = ScoreJournal.from_env(
+                getattr(self.model_config.hf_config, "model_type", None)
+            )
+        score_journal = self._slimserve_score_journal
+
+        if not hasattr(self, "_slimserve_prompt_score_shadow"):
+            from slimserve.prompt_score_shadow import PromptScoreShadow
+
+            self._slimserve_prompt_score_shadow = PromptScoreShadow.from_env(self)
+        score_shadow = self._slimserve_prompt_score_shadow
+
         prompt_logprobs_dict: dict[str, LogprobsTensors | None] = {}
 
         # Since prompt logprobs are a rare feature, prioritize simple,
@@ -5965,7 +6033,24 @@ class GPUModelRunner(
             req_idx = self.input_batch.req_id_to_index[req_id]
             offset = self.query_start_loc.np[req_idx].item()
             prompt_hidden_states = hidden_states[offset : offset + num_logits]
+            trace_match = (
+                score_journal.begin(
+                    request.prompt_token_ids,
+                    start_idx,
+                    num_logits,
+                    num_prompt_logprobs,
+                    req_id,
+                )
+                if score_journal is not None
+                else None
+            )
+            if trace_match is not None:
+                score_journal.record(
+                    trace_match, "prompt_head_input", prompt_hidden_states
+                )
             logits = self.model.compute_logits(prompt_hidden_states)
+            if trace_match is not None:
+                score_journal.record(trace_match, "logits", logits)
 
             # Get the "target" tokens for each index. For prompt at index i,
             # the token at prompt index i+1 is the "sampled" token we want
@@ -5975,13 +6060,49 @@ class GPUModelRunner(
             # Compute prompt scores respecting logprobs_mode.
             # NOTE: prompt tokens skip sampling processors, so
             # processed_* and raw_* yield the same scores here.
-            if self.model_config.logprobs_mode in ("raw_logits", "processed_logits"):
-                scores = logits.to(torch.float32)
+            if score_shadow is not None:
+                if not chunk_rows or trace_match is not None:
+                    raise ValueError("score shadow requires chunks without journals")
+                token_ids, logprobs, ranks, _ = score_shadow.gather(
+                    logits,
+                    tgt_token_ids,
+                    num_prompt_logprobs,
+                    self.model_config.logprobs_mode,
+                    sampler=self.sampler,
+                    prompt_ids=request.prompt_token_ids,
+                    start_idx=start_idx,
+                    request_id=req_id,
+                )
+            elif chunk_rows and num_logits > chunk_rows and trace_match is None:
+                from vllm.v1.sample.prompt_logprobs import gather_prompt_logprobs
+
+                token_ids, logprobs, ranks, _ = gather_prompt_logprobs(
+                    logits,
+                    tgt_token_ids,
+                    num_prompt_logprobs,
+                    self.model_config.logprobs_mode,
+                    sampler=self.sampler,
+                    chunk_rows=chunk_rows,
+                )
             else:
-                scores = self.sampler.compute_logprobs(logits)
-            token_ids, logprobs, ranks, _ = self.sampler.gather_logprobs(
-                scores, num_prompt_logprobs, tgt_token_ids
-            )
+                # Small requests and the bounded 639-row diagnostic journal keep
+                # the original operations and score-stage fingerprints.
+                if self.model_config.logprobs_mode in (
+                    "raw_logits",
+                    "processed_logits",
+                ):
+                    scores = logits.to(torch.float32)
+                else:
+                    scores = self.sampler.compute_logprobs(logits)
+                if trace_match is not None:
+                    score_journal.record(trace_match, "scores", scores)
+                    score_journal.record(trace_match, "target_token_ids", tgt_token_ids)
+                token_ids, logprobs, ranks, _ = self.sampler.gather_logprobs(
+                    scores, num_prompt_logprobs, tgt_token_ids
+                )
+            if trace_match is not None:
+                score_journal.record(trace_match, "selected_logprobs", logprobs)
+                score_journal.finish(trace_match)
 
             # Transfer GPU->CPU async.
             chunk_slice = slice(start_idx, start_idx + num_logits)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -902,6 +902,7 @@ class Worker(WorkerBase):
 
             # Dummy forwards never cross a live request's cache-block boundary.
             # Compile the real state-copy signature before declaring readiness.
+            # Qualification: warm_mamba_copy_kernel's docstring and review map.
             warm_mamba_copy_kernel(self.device)
             bootstamp(f"worker[{self.rank}]: mamba state-copy warmup done")
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -892,6 +892,19 @@ class Worker(WorkerBase):
                 self.model_runner._dummy_sampler_run(hidden_states=last_hidden_states)
             bootstamp(f"worker[{self.rank}]: sampler warmup done")
 
+        if (
+            not self.use_v2_model_runner
+            and self.cache_config.mamba_cache_mode == "align"
+        ):
+            from vllm.model_executor.warmup.mamba_copy_warmup import (
+                warm_mamba_copy_kernel,
+            )
+
+            # Dummy forwards never cross a live request's cache-block boundary.
+            # Compile the real state-copy signature before declaring readiness.
+            warm_mamba_copy_kernel(self.device)
+            bootstamp(f"worker[{self.rank}]: mamba state-copy warmup done")
+
         # Reset the seed to ensure that the random state is not affected by
         # the model initialization and profiling.
         set_random_seed(self.model_config.seed)


### PR DESCRIPTION
## Scope — part 2/5 (83 files)

Selected weight recipe, registry aliases, streaming/CLI, model/runner integration, KDA projection layouts, TP indexer sharding and platform-specific MTP adapters. SM120 keeps the measured V1/raw-cache path; A100 keeps V2/DFlash2, compact cache and its raw per-row fallback. Includes loader, profile, model and serving-integration regressions.

## Review stack — ready

Dependency order: #26 → #27 → #28 → #25 → #24. Each PR targets the preceding layer; #26 targets main. Retarget the next layer after its base lands. Do not land later layers independently or merge automatically.

| Part | PR | Scope | Files |
|---|---|---|---:|
| 1 | #26 | Native kernels, bindings, focused probes/tests | 94 |
| 2 | #27 | Serving recipe, platform integration, regressions | 83 |
| 3 | #28 | Numerical diagnostics and prefill qualification | 83 |
| 4 | #25 | Indexer/routing diagnostics and qualification | 57 |
| 5 | #24 | Campaign harnesses, evidence and roadmap | 55 |

## Review outcome — 2026-09-11

- #26: 13 inline findings resolved; 14 nits dispositioned. 99 CPU / 172 GPU passes, plus18 cold-compilation/dispatch regressions.
- #27: 17 inline findings resolved; six nits dispositioned. Layer/microbatch-owned Marlin scratch, BF16 combine fallback, sidecar/MTP/journal/sampler contract fixes. 137 CPU / 11 GPU passes plus17 final CPU cleanup checks. [Disposition](https://github.com/QuixiAI/SlimServe/pull/27#issuecomment-5640839113).
- #28: CodeRabbit completed a full83-file static review with no actionable defects. This is a [review comment](https://github.com/QuixiAI/SlimServe/pull/28#issuecomment-5640985715), not a formal GitHub approval.
- #25: nine inline findings resolved; four nits dispositioned. Fix172c68bf7 tightens diagnostic per-rank/set-tail/SASS/archive evidence and path/environment/device/probe handling. 107 CPU +1 inherited-environment +1 compiled-indexer GPU pass;23 expected unavailable-device/probe skips. [Disposition](https://github.com/QuixiAI/SlimServe/pull/25#issuecomment-5641266239).
- #24: ten actionable findings resolved; two test nits addressed,128 CPU passes.

All49 inline threads are resolved. CI guards pass and main conflicts are resolved. Fixes are committed as Auroter on their owning branches and merged forward, without force-push. No merge into main has occurred.

## Combined serving qualification

Target: four RTX PRO6000 Blackwell SM120 GPUs, stock600W, TP4/no EP/no speculation, explicit V1 runner. Canonical profile `glm53f-nvfp4-4` (alias `glm53-nvfp4-4`), recipe `glm53-redhatai-nvfp4-fp8-kda-tp4-v1`: RedHatAI NVFP4 experts, pinned FP8 sidecars/FP32 repairs, BF16 KV/head.

Final clean-tree `f9963f878` includes main0313f5228, the rebuilt native binding, independent Marlin scratch and all serving-review fixes. One boot, three exact1000-input/300-output cold-prefix repeats, no source changes/restarts/exclusions:

| Measurement | Median [min,max] |
|---|---:|
| c1 E2E tok/s | 156.838 [156.689,157.100] |
| c8 E2E tok/s | 577.605 [577.499,578.503] |
| c16 E2E tok/s | 782.960 [781.820,784.241] |
| cold32K engine TTFT ms | 2511.369 [2508.355,2513.162] |
| cold128K engine TTFT ms | 9921.773 [9896.923,9948.182] |

Exact tokens, text/image canaries and six retrieval contrasts pass;4096 scored text tokens, mean logprob -2.731236241. Exit0 and GPU release verified. Later part4 fixes change only diagnostics/tests/docs: no changes under csrc/, slimserve/ or vllm/ since this serving qualification. No additional model boot.

This preserves performance, not a paired speedup or a resolution of historical score-repeatability limits. Known recovered prompt-score allocation warnings remain; chunked scoring stays opt-in. Earlier failed startup receipts remain preserved. No A100, DBO, MTP or disabled-tier qualification is implied.

Raw local receipts: `perf/results/2026-09-11/pr-review/`, including `serving-final-review/` and `part4-{cpu,env,gpu}.xml`. [Baseline and limitations](https://github.com/QuixiAI/SlimServe/blob/glm53-flash-sm120/perf/baseline_status.md#rtx6000-final-combined-review-qualification---2026-09-11), [review map](https://github.com/QuixiAI/SlimServe/blob/glm53-flash-sm120/docs/glm53-flash-sm120-review.md), [roadmap](https://github.com/QuixiAI/SlimServe/blob/glm53-flash-sm120/docs/glm53-flash-sm120-plan.md).

## Why the split and remaining scope

The user authorized splitting only if needed. CodeRabbit confirmed the original365-file diff exceeded the configured100-file and absolute300-file limits, with no supported within-PR file batching. Every file remains in this stack; no test/diagnostic exclusions or path filters were added. The history join `e5d0ec096` preserved all original campaign commits and was byte-identical to `c41148025`. Intermediate layers are review units, not independently serving-qualified releases.

The17 original main conflicts and two later binding/indexer conflicts are resolved. SM120 retains its qualified BF16/raw-cache/V1 path; A100's compact-cache/FP8-decode/V2/DFlash2 work remains intact. The unrelated main defect in `glm53f-q2-1/metal` (missing `glm53f-gguf` source/FP8-KV note; eight known registry failures) remains documented rather than hidden by invented metadata.

Foundry, disabled host/NVMe tiers and external QuixiCore port-back are out of scope. Broader next-layer prefetch and persistent decode remain explicitly deferred, not claimed implemented or exhausted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GLM-5.3-Flash support for RTX PRO 6000 hardware, including MTP speculative decoding and platform-specific profiles.
  * Added automated weight preparation, FP8 swap sets, and F32 override generation.
  * Added optional CUDA profiling, routing, prompt-scoring, and deterministic-reduction diagnostics.
  * Added streamed response event callbacks and optional reasoning-content filtering.
  * Added optimized sampling, indexing, MoE routing, and attention paths for supported workloads.

* **Bug Fixes**
  * Fixed explicit synchronous scheduling, safetensor selection, indexer tail-token handling, and Mamba state-copy warmup behavior.

* **Tests**
  * Expanded coverage for new model, hardware, quantization, sampling, streaming, and diagnostic workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->